### PR TITLE
WIP: an example void dataset descriptor for openfmri ds001

### DIFF
--- a/examples/dataset-descriptors/OpenfMRI-DS001.ttl
+++ b/examples/dataset-descriptors/OpenfMRI-DS001.ttl
@@ -1,6 +1,3 @@
-# currently open for discussion on github at:
-# https://github.com/ni-/ni-dm/pull/1
-
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .


### PR DESCRIPTION
This is an example dataset descriptor using the [VoID vocabulary](http://www.w3.org/TR/void/).

We currently use only [General Dataset Metadata](http://www.w3.org/TR/void/#metadata), which will extended to use more domain specific neuroinformatics vocabulary.

The file is written using the [Turtle](http://www.w3.org/TR/turtle/) serialization of [RDF](http://www.w3.org/RDF/)
