### PR TITLE
Fix: SPM ground truth

### DIFF
--- a/nidm/nidm-results/spm/example001/example001_spm_results.provn
+++ b/nidm/nidm-results/spm/example001/example001_spm_results.provn
@@ -51,12 +51,12 @@ document
       nidm:effectDegreesOfFreedom = "1" %% xsd:float,
       nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = "799e9bbf8c15b35c0098bca468846bf2cd895a3366382b5ceaa953f1e9e576955341a7c86e13e6fe9359da4ff1496a609f55ce9ecff8da2e461365372f2506d6" %% xsd:string])
-    entity(niiri:map_id_1,
+    entity(niiri:map_id_6,
       [prov:type = 'nidm:Map',
       nidm:originalFileName = "spmT_0001.nii" %% xsd:string,
       dct:format = 'nidm:Nifti1',
       crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
-    wasDerivedFrom(niiri:statistic_map_id, niiri:map_id_1)
+    wasDerivedFrom(niiri:statistic_map_id, niiri:map_id_6)
     
     entity(niiri:contrast_map_id,
       [prov:type = 'nidm:ContrastMap',
@@ -66,37 +66,37 @@ document
       nidm:contrastName = "passive listening > rest" %% xsd:string,
       nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = "f0720b732aaf19c2ec42d0469f8308beb3aa978baf65c7dce6476a0d8e5b2f38c4fa9609f045a536678440feebce9a047e3bd6d59fdb8fb64baae058690bbda2" %% xsd:string])
-    entity(niiri:map_id_2,
+    entity(niiri:map_id_7,
       [prov:type = 'nidm:Map',
       nidm:originalFileName = "con_0001.nii" %% xsd:string,
       dct:format = 'nidm:Nifti1',
       crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
-    wasDerivedFrom(niiri:contrast_map_id, niiri:map_id_2)
+    wasDerivedFrom(niiri:contrast_map_id, niiri:map_id_7)
 
     entity(niiri:beta_map_id_1,
       [prov:type = 'nidm:ParameterEstimateMap',
       prov:label = "Beta Map 1" %% xsd:string,
       nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1'])
       
-    entity(niiri:map_id_4,
+    entity(niiri:map_id_2,
       [prov:type = 'nidm:Map',
       nidm:originalFileName = "beta_0001.nii" %% xsd:string,
       dct:format = 'nidm:Nifti1',
       crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
 
-    wasDerivedFrom(niiri:beta_map_id_1, niiri:map_id_4)
+    wasDerivedFrom(niiri:beta_map_id_1, niiri:map_id_2)
     wasGeneratedBy(niiri:beta_map_id_1, niiri:model_pe_id,-)
     used(niiri:contrast_estimation_id, niiri:beta_map_id_1,-)
     entity(niiri:beta_map_id_2,
       [prov:type = 'nidm:ParameterEstimateMap',
       prov:label = "Beta Map 2" %% xsd:string,
       nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1'])
-    entity(niiri:map_id_5,
+    entity(niiri:map_id_3,
       [prov:type = 'nidm:Map',
       nidm:originalFileName = "beta_0002.nii" %% xsd:string,
       dct:format = 'nidm:Nifti1',
       crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
-    wasDerivedFrom(niiri:beta_map_id_2, niiri:map_id_5)
+    wasDerivedFrom(niiri:beta_map_id_2, niiri:map_id_3)
     wasGeneratedBy(niiri:beta_map_id_2, niiri:model_pe_id,-)
     used(niiri:contrast_estimation_id, niiri:beta_map_id_2,-)
 
@@ -114,6 +114,12 @@ document
       prov:label = "Residual Mean Squares Map" %% xsd:string,
       nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = "84cd0e608b8763307a1166b88761291e552838d85b58334a69a286060f6489a3b0929a940c3ccac883803455118787ea32e0bb5a6d236a5d6e9e8b6a9f918a6b" %% xsd:string])
+    entity(niiri:map_id_4,
+      [prov:type = 'nidm:Map',
+      nidm:originalFileName = "ResMS.nii" %% xsd:string,
+      dct:format = 'nidm:Nifti1',
+      crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
+    wasDerivedFrom(niiri:residual_mean_squares_map_id, niiri:map_id_4)
     entity(niiri:grand_mean_map_id,
       [prov:type = 'nidm:GrandMeanMap',
       prov:location = "file://./GrandMean.nii.gz" %% xsd:anyURI,
@@ -130,13 +136,13 @@ document
       nidm:originalFileName = "RPV" %% xsd:string,
       nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = "2025dc6c33708b80708c2eba3215fb1149df236fb558a8e8f8f6cf34595fb54734fe5e436db3e192a424d99699dd7feb2f4a9020ceae8e7bcbd881b17825256a" %% xsd:string])
-    entity(niiri:map_id_6,
+    entity(niiri:map_id_5,
       [prov:type = 'nidm:Map',
       nidm:originalFileName = "RPV.nii" %% xsd:string,
       dct:format = 'nidm:Nifti1',
       crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
     
-    wasDerivedFrom(niiri:resels_per_voxel_map_id, niiri:map_id_6)
+    wasDerivedFrom(niiri:resels_per_voxel_map_id, niiri:map_id_5)
     used(niiri:inference_id, niiri:resels_per_voxel_map_id,-)
     entity(niiri:design_matrix_id,
       [prov:type = 'nidm:DesignMatrix',


### PR DESCRIPTION
This pull request include a few fixes in the ground truth example 001 for SPM export, in particular:
- Add `MaskMap` entity
- Add `ResidualMeanSquaresMap` original file entity
- Update original map identifiers to match SPM export
