### PR TITLE
Inference and testDirection attribute instead of Inference(One|Two)Tailed [ following the Hackathon ]

### DIFF
--- a/examples/fsl/example001/fsl_nidm.provn
+++ b/examples/fsl/example001/fsl_nidm.provn
@@ -300,7 +300,7 @@ document
 
     activity(niiri:inference_id_1,
         [prov:type = 'nidm:Inference',
-        nidm:testDirection = 'nidm:OneTailedTest',
+        nidm:alternativeHypothesis = 'nidm:OneTailedTest',
         prov:label = "Inference: Generation"])
 
     used(niiri:inference_id_1, niiri:z_statistic_map_id_1, -)

--- a/examples/fsl/fsl_results.provn
+++ b/examples/fsl/fsl_results.provn
@@ -188,7 +188,7 @@ document
 
     activity(niiri:inference_id,
         [prov:type = 'nidm:Inference',
-        nidm:testDirection = 'nidm:OneTailedTest',
+        nidm:alternativeHypothesis = 'nidm:OneTailedTest',
         prov:label = "Inference"])
 
     used(niiri:inference_id, niiri:z_statistic_map_id, -)

--- a/examples/spm/example001/example001_spm_results.provn
+++ b/examples/spm/example001/example001_spm_results.provn
@@ -157,7 +157,7 @@ document
       nidm:pValueFWER = "1" %% xsd:float])
     activity(niiri:inference_id,
       [prov:type = 'nidm:Inference',
-      nidm:testDirection = 'nidm:OneTailedTest',
+      nidm:alternativeHypothesis = 'nidm:OneTailedTest',
       prov:label = "Inference"])
     used(niiri:inference_id, niiri:statistic_map_id,-)
     wasGeneratedBy(niiri:search_space_id,niiri:inference_id,-)

--- a/examples/spm/example002/spm_results_2contrasts.provn
+++ b/examples/spm/example002/spm_results_2contrasts.provn
@@ -254,7 +254,7 @@ document
     nidm:pValueFWER = "1" %% xsd:float])
   activity(niiri:inference_id_3,
     [prov:type = 'nidm:ConjunctionInference',
-    nidm:testDirection = 'nidm:OneTailedTest',
+    nidm:alternativeHypothesis = 'nidm:OneTailedTest',
     prov:label = "Conjunction Inference 3"])
   used(niiri:inference_id_3, niiri:statistic_map_id,-)
   used(niiri:inference_id_3, niiri:statistic_map_id_2,-)
@@ -293,7 +293,7 @@ document
     nidm:pValueFWER = "1" %% xsd:float])
   activity(niiri:inference_id_2,
     [prov:type = 'nidm:Inference',
-    nidm:testDirection = 'nidm:OneTailedTest',
+    nidm:alternativeHypothesis = 'nidm:OneTailedTest',
     prov:label = "Inference 2"])
   used(niiri:inference_id_2, niiri:statistic_map_id_2,-)
   used(niiri:inference_id_2, niiri:search_space_id_2,-)

--- a/examples/spm/example003/spm_results_conjunction.provn
+++ b/examples/spm/example003/spm_results_conjunction.provn
@@ -219,7 +219,7 @@ document
     nidm:pValueFWER = "1" %% xsd:float])
   activity(niiri:inference_id_3,
     [prov:type = 'nidm:ConjunctionInference',
-    nidm:testDirection = 'nidm:OneTailedTest',
+    nidm:alternativeHypothesis = 'nidm:OneTailedTest',
     prov:label = "Conjunction Inference"])
   used(niiri:inference_id_3, niiri:statistic_map_id,-)
   used(niiri:inference_id_3, niiri:statistic_map_id_2,-)

--- a/examples/spm/example004/spm_inference_activities.provn
+++ b/examples/spm/example004/spm_inference_activities.provn
@@ -7,18 +7,18 @@ document
 
   activity(niiri:inference_id_3,
     [prov:label = "Inference",
-    nidm:testDirection = 'nidm:OneTailedTest',
+    nidm:alternativeHypothesis = 'nidm:OneTailedTest',
     prov:type = 'nidm:Inference'])
    
   activity(niiri:conjunction_id_1,
     [prov:label = "Conjunction Inference)",
-    nidm:testDirection = 'nidm:OneTailedTest',
+    nidm:alternativeHypothesis = 'nidm:OneTailedTest',
     prov:type = 'nidm:ConjunctionInference'])
   
   activity(niiri:conjunction_id_2,
     [prov:label = "k-Conjunction Inference",
     nidm:globalNullDegree = "1",
-    nidm:testDirection = 'nidm:OneTailedTest',
+    nidm:alternativeHypothesis = 'nidm:OneTailedTest',
     prov:type = 'spm:KConjunctionInference'])
 
 endDocument

--- a/examples/spm/spm_results.provn
+++ b/examples/spm/spm_results.provn
@@ -190,7 +190,7 @@ document
       nidm:pValueFWER = "1" %% xsd:float])
     activity(niiri:inference_id,
       [prov:type = 'nidm:Inference',
-      nidm:testDirection = 'nidm:OneTailedTest',
+      nidm:alternativeHypothesis = 'nidm:OneTailedTest',
       prov:label = "Inference"])
     used(niiri:inference_id, niiri:mask_id_2,-)
     used(niiri:inference_id, niiri:statistic_map_id,-)


### PR DESCRIPTION
As discussed at the hackathon/HBM 2014 with @chrisfilo, @nicholst, @nicholsn, @jbpoline, @gllmflndn and @tiborauer (see also #68). 

This is a proposal to replace `InferenceOneTailed`/`InferenceTwoTailed`  types by `Inference`with a `testDirection` attribute specifying if the test is one- or two-tailed. This will, in particular, ease querying across different inference activities.

(The same update is also implemented for conjunctions in this pull request).

This is similar to what was done for `StatisticMap` in Pull Request #80.
## 

Note: `nidm:OneTailedTest` (respectively `nidm:TwoTailedTest`) could re-use [one tailed test](http://bioportal.bioontology.org/ontologies/STATO/?p=classes&conceptid=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FSTATO_0000286) (respectively [two tailed test](http://bioportal.bioontology.org/ontologies/STATO/?p=classes&conceptid=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FSTATO_0000287)) from STATO.
