### PR TITLE
Merge: Delete underlayFile attribute

### DIFF
--- a/examples/fsl/fsl_results.provn
+++ b/examples/fsl/fsl_results.provn
@@ -169,7 +169,6 @@ document
         nidm:voxelToWorldMapping = "[[1,2,3,4], [1,2,3,4], [1,2,3,4], [0,0,0,1]]" %% xsd:string,
         prov:label = "Excursion Set" %% xsd:string,        
         fsl:slicesPlot = "file:///path/to/rendered_thresh_zstat1.png" %% xsd:anyURI,
-        fsl:underlayFile = "file:///path/to/todo.nii" %% xsd:anyURI,
         nidm:numberOfDimensions = "3" %% xsd:int,
         nidm:dimensions = "53 63 46" %% xsd:string,
         nidm:voxelUnits = "['mm', 'mm', 'mm']" %% xsd:string,

--- a/examples/spm/spm_results.provn
+++ b/examples/spm/spm_results.provn
@@ -208,7 +208,6 @@ document
     prov:label = "Excursion Set" %% xsd:string,
     nidm:clusterLabels = "file:///path/to/cluster_labels.img" %% xsd:anyURI,
     spm:maximumIntensityProjection = "file:///path/to/MIP.png" %% xsd:anyURI,
-    nidm:underlayFile = "file:///path/to/mwStructural.nii" %% xsd:anyURI,
     nidm:fileName = "thresh_spmT_0001.img" %% xsd:string,
     nidm:coordinateSpace = 'niiri:coordinate_space_id_1',
     crypto:sha = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])

--- a/test/spm/GroundTruth/test01/test01_spm_results.provn
+++ b/test/spm/GroundTruth/test01/test01_spm_results.provn
@@ -194,7 +194,6 @@ document
     prov:label = "Excursion Set" %% xsd:string,
     nidm:clusterLabels = "file:///path/to/cluster_labels.nii.gz" %% xsd:anyURI,
     spm:maximumIntensityProjection = "file:///path/to/MIP.png" %% xsd:anyURI,
-    nidm:underlayFile = "file:///path/to/mwStructural.nii" %% xsd:anyURI,
     nidm:fileName = "thresh_spmT_0001.nii.gz" %% xsd:string,
     nidm:coordinateSpace = 'niiri:coordinate_space_id_1',
     crypto:sha = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])


### PR DESCRIPTION
Following issue #46, and as agreed on [NIDASH-DDWG call on 28th of April](https://docs.google.com/document/d/1p1eV5PvNvEz001rIckDGq9I5ez-8oafZrKokJZH8ijM/edit?usp=sharing) this pull request deletes the `nidm:underlayFile` attribute.
