### PR TITLE
ContrastWeights and statisticType attribute instead of (T|F)ContrastWeights [ following the Hackathon ]

### DIFF
--- a/nidm/nidm-results/fsl/example001/fsl_nidm.provn
+++ b/nidm/nidm-results/fsl/example001/fsl_nidm.provn
@@ -127,7 +127,7 @@ document
 
     entity(niiri:statistic_map_id_1,
         [prov:type = 'nidm:StatisticMap',
-        nidm:statisticType = 'nidm:tStatistic',
+        nidm:statisticType = 'nidm:TStatistic',
         prov:location = "file://./stats/tstat1.nii.gz" %% xsd:anyURI,
         prov:label = "Statistic Map: Generation",
         nidm:contrastName = "Generation" %% xsd:string,
@@ -247,7 +247,7 @@ document
         nidm:fileName = "design_matrix.csv" %% xsd:string])
     entity(niiri:contrast_id_1,
         [prov:type = 'nidm:ContrastWeights',
-        nidm:statisticType = 'nidm:tStatistic',
+        nidm:statisticType = 'nidm:TStatistic',
         nidm:contrastName = "Generation" %% xsd:string,
         prov:label = "T Contrast: Generation" %% xsd:string,
         prov:value = "[1, 0, 0, 0]" %% xsd:string])

--- a/nidm/nidm-results/fsl/fsl_results.provn
+++ b/nidm/nidm-results/fsl/fsl_results.provn
@@ -34,7 +34,7 @@ document
 
     entity(niiri:statistic_map_id,
         [prov:type = 'nidm:StatisticMap',
-        nidm:statisticType = 'nidm:tStatistic',
+        nidm:statisticType = 'nidm:TStatistic',
         prov:location = "file:///path/to/tstat1.nii.gz" %% xsd:anyURI,
         prov:label = "Statistic Map: listening &gt; rest: tstat1",
         nidm:contrastName = "listening &gt; rest" %% xsd:string,
@@ -135,7 +135,7 @@ document
         nidm:originalFileName = "design_matrix.csv" %% xsd:string])
     entity(niiri:contrast_id,
         [prov:type = 'nidm:ContrastWeights',
-        nidm:statisticType = 'nidm:tStatistic',
+        nidm:statisticType = 'nidm:TStatistic',
         nidm:contrastName = "listening > rest" %% xsd:string,
         prov:label = "Contrast weights" %% xsd:string,
         prov:value = "[1, 0, 0]" %% xsd:string])

--- a/nidm/nidm-results/spm/example001/example001_spm_results.provn
+++ b/nidm/nidm-results/spm/example001/example001_spm_results.provn
@@ -24,8 +24,13 @@ document
       nidm:dimensionsInVoxels = "[53,63,46]" %% xsd:string])
     entity(niiri:statistic_map_id,
       [prov:type = 'nidm:StatisticMap',
+<<<<<<< HEAD
       nidm:statisticType = 'nidm:tStatistic',
       prov:location = "file://./spmT_0001.nii.gz" %% xsd:anyURI,
+=======
+      nidm:statisticType = 'nidm:TStatistic',
+      prov:location = "file:///path/to/spmT_0001.nii.gz" %% xsd:anyURI,
+>>>>>>> Capital t for TStatistic
       prov:label = "Statistic Map: passive listening > rest" %% xsd:string,
       nidm:contrastName = "passive listening > rest" %% xsd:string,
       nidm:originalFileName = "spmT_0001.nii.gz" %% xsd:string,
@@ -97,7 +102,7 @@ document
 
     entity(niiri:contrast_id,
       [prov:type = 'nidm:ContrastWeights',
-      nidm:statisticType = 'nidm:tStatistic',
+      nidm:statisticType = 'nidm:TStatistic',
       nidm:contrastName = "passive listening > rest" %% xsd:string,
       prov:label = "Contrast: passive listening > rest" %% xsd:string,
       prov:value = "[1, 0]" %% xsd:string])

--- a/nidm/nidm-results/spm/example002/spm_results_2contrasts.provn
+++ b/nidm/nidm-results/spm/example002/spm_results_2contrasts.provn
@@ -21,7 +21,7 @@ document
     prov:label = "Statistic Map: listening > reading" %% xsd:string,
     nidm:contrastName = "listening > reading" %% xsd:string,
     nidm:originalFileName = "spmT_0001.img" %% xsd:string,
-    nidm:statisticType = 'nidm:tStatistic',
+    nidm:statisticType = 'nidm:TStatistic',
     nidm:errorDegreesOfFreedom = "72.9999999990787" %% xsd:float,
     nidm:effectDegreesOfFreedom = "1" %% xsd:float,
     nidm:coordinateSpace = 'niiri:coordinate_space_id_1',
@@ -61,7 +61,7 @@ document
     prov:label = "Statistic Map: motor" %% xsd:string,
     nidm:contrastName = "motor" %% xsd:string,
     nidm:originalFileName = "spmT_0002.img" %% xsd:string,
-    nidm:statisticType = 'nidm:tStatistic',
+    nidm:statisticType = 'nidm:TStatistic',
     nidm:errorDegreesOfFreedom = "72.9999999990787" %% xsd:float,
     nidm:effectDegreesOfFreedom = "1" %% xsd:float,
     nidm:coordinateSpace = 'niiri:coordinate_space_id_1',
@@ -88,7 +88,7 @@ document
 
   entity(niiri:contrast_id_2,
     [prov:type = 'nidm:ContrastWeights',
-    nidm:statisticType = 'nidm:tStatistic',
+    nidm:statisticType = 'nidm:TStatistic',
     nidm:contrastName = "motor" %% xsd:string,
     prov:label = "T Contrast weights: 0 0 1" %% xsd:string,
     prov:value = "[0, 0, 1]" %% xsd:string])
@@ -176,7 +176,7 @@ document
     nidm:originalFileName = "design_matrix.csv" %% xsd:string])
   entity(niiri:contrast_id,
     [prov:type = 'nidm:ContrastWeights',
-    nidm:statisticType = 'nidm:tStatistic',
+    nidm:statisticType = 'nidm:TStatistic',
     nidm:contrastName = "listening > reading" %% xsd:string,
     prov:label = "T Contrast weights: 1 -1 0 0" %% xsd:string,
     prov:value = "[1, -1, 0, 0]" %% xsd:string])

--- a/nidm/nidm-results/spm/example003/spm_results_conjunction.provn
+++ b/nidm/nidm-results/spm/example003/spm_results_conjunction.provn
@@ -21,7 +21,7 @@ document
     prov:label = "Statistic Map: listening > reading" %% xsd:string,
     nidm:contrastName = "listening > reading" %% xsd:string,
     nidm:originalFileName = "spmT_0001.img" %% xsd:string,
-    nidm:statisticType = 'nidm:tStatistic',
+    nidm:statisticType = 'nidm:TStatistic',
     nidm:errorDegreesOfFreedom = "72.9999999990787" %% xsd:float,
     nidm:effectDegreesOfFreedom = "1" %% xsd:float,
     nidm:coordinateSpace = 'niiri:coordinate_space_id_1',
@@ -61,7 +61,7 @@ document
     prov:label = "Statistic Map: motor" %% xsd:string,
     nidm:contrastName = "motor" %% xsd:string,
     nidm:originalFileName = "spmT_0002.img" %% xsd:string,
-    nidm:statisticType = 'nidm:tStatistic',
+    nidm:statisticType = 'nidm:TStatistic',
     nidm:errorDegreesOfFreedom = "72.9999999990787" %% xsd:float,
     nidm:effectDegreesOfFreedom = "1" %% xsd:float,
     nidm:coordinateSpace = 'niiri:coordinate_space_id_1',
@@ -89,7 +89,7 @@ document
 
   entity(niiri:contrast_id_2,
     [prov:type = 'nidm:ContrastWeights',
-    nidm:statisticType = 'nidm:tStatistic',
+    nidm:statisticType = 'nidm:TStatistic',
     nidm:contrastName = "motor" %% xsd:string,
     prov:label = "T Contrast weights: 0 0 1" %% xsd:string,
     prov:value = "[0, 0, 1]" %% xsd:string])
@@ -177,7 +177,7 @@ document
     nidm:originalFileName = "design_matrix.csv" %% xsd:string])
   entity(niiri:contrast_id,
     [prov:type = 'nidm:ContrastWeights',
-    nidm:statisticType = 'nidm:tStatistic',
+    nidm:statisticType = 'nidm:TStatistic',
     nidm:contrastName = "listening > reading" %% xsd:string,
     prov:label = "T Contrast weights: 1 -1 0 0" %% xsd:string,
     prov:value = "[1, -1, 0, 0]" %% xsd:string])

--- a/nidm/nidm-results/spm/spm_results.provn
+++ b/nidm/nidm-results/spm/spm_results.provn
@@ -32,7 +32,7 @@ document
       nidm:dimensionsInVoxels = "[53,63,46]" %% xsd:string])
     entity(niiri:statistic_map_id,
       [prov:type = 'nidm:StatisticMap',
-      nidm:statisticType = 'nidm:tStatistic',
+      nidm:statisticType = 'nidm:TStatistic',
       prov:location = "file:///path/to/spmT_0001.img" %% xsd:anyURI,
       prov:label = "Statistic Map: listening > rest" %% xsd:string,
       nidm:contrastName = "listening > rest" %% xsd:string,
@@ -122,7 +122,7 @@ document
     used(niiri:model_pe_id, niiri:mask_id_1,-)
     entity(niiri:contrast_id,
       [prov:type = 'nidm:ContrastWeights',
-      nidm:statisticType = 'nidm:tStatistic',
+      nidm:statisticType = 'nidm:TStatistic',
       nidm:contrastName = "listening > rest" %% xsd:string,
       prov:label = "Contrast: Listening > Rest" %% xsd:string,
       prov:value = "[1, 0, 0]" %% xsd:string])


### PR DESCRIPTION
As discussed at the hackathon/HBM 2014 (see also #68). 

This is a proposal to replace `TContrastWeights`/`FContrastWeights`  types by `ContrastWeights`with a `statisticType` attribute specifying. This will, in particular, ease querying across different inference activities.

This is similar to what was done for `StatisticMap` and `Inference` in Pull Request #80 and #81.
