### PR TITLE
Correct typo in attribute `fileName` of `excursion_set_id`

### DIFF
--- a/examples/spm/spm_results.provn
+++ b/examples/spm/spm_results.provn
@@ -101,7 +101,7 @@ document
     prov:label = "Excursion Set" %% xsd:string,
     spm:maximumIntensityProjection = "file:///path/to/MIP.png" %% xsd:anyURI,
     nidm:underlayFile = "file:///path/to/mwStructural.nii" %% xsd:anyURI,
-    nidm:fileName = "con_0001.img" %% xsd:string,
+    nidm:fileName = "thresh_spmT_0001.img" %% xsd:string,
     nidm:numberOfDimensions = "3" %% xsd:int,
     nidm:dimensions = "[53,63,46]" %% xsd:string,
     nidm:coordinateSpace = "MNI" %% xsd:string,


### PR DESCRIPTION
fix: `filename` in `excursion_set_id` was `con_0001.img`
