### PR TITLE
Merge: (minor) term updates for consistency with terms and specification

### DIFF
--- a/examples/spm/spm_results.provn
+++ b/examples/spm/spm_results.provn
@@ -137,7 +137,7 @@ document
   wasGeneratedBy(niiri:contrast_standard_error_map_id, niiri:contrast_estimation_id,-)
   wasGeneratedBy(niiri:statistical_map_id, niiri:contrast_estimation_id,-)
   entity(niiri:sub_volume_id,
-    [prov:type = 'nidm:MaskMap',
+    [prov:type = 'nidm:SubVolumeMap',
     prov:location = "file:///path/to/svc_mask.nii" %% xsd:anyURI,
     prov:label = "Sub-volume" %% xsd:string,
     nidm:originalFileName = "mask.img" %% xsd:string,


### PR DESCRIPTION
This is a practical proposal to rename some attributes of the data model. These changes are not definitive and are just introduced for consistency across the model and with the terms (and specification) in view of the Hackathon. 

Changes introduced:
- Create sub-types of `MaskMap` (to have a different definition for each and comply with the corresponding label): `nidm:CustomMask`, `nidm:SearchSpaceMap`, `nidm:SubVolumeMap`.
- `coordinateSpace` attribute renamed in `atCoordinateSpace` (to disambiguate with `CoordinateSpace` entity).
