### PR TITLE
Update terms to be consistent with Terms spreadsheet

### DIFF
--- a/examples/spm/spm_results.provn
+++ b/examples/spm/spm_results.provn
@@ -57,16 +57,16 @@ document
         prov:label = "Height Threshold: p&lt;0.05 (FWE)" %% xsd:string,
         spm:userSpecifiedThresholdType = "p-value FWE",
         prov:value = "5.235300" %% xsd:float,
-        nidm:pUncorr = "0.000001" %% xsd:float,
-        spm:pFWER = "0.050000" %% xsd:float])
+        nidm:pValueUncorrected = "0.000001" %% xsd:float,
+        spm:pValueFWER = "0.050000" %% xsd:float])
 
     entity(niiri:extent_threshold_id,
         [prov:type = 'nidm:extentThreshold',
         prov:label = "Extent Threshold",
         nidm:clusterSizeInVoxels = "0.000000" %% xsd:float,
         spm:clusterSizeInResels = "0.000000" %% xsd:float,
-        nidm:pUncorr = "1.000000" %% xsd:float,
-        spm:pFWER = "1.000000" %% xsd:float])
+        nidm:pValueUncorrected = "1.000000" %% xsd:float,
+        spm:pValueFWER = "1.000000" %% xsd:float])
 
     activity(niiri:inference_id,
         [prov:type = "spm:inference",
@@ -104,7 +104,7 @@ document
         [prov:type = 'spm:setLevelStatistic',
         prov:label = "Set Level Statistic" %% xsd:string,
         prov:value = "8" %% xsd:int,
-        nidm:pUncorr = "0.000000" %% xsd:float])
+        nidm:pValueUncorrected = "0.000000" %% xsd:float])
     
     wasDerivedFrom(niiri:set_level_statistic_id, niiri:excursion_set_id)
         
@@ -113,9 +113,9 @@ document
         prov:label = "Cluster Level Statistic: 0001" %% xsd:string,
         nidm:clusterSizeInVoxels = "530" %% xsd:int,
         spm:clusterSizeInResels = "23.120919" %% xsd:float,
-        nidm:pUncorr = "0.000000" %% xsd:float,
-        spm:pFWER = "0.000000" %% xsd:float,
-        spm:qFDR = "0.000000" %% xsd:float])
+        nidm:pValueUncorrected = "0.000000" %% xsd:float,
+        spm:pValueFWER = "0.000000" %% xsd:float,
+        spm:qValueFDR = "0.000000" %% xsd:float])
     
     wasDerivedFrom(niiri:cluster_0001, niiri:set_level_statistic_id)   
     
@@ -124,9 +124,9 @@ document
         prov:label = "Cluster Level Statistic: 0002" %% xsd:string,
         nidm:clusterSizeInVoxels = "445" %% xsd:int,
         spm:clusterSizeInResels = "19.412847" %% xsd:float,
-        nidm:pUncorr = "0.000000" %% xsd:float,
-        spm:pFWER = "0.000000" %% xsd:float,
-        spm:qFDR = "0.000000" %% xsd:float])
+        nidm:pValueUncorrected = "0.000000" %% xsd:float,
+        spm:pValueFWER = "0.000000" %% xsd:float,
+        spm:qValueFDR = "0.000000" %% xsd:float])
     
     wasDerivedFrom(niiri:cluster_0002, niiri:set_level_statistic_id)
     
@@ -134,10 +134,10 @@ document
         [prov:type = 'spm:peakLevelStatistic',
         prov:atLocation = 'niiri:coordinate_0001',
         prov:value = "13.934620" %% xsd:float,
-        nidm:EquivZstat = "9999999.000000" %% xsd:float,
-        nidm:pUncorr = "0.000000" %% xsd:float,
-        spm:pFWER = "0.000000" %% xsd:float,
-        spm:qFDR = "0.000000" %% xsd:float])
+        nidm:equivalentZStatistic = "9999999.000000" %% xsd:float,
+        nidm:pValueUncorrected = "0.000000" %% xsd:float,
+        spm:pValueFWER = "0.000000" %% xsd:float,
+        spm:qValueFDR = "0.000000" %% xsd:float])
 
     entity(niiri:coordinate_0001,
         [prov:type = 'prov:location',
@@ -153,10 +153,10 @@ document
         [prov:type = 'spm:peakLevelStatistic',
         prov:atLocation = 'niiri:coordinate_0002',
         prov:value = "11.345750" %% xsd:float,
-        nidm:EquivZstat = "9999999.000000" %% xsd:float,
-        nidm:pUncorr = "0.000000" %% xsd:float,
-        spm:pFWER = "0.000000" %% xsd:float,
-        spm:qFDR = "0.000000" %% xsd:float])
+        nidm:equivalentZStatistic = "9999999.000000" %% xsd:float,
+        nidm:pValueUncorrected = "0.000000" %% xsd:float,
+        spm:pValueFWER = "0.000000" %% xsd:float,
+        spm:qValueFDR = "0.000000" %% xsd:float])
 
     entity(niiri:coordinate_0002,
         [prov:type = 'prov:location',
@@ -172,10 +172,10 @@ document
         [prov:type = 'spm:peakLevelStatistic',
         prov:atLocation = 'niiri:coordinate_0003',
         prov:value = "9.821856" %% xsd:float,
-        nidm:EquivZstat = "7.804049" %% xsd:float,
-        nidm:pUncorr = "0.000000" %% xsd:float,
-        spm:pFWER = "0.000000" %% xsd:float,
-        spm:qFDR = "0.000000" %% xsd:float])
+        nidm:equivalentZStatistic = "7.804049" %% xsd:float,
+        nidm:pValueUncorrected = "0.000000" %% xsd:float,
+        spm:pValueFWER = "0.000000" %% xsd:float,
+        spm:qValueFDR = "0.000000" %% xsd:float])
 
     entity(niiri:coordinate_0003,
         [prov:type = 'prov:location',
@@ -191,10 +191,10 @@ document
         [prov:type = 'spm:peakLevelStatistic',
         prov:atLocation = 'niiri:coordinate_0004',
         prov:value = "13.720881" %% xsd:float,
-        nidm:EquivZstat = "9999999.000000" %% xsd:float,
-        nidm:pUncorr = "0.000000" %% xsd:float,
-        spm:pFWER = "0.000000" %% xsd:float,
-        spm:qFDR = "0.000000" %% xsd:float])
+        nidm:equivalentZStatistic = "9999999.000000" %% xsd:float,
+        nidm:pValueUncorrected = "0.000000" %% xsd:float,
+        spm:pValueFWER = "0.000000" %% xsd:float,
+        spm:qValueFDR = "0.000000" %% xsd:float])
     
     entity(niiri:coordinate_0004,
         [prov:type = 'prov:location',
@@ -210,10 +210,10 @@ document
         [prov:type = 'spm:peakLevelStatistic',
         prov:atLocation = 'niiri:coordinate_0005',
         prov:value = "12.322902" %% xsd:float,
-        nidm:EquivZstat = "9999999.000000" %% xsd:float,
-        nidm:pUncorr = "0.000000" %% xsd:float,
-        spm:pFWER = "0.000000" %% xsd:float,
-        spm:qFDR = "0.000000" %% xsd:float])
+        nidm:equivalentZStatistic = "9999999.000000" %% xsd:float,
+        nidm:pValueUncorrected = "0.000000" %% xsd:float,
+        spm:pValueFWER = "0.000000" %% xsd:float,
+        spm:qValueFDR = "0.000000" %% xsd:float])
     
     entity(niiri:coordinate_0005,
         [prov:type = 'prov:location',
@@ -229,10 +229,10 @@ document
         [prov:type = 'spm:peakLevelStatistic',
         prov:atLocation = 'niiri:coordinate_0006',
         prov:value = "9.620708" %% xsd:float,
-        nidm:EquivZstat = "7.702694" %% xsd:float,
-        nidm:pUncorr = "0.000000" %% xsd:float,
-        spm:pFWER = "0.000000" %% xsd:float,
-        spm:qFDR = "0.000000" %% xsd:float])
+        nidm:equivalentZStatistic = "7.702694" %% xsd:float,
+        nidm:pValueUncorrected = "0.000000" %% xsd:float,
+        spm:pValueFWER = "0.000000" %% xsd:float,
+        spm:qValueFDR = "0.000000" %% xsd:float])
 
     entity(niiri:coordinate_0006,
         [prov:type = 'prov:location',


### PR DESCRIPTION
Update terms voxelToWorld, pValueUnc, pValueFWER and equiv_Z-statistic
into voxelToWorldMapping, pUncor, pFWER and EquivZstat to be consistent
with the terms defined in the Neuroimaging terms spreadsheet.
