### PR TITLE
Capitalize class names in prov namspace

### DIFF
--- a/examples/spm/spm_results.provn
+++ b/examples/spm/spm_results.provn
@@ -271,7 +271,7 @@ document
     spm:pValueFWER = "0" %% xsd:float,
     spm:qValueFDR = "6.3705194444993e-11" %% xsd:float])
   entity(niiri:coordinate_0001,
-    [prov:type = 'prov:location',
+    [prov:type = 'prov:Location',
     prov:type = 'nidm:coordinate',
     prov:label = "Coordinate: 0001" %% xsd:string,
     nidm:coordinate1 = "-60" %% xsd:float,
@@ -288,7 +288,7 @@ document
     spm:pValueFWER = "0" %% xsd:float,
     spm:qValueFDR = "3.12855975726156e-10" %% xsd:float])
   entity(niiri:coordinate_0002,
-    [prov:type = 'prov:location',
+    [prov:type = 'prov:Location',
     prov:type = 'nidm:coordinate',
     prov:label = "Coordinate: 0002" %% xsd:string,
     nidm:coordinate1 = "-66" %% xsd:float,
@@ -305,7 +305,7 @@ document
     spm:pValueFWER = "1.82057147135595e-10" %% xsd:float,
     spm:qValueFDR = "9.95383070867767e-08" %% xsd:float])
   entity(niiri:coordinate_0003,
-    [prov:type = 'prov:location',
+    [prov:type = 'prov:Location',
     prov:type = 'nidm:coordinate',
     prov:label = "Coordinate: 0003" %% xsd:string,
     nidm:coordinate1 = "-63" %% xsd:float,
@@ -322,7 +322,7 @@ document
     spm:pValueFWER = "0" %% xsd:float,
     spm:qValueFDR = "6.3705194444993e-11" %% xsd:float])
   entity(niiri:coordinate_0004,
-    [prov:type = 'prov:location',
+    [prov:type = 'prov:Location',
     prov:type = 'nidm:coordinate',
     prov:label = "Coordinate: 0004" %% xsd:string,
     nidm:coordinate1 = "57" %% xsd:float,
@@ -339,7 +339,7 @@ document
     spm:pValueFWER = "0" %% xsd:float,
     spm:qValueFDR = "6.3705194444993e-11" %% xsd:float])
   entity(niiri:coordinate_0005,
-    [prov:type = 'prov:location',
+    [prov:type = 'prov:Location',
     prov:type = 'nidm:coordinate',
     prov:label = "Coordinate: 0005" %% xsd:string,
     nidm:coordinate1 = "66" %% xsd:float,
@@ -356,7 +356,7 @@ document
     spm:pValueFWER = "4.2237258135458e-10" %% xsd:float,
     spm:qValueFDR = "1.58195372181651e-07" %% xsd:float])
   entity(niiri:coordinate_0006,
-    [prov:type = 'prov:location',
+    [prov:type = 'prov:Location',
     prov:type = 'nidm:coordinate',
     prov:label = "Coordinate: 0006" %% xsd:string,
     nidm:coordinate1 = "57" %% xsd:float,
@@ -373,7 +373,7 @@ document
     spm:pValueFWER = "4.05099727462943e-06" %% xsd:float,
     spm:qValueFDR = "0.000463130517859672" %% xsd:float])
   entity(niiri:coordinate_0007,
-    [prov:type = 'prov:location',
+    [prov:type = 'prov:Location',
     prov:type = 'nidm:coordinate',
     prov:label = "Coordinate: 0007" %% xsd:string,
     nidm:coordinate1 = "36" %% xsd:float,


### PR DESCRIPTION
Caught these two capitalization issues while validating the RDF conversion from PROV-N.
1. `prov:collection` should be `prov:Collection`: http://www.w3.org/TR/prov-dm/#component6
2. `prov:location` should be `prov:Location`: http://www.w3.org/TR/prov-o/#Location

Note: While `prov:location` is a valid term in PROV-DM, the context in which it is used on lines [274](https://github.com/nicholsn/ni-dm/compare#diff-ea33497cc431cdd97b9858c9608fe263L274), [291](https://github.com/nicholsn/ni-dm/compare#diff-ea33497cc431cdd97b9858c9608fe263L291), etc. is as the `prov:type` of a `prov:Entity`, not as the relation that the lowercase version refers to (i.e.,  `prov:location`).

When the file is converted into RDF, all `prov:type` are interpreted as `rdf:type` and correspond to classes, not relations. PROV Classes follow the convention as being CamelCase with the first letter capitalized, thus any class names listed as `prov:type` should start with a capital letter (unless coming from a vocabulary following a different convention). In this way, URIs can be considered case-sensitive in order dereference correctly when multiple terms exist with the same spelling in the same namespace..

The relation `prov:location`, when converted into RDF, becomes `prov:atLocation`.

Further,`prov:Location` being used as the `prov:type` of an entity has an implication in the RDF world. For example, in RDF the `niiri:coordinate_0001` on line [273](https://github.com/nicholsn/ni-dm/compare#diff-ea33497cc431cdd97b9858c9608fe263L273) is a `prov:Entity`,  `prov:Location`, and `nidm:coordinate`; however, `prov:Entity` and `prov:Location` are not related in the PROV Ontology. To correctly map `nidm:coordinate` we define it as a subclass of both a `prov:Entity` and `prov:Location`, meaning that a `nidm:coordinate` is a `prov:entity` with some spatial aspect to it, which makes sense...
