### PR TITLE
Definition of "voxelToWorldMapping"

### DIFF
--- a/nidm/nidm-results/nidm-results.owl
+++ b/nidm/nidm-results/nidm-results.owl
@@ -971,7 +971,7 @@ nidm:voxelToWorldMapping rdf:type owl:DatatypeProperty ;
                          iao:IAO_0000116 """Range: Matrixoffloat not found. BIRNLex or 
 NIDM Concept ID: nidm_68. """ ;
                          
-                         prov:definition "Change-of-basis matrix from the voxel to world space." ;
+                         prov:definition "Homogeneous transformation matrix to map from voxel coordinate system to world coordinate system." ;
                          
                          rdfs:domain nidm:CoordinateSpace ;
                          


### PR DESCRIPTION
**Term**: `voxelToWorldMapping`
**Current definition**: "Voxel to World Mapping. Change-of-basis matrix from the voxel to world space?"
**Original comment**: [link](https://docs.google.com/spreadsheets/d/16pC2cDsdxlzv2CzlNMtStqt5-xHwDEsU6MjZVxWhrE4/edit?disco=AAAAAGsYjjM)

---

@khelm `20:39 9 Apr`
"Voxel to World Mapping. " could be omitted

@nicholsn `21:05 18 Apr`
+1
