### PR TITLE
Remove definition of spm:StatisticImageProperties in nidm-results.owl (following #132) 

### DIFF
--- a/nidm/nidm-results/nidm-results.owl
+++ b/nidm/nidm-results/nidm-results.owl
@@ -2544,31 +2544,6 @@ NIDM Concept ID: spm_83. """ .
 
 
 
-###  http://www.incf.org/ns/nidash/spm#StatisticImageProperties
-
-nidm:SearchSpaceMap rdf:type owl:Class ;
-                             
-                             rdfs:subClassOf prov:Entity ;
-                             
-                             rdfs:seeAlso "http://purl.obolibrary.org/obo/OBI_0000235" ;
-                             
-                             prov:definition "Properties of the underlying statistical process." ;
-                             
-                             iao:IAO_0000112 """entity(niiri:stat_image_properties_id,
-      [prov:type = 'nidm:SearchSpaceMap',
-      prov:label = \"Statistical image properties\",
-      spm:expectedNumberOfVoxelsPerCluster = \"0.553331387916112\" %% xsd:float,
-      spm:expectedNumberOfClusters = \"0.0889172687960151\" %% xsd:float,
-      spm:heightCriticalThresholdFWE05 = \"5.23529984739211\" %% xsd:float,
-      spm:heightCriticalThresholdFDR05 = \"6.22537899017334\" %% xsd:float,
-      spm:smallestSignifClusterSizeInVoxelsFWE05 = \"1\" %% xsd:float,
-      spm:smallestSignifClusterSizeInVoxelsFDR05 = \"3\" %% xsd:float])""" ;
-                             
-                             iao:IAO_0000116 """BIRNLex or 
-NIDM Concept ID: spm_95. """ .
-
-
-
 ###  http://www.incf.org/ns/nidash/spm#kConjunctionInference
 
 spm:kConjunctionInference rdf:type owl:Class ;


### PR DESCRIPTION
As noted by @jorisslob in #166, the definition associated with `StatisticImageProperties` had not been deleted in `nidm-results.owl` following its deletion from the model in #132.

This pull request fixes `nidm-results.owl` by removing the useless definition.
