### PR TITLE
Definition of "Coordinate": re-use NCI term?

### DIFF
--- a/nidm/nidm-results/nidm-results.owl
+++ b/nidm/nidm-results/nidm-results.owl
@@ -1600,15 +1600,13 @@ nidm:Coordinate rdf:type owl:Class ;
                 
                 rdfs:subClassOf prov:Entity ;
                 
+                owl:sameAs "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C44465"^^xsd:anyURI ;
+                
                 iao:IAO_0000116 """Model: - search for coordinate uri
 - subclasses of coordinate
 - additional properties (e.g. units) 
 . Context: Functional. BIRNLex or 
 NIDM Concept ID: nidm_14. """ ;
-                
-                prov:definition "A point in N-dimensional space where the dimensions could be arbitrary." ;
-                
-                rdfs:seeAlso "http://purl.obolibrary.org/obo/IAO_0000400" ;
                 
                 iao:IAO_0000112 "3D (x,y,x), 2D (x,y), Vertices, etc." .
 


### PR DESCRIPTION
**Term**: `Coordinate`
**Current definition**: "A point in N-dimensional space where the dimensions could be arbitrary."
**Original comment**: [link](https://docs.google.com/spreadsheets/d/16pC2cDsdxlzv2CzlNMtStqt5-xHwDEsU6MjZVxWhrE4/edit?disco=AAAAAGscQFo)
**See also**: ["cartesian spatial coordinate datum" from OBO](http://purl.obolibrary.org/obo/IAO_0000400)

---

@satra `15:15 23 Sep 2013` [commenting on seeAlso: "cartesian spatial coordinate datum"]
this refers to a spatial coordinate as opposed to an arbitrary coordinate in N-dimensional space where the dimensions could be space or time or other things such as channels in an MRI setting.

@nicholsn `21:01 18 Apr`
Could use NCI [link](http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C44465):
"A number or other designation that identifies a position relative to an axis or grid."

@cmaumet `12:09 25 Apr`
+1 for the NCI definition
