### PR TITLE
Range of "spm:softwareRevision"

### DIFF
--- a/nidm/nidm-results/nidm-results.owl
+++ b/nidm/nidm-results/nidm-results.owl
@@ -1164,7 +1164,7 @@ NIDM Concept ID: spm_94. """ ;
                      
                      prov:definition "revision number of a piece of software." ;
                      
-                     rdfs:range xsd:int ;
+                     rdfs:range xsd:string ;
                      
                      rdfs:domain prov:SoftwareAgent .
 


### PR DESCRIPTION
**Term**: `spm:softwareRevision`
**Range**: xsd:int
**Current link**:  [nidm-results.owl/spm:softwareRevision](https://github.com/incf-nidash/nidm/blob/master/nidm/nidm-results/nidm-results.owl#L1156-L1169)

---

@cmaumet `10:14 25 Apr`
Are software revisions in SPM always defined with integers?
