### PR TITLE
Fix a potential problem with StatisticImageProperties Class definition.

### DIFF
--- a/nidm/nidm-results/nidm-results.owl
+++ b/nidm/nidm-results/nidm-results.owl
@@ -43,12 +43,6 @@ owl:sameAs rdf:type owl:AnnotationProperty .
 
 
 
-###  http://www.w3.org/ns/prov#definition
-
-prov:definition rdf:type owl:AnnotationProperty .
-
-
-
 
 
 #################################################################
@@ -212,58 +206,6 @@ NIDM Concept ID: spm_77. """ ;
                                   rdfs:domain nidm:ExcursionSet ;
                                   
                                   rdfs:range nidm:Image .
-
-
-
-###  http://www.w3.org/ns/prov#atLocation
-
-prov:atLocation rdf:type owl:ObjectProperty ;
-                
-                rdfs:domain prov:Entity ;
-                
-                rdfs:range prov:Location .
-
-
-
-###  http://www.w3.org/ns/prov#used
-
-prov:used rdf:type owl:ObjectProperty ;
-          
-          rdfs:domain prov:Activity ;
-          
-          rdfs:range prov:Entity .
-
-
-
-###  http://www.w3.org/ns/prov#wasAssociatedWith
-
-prov:wasAssociatedWith rdf:type owl:ObjectProperty ;
-                       
-                       rdfs:subPropertyOf owl:topObjectProperty ;
-                       
-                       rdfs:domain prov:Activity ;
-                       
-                       rdfs:range prov:Agent .
-
-
-
-###  http://www.w3.org/ns/prov#wasDerivedFrom
-
-prov:wasDerivedFrom rdf:type owl:ObjectProperty ;
-                    
-                    rdfs:range prov:Entity ;
-                    
-                    rdfs:domain prov:Entity .
-
-
-
-###  http://www.w3.org/ns/prov#wasGeneratedBy
-
-prov:wasGeneratedBy rdf:type owl:ObjectProperty ;
-                    
-                    rdfs:range prov:Activity ;
-                    
-                    rdfs:domain prov:Entity .
 
 
 
@@ -2597,48 +2539,6 @@ spm:nonStationaryRandomField rdf:type owl:Class ;
                              
                              iao:IAO_0000116 """Range: <thisisanattributevalue> not found. BIRNLex or 
 NIDM Concept ID: spm_81. """ .
-
-
-
-###  http://www.w3.org/ns/prov#Activity
-
-prov:Activity rdf:type owl:Class .
-
-
-
-###  http://www.w3.org/ns/prov#Agent
-
-prov:Agent rdf:type owl:Class .
-
-
-
-###  http://www.w3.org/ns/prov#Bundle
-
-prov:Bundle rdf:type owl:Class ;
-            
-            rdfs:subClassOf prov:Entity .
-
-
-
-###  http://www.w3.org/ns/prov#Entity
-
-prov:Entity rdf:type owl:Class .
-
-
-
-###  http://www.w3.org/ns/prov#Location
-
-prov:Location rdf:type owl:Class ;
-              
-              rdfs:subClassOf prov:Entity .
-
-
-
-###  http://www.w3.org/ns/prov#SoftwareAgent
-
-prov:SoftwareAgent rdf:type owl:Class ;
-                   
-                   rdfs:subClassOf prov:Agent .
 
 
 


### PR DESCRIPTION
In issue #165 I noted that the StatisticImageProperties were not properly defined in the nidm-results.owl.
This is a potential fix to it, by changing the names of the definition under this comment line.
