### PR TITLE
Merge(?): Definition of "pValue"

### DIFF
--- a/nidm/nidm-results/nidm-results.owl
+++ b/nidm/nidm-results/nidm-results.owl
@@ -733,6 +733,8 @@ NIDM Concept ID: nidm_44. """ ;
 
 nidm:pValue rdf:type owl:DatatypeProperty ;
             
+            owl:sameAs "http://purl.obolibrary.org/obo/OBI_0000175"^^xsd:anyURI ;
+            
             iao:IAO_0000112 "8.95E-14" ;
             
             iao:IAO_0000116 """Range: Floatbetween0and1 not found. BIRNLex or 
@@ -743,8 +745,6 @@ http://purl.obolibrary.org/obo/OBI_0000175
 http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#P-Value""" ;
             
             owl:sameAs "This definition is from OBI. Please update this note if the definition is modified." ;
-            
-            prov:definition "\"A quantitative confidence value that represents the probability of obtaining a result at least as extreme as that actually obtained, assuming that the actual value was the result of chance alone.\"" ;
             
             rdfs:domain nidm:ExcursionSet ;
             
@@ -2363,16 +2363,6 @@ NIDM Concept ID: nidm_100. """ ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#Statistic
-
-nidm:Statistic rdf:type owl:Class ;
-               
-               rdfs:subClassOf prov:Entity ;
-               
-               owl:sameAs "http://purl.obolibrary.org/obo/STATO_0000039"^^xsd:anyURI .
-
-
-
 ###  http://www.incf.org/ns/nidash/nidm#StandardizedCoordinateSystem
 
 nidm:StandardizedCoordinateSystem rdf:type owl:Class ;
@@ -2383,6 +2373,16 @@ nidm:StandardizedCoordinateSystem rdf:type owl:Class ;
                                                "This is meant to be used for retrospective export when exact template is unknown." ;
                                   
                                   prov:definition "Parent of all reference spaces except \"Subject\"." .
+
+
+
+###  http://www.incf.org/ns/nidash/nidm#Statistic
+
+nidm:Statistic rdf:type owl:Class ;
+               
+               rdfs:subClassOf prov:Entity ;
+               
+               owl:sameAs "http://purl.obolibrary.org/obo/STATO_0000039"^^xsd:anyURI .
 
 
 
@@ -2432,28 +2432,6 @@ NIDM Concept ID: nidm_101. """ .
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#TStatistic
-
-nidm:TStatistic rdf:type owl:Class ;
-                
-                rdfs:subClassOf nidm:Statistic ;
-                
-                owl:sameAs "http://purl.obolibrary.org/obo/STATO_0000176"^^xsd:anyURI .
-
-
-
-###  http://www.incf.org/ns/nidash/nidm#TwoTailedTest
-
-nidm:TwoTailedTest rdf:type owl:Class ;
-                   
-                   rdfs:subClassOf prov:Entity ;
-                   
-                   prov:definition "Re-use \"two tailed test\" from STATO"^^xsd:anyURI ;
-                   
-                   owl:sameAs "http://purl.obolibrary.org/obo/STATO_0000287"^^xsd:anyURI .
-
-
-
 ###  http://www.incf.org/ns/nidash/nidm#SubjectCoordinateSystem
 
 nidm:SubjectCoordinateSystem rdf:type owl:Class ;
@@ -2463,6 +2441,16 @@ nidm:SubjectCoordinateSystem rdf:type owl:Class ;
                              prov:definition "Coordinate system defined by the subject brain (no spatial normalisation applied)." ;
                              
                              rdfs:comment "Used in FSL and SPM un-registered data." .
+
+
+
+###  http://www.incf.org/ns/nidash/nidm#TStatistic
+
+nidm:TStatistic rdf:type owl:Class ;
+                
+                rdfs:subClassOf nidm:Statistic ;
+                
+                owl:sameAs "http://purl.obolibrary.org/obo/STATO_0000176"^^xsd:anyURI .
 
 
 
@@ -2477,6 +2465,18 @@ nidm:TalairachCoordinateSystem rdf:type owl:Class ;
                                rdfs:comment "FIXME. This definition needs to be re-worked and reviewed." ;
                                
                                rdfs:seeAlso "http://www.talairach.org/" .
+
+
+
+###  http://www.incf.org/ns/nidash/nidm#TwoTailedTest
+
+nidm:TwoTailedTest rdf:type owl:Class ;
+                   
+                   rdfs:subClassOf prov:Entity ;
+                   
+                   prov:definition "Re-use \"two tailed test\" from STATO"^^xsd:anyURI ;
+                   
+                   owl:sameAs "http://purl.obolibrary.org/obo/STATO_0000287"^^xsd:anyURI .
 
 
 


### PR DESCRIPTION
**Term**: `pValue`
**Original comment**: [link](https://docs.google.com/spreadsheets/d/16pC2cDsdxlzv2CzlNMtStqt5-xHwDEsU6MjZVxWhrE4/edit?disco=AAAAAGscQFs)
**Current link**:  [nidm-results.owl/pValue](https://github.com/incf-nidash/nidm/blob/master/nidm/nidm-results/nidm-results.owl#L732-L751)

---

@jbpoline  `11:07 31 Aug 2013`
uri from experimental factor ontology? (form OB) or create property - look for stat ontology like EDAM

@nicholsn `20:52 18 Apr`
+1 for reuse of term from OBI (http://purl.obolibrary.org/obo/OBI_0000175), or list as a synonym

@cmaumet `09:53 24 Apr`
+1 to re-use the OBI term.

[there were more comments not reported here about how to indicate re-use of definitions within the spreadsheet]
