### PR TITLE
Update SPM ground truth example001: original files are .nii (not .hdr/.img)

### DIFF
--- a/nidm/nidm-results/spm/example001/example001_spm_results.provn
+++ b/nidm/nidm-results/spm/example001/example001_spm_results.provn
@@ -36,16 +36,9 @@ document
       crypto:sha512 = "799e9bbf8c15b35c0098bca468846bf2cd895a3366382b5ceaa953f1e9e576955341a7c86e13e6fe9359da4ff1496a609f55ce9ecff8da2e461365372f2506d6" %% xsd:string])
     entity(niiri:map_id_1,
       [prov:type = 'nidm:Map',
-      nidm:originalFileName = "spmT_0001.img" %% xsd:string,
-      dct:format = 'nidm:Nifti1PairImage',
-      nidm:hasMapHeader = 'niiri:statistic_original_map_header_id',
+      nidm:originalFileName = "spmT_0001.nii" %% xsd:string,
+      dct:format = 'nidm:Nifti1',
       crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
-    entity(niiri:statistic_original_map_header_id,
-      [ dct:format = 'nidm:Nifti1PairHeader',
-        prov:type = 'nidm:MapHeader',
-        nidm:originalFileName = "spmT_0001.hdr" %% xsd:string,
-        crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string
-      ])      
     wasDerivedFrom(niiri:statistic_map_id, niiri:map_id_1)
     entity(niiri:contrast_map_id,
       [prov:type = 'nidm:ContrastMap',
@@ -57,16 +50,9 @@ document
       crypto:sha512 = "f0720b732aaf19c2ec42d0469f8308beb3aa978baf65c7dce6476a0d8e5b2f38c4fa9609f045a536678440feebce9a047e3bd6d59fdb8fb64baae058690bbda2" %% xsd:string])
     entity(niiri:map_id_2,
       [prov:type = 'nidm:Map',
-      nidm:originalFileName = "con_0001.img" %% xsd:string,
-      dct:format = 'nidm:Nifti1PairImage',
-      nidm:hasMapHeader = 'niiri:original_contrast_map_header_id',
+      nidm:originalFileName = "con_0001.nii" %% xsd:string,
+      dct:format = 'nidm:Nifti1',
       crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
-    entity(niiri:original_contrast_map_header_id,
-      [ dct:format = 'nidm:Nifti1PairHeader',
-        prov:type = 'nidm:MapHeader',
-        nidm:originalFileName = "con_0001.hdr" %% xsd:string,
-        crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string
-      ])
     wasDerivedFrom(niiri:contrast_map_id, niiri:map_id_2)
 
     entity(niiri:beta_map_id_1,
@@ -76,16 +62,10 @@ document
       
     entity(niiri:map_id_4,
       [prov:type = 'nidm:Map',
-      nidm:originalFileName = "beta_0001.img" %% xsd:string,
-      dct:format = 'nidm:Nifti1PairImage',
-      nidm:hasMapHeader = 'niiri:original_pe_map_header_id',
+      nidm:originalFileName = "beta_0001.nii" %% xsd:string,
+      dct:format = 'nidm:Nifti1',
       crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
-    entity(niiri:original_pe_map_header_id,
-      [ dct:format = 'nidm:Nifti1PairHeader',
-        prov:type = 'nidm:MapHeader',
-        nidm:originalFileName = "beta_0001.hdr" %% xsd:string,
-        crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string
-      ])
+
     wasDerivedFrom(niiri:beta_map_id_1, niiri:map_id_4)
     wasGeneratedBy(niiri:beta_map_id_1, niiri:model_pe_id,-)
     used(niiri:contrast_estimation_id, niiri:beta_map_id_1,-)
@@ -95,16 +75,9 @@ document
       nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1'])
     entity(niiri:map_id_5,
       [prov:type = 'nidm:Map',
-      nidm:originalFileName = "beta_0002.img" %% xsd:string,
-      dct:format = 'nidm:Nifti1PairImage',
-      nidm:hasMapHeader = 'niiri:original_pe_map_header_2_id',
+      nidm:originalFileName = "beta_0002.nii" %% xsd:string,
+      dct:format = 'nidm:Nifti1',
       crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
-    entity(niiri:original_pe_map_header_2_id,
-      [ dct:format = 'nidm:Nifti1PairHeader',
-        prov:type = 'nidm:MapHeader',
-        nidm:originalFileName = "beta_0002.hdr" %% xsd:string,
-        crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string
-      ])
     wasDerivedFrom(niiri:beta_map_id_2, niiri:map_id_5)
     wasGeneratedBy(niiri:beta_map_id_2, niiri:model_pe_id,-)
     used(niiri:contrast_estimation_id, niiri:beta_map_id_2,-)
@@ -141,16 +114,10 @@ document
       crypto:sha512 = "2025dc6c33708b80708c2eba3215fb1149df236fb558a8e8f8f6cf34595fb54734fe5e436db3e192a424d99699dd7feb2f4a9020ceae8e7bcbd881b17825256a" %% xsd:string])
     entity(niiri:map_id_6,
       [prov:type = 'nidm:Map',
-      nidm:originalFileName = "RPV.img" %% xsd:string,
-      dct:format = 'nidm:Nifti1PairImage',
-      nidm:hasMapHeader = 'niiri:original_rpv_map_header_id',
+      nidm:originalFileName = "RPV.nii" %% xsd:string,
+      dct:format = 'nidm:Nifti1',
       crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
-    entity(niiri:original_rpv_map_header_id,
-      [ dct:format = 'nidm:Nifti1PairHeader',
-        prov:type = 'nidm:MapHeader',
-        nidm:originalFileName = "RPV.hdr" %% xsd:string,
-        crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string
-      ])
+    
     wasDerivedFrom(niiri:resels_per_voxel_map_id, niiri:map_id_6)
     used(niiri:inference_id, niiri:resels_per_voxel_map_id,-)
     entity(niiri:design_matrix_id,


### PR DESCRIPTION
As commented by @gllmflndn, images created by SPM12 are in .nii format (and not nifti pair: .img/.hdr). This pull request update the SPM example 001 accordingly.
