### PR TITLE
Rename "atCoordinateSpace" in "inCoordinateSpace" + definition

### DIFF
--- a/nidm/nidm-results/fsl/example001/fsl_nidm.provn
+++ b/nidm/nidm-results/fsl/example001/fsl_nidm.provn
@@ -147,7 +147,7 @@ document
         nidm:filename = "TStatistic.nii.gz" %% xsd:string,
         nidm:errorDegreesOfFreedom = "102" %% xsd:float,
         nidm:effectDegreesOfFreedom = "1" %% xsd:float,
-        nidm:atCoordinateSpace = 'niiri:coordinate_space_id_12',
+        nidm:inCoordinateSpace = 'niiri:coordinate_space_id_12',
         crypto:sha512 = "b6286d36e678c23622b5b0486f0efb5b274f9a5e2a3ee6aceb6a0338f7745fb8a4d8f72b8af22c4ffb40c860bfb65940c87b03a7336cdf1a665f9cb07a5c2527" %% xsd:string])
 
     entity(niiri:z_statistic_map_id_1,
@@ -159,7 +159,7 @@ document
         nidm:contrastName = "Generation" %% xsd:string,
         nidm:filename = "zstat1.nii.gz" %% xsd:string,
         nidm:filename = "ZStatistic.nii.gz" %% xsd:string,
-        nidm:atCoordinateSpace = 'niiri:coordinate_space_id_11',
+        nidm:inCoordinateSpace = 'niiri:coordinate_space_id_11',
         crypto:sha512 = "3a68a4e5963766af86d22a871a4dbca9568a46441a567855b3a84dbd47ea01acea11ed77b37ce85078a219adaa92264296a4548c1ba39b11ff028e8fefd95d03" %% xsd:string])
 
    
@@ -171,35 +171,35 @@ document
         nidm:contrastName = "Generation" %% xsd:string,
         nidm:filename = "cope1.nii.gz" %% xsd:string,
         nidm:filename = "Contrast.nii.gz" %% xsd:string,
-        nidm:atCoordinateSpace = 'niiri:coordinate_space_id_8',        
+        nidm:inCoordinateSpace = 'niiri:coordinate_space_id_8',        
         crypto:sha512 = "4c755c0ae6088f8001e0458f89e51fea0e2719b5dc747fed6f617ae12ad5c6a643e1afcb886bcabaaac7911f5e69086c1bd084af9f75dae75913d44a783151f6" %% xsd:string])
 
     entity(niiri:beta_map_id_1,
         [prov:type = 'nidm:ParameterEstimateMap',
         prov:label = "Parameter estimate 1" %% xsd:string,
         nidm:filename = "pe1.nii.gz" %% xsd:string,
-        nidm:atCoordinateSpace = 'niiri:coordinate_space_id_4'])
+        nidm:inCoordinateSpace = 'niiri:coordinate_space_id_4'])
   
 
     entity(niiri:beta_map_id_2,
         [prov:type = 'nidm:ParameterEstimateMap',
         prov:label = "Parameter estimate 2" %% xsd:string,
         nidm:filename = "pe2.nii.gz" %% xsd:string,
-        nidm:atCoordinateSpace = 'niiri:coordinate_space_id_5'])
+        nidm:inCoordinateSpace = 'niiri:coordinate_space_id_5'])
 
 
     entity(niiri:beta_map_id_3,
         [prov:type = 'nidm:ParameterEstimateMap',
         prov:label = "Parameter estimate 3" %% xsd:string,
         nidm:filename = "pe3.nii.gz" %% xsd:string,
-        nidm:atCoordinateSpace = 'niiri:coordinate_space_id_6'])
+        nidm:inCoordinateSpace = 'niiri:coordinate_space_id_6'])
 
 
     entity(niiri:beta_map_id_4,
         [prov:type = 'nidm:ParameterEstimateMap',
         prov:label = "Parameter estimate 4" %% xsd:string,
         nidm:filename = "pe4.nii.gz" %% xsd:string,
-        nidm:atCoordinateSpace = 'niiri:coordinate_space_id_7'])
+        nidm:inCoordinateSpace = 'niiri:coordinate_space_id_7'])
   
 
     wasGeneratedBy(niiri:beta_map_id_1, niiri:model_parameters_estimation_id,-)
@@ -213,7 +213,7 @@ document
         nidm:filename = "ContrastStandardError.nii.gz" %% xsd:string,
         dct:format = "image/nifti",
         prov:label = "Contrast Standard Error Map" %% xsd:string,
-        nidm:atCoordinateSpace = 'niiri:coordinate_space_id_10',
+        nidm:inCoordinateSpace = 'niiri:coordinate_space_id_10',
         crypto:sha512 = "8529f3ff9f10da8f332ced9d579990321475c1498b56d79ede560ba2eccf6d68718757dc7af78eb1e86617a41e6c9f55161f756d184e2b0fb06c3d419dc99856" %% xsd:string])
     entity(niiri:map_id_1,
       [prov:type = 'nidm:Map',
@@ -228,7 +228,7 @@ document
         prov:label = "Residual Mean Squares Map" %% xsd:string,
         nidm:filename = "sigmasquareds.nii.gz" %% xsd:string,
         nidm:filename = "ResidualMeanSquares.nii.gz" %% xsd:string,
-        nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+        nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
         crypto:sha512 = "1327a300eb1e20d42c67abb3c49a47b80ecabfebd13d0ba0aca0560e8bf43891f0e35a958c1afa84e041f62cf0038f58b4ab71f68b0b50d4153210aeed74f4ff" %% xsd:string])    
 
     entity(niiri:grand_mean_map_id,
@@ -239,7 +239,7 @@ document
       nidm:filename = "mean_func.nii.gz" %% xsd:string,
       nidm:filename = "GrandMean.nii.gz" %% xsd:string,
       nidm:maskedMedian = "115" %% xsd:float,
-      nidm:atCoordinateSpace = 'niiri:coordinate_space_id_2',
+      nidm:inCoordinateSpace = 'niiri:coordinate_space_id_2',
       crypto:sha512 = "7a2703cea740e27a5170fb19e4a09b5e815e4b7e477bc75958404d675aa408f53f747892a2ef4472f933cf5f12cd21cea99d5f5e551938081636fb6d4049473e" %% xsd:string])
 
     entity(niiri:data_id,
@@ -293,7 +293,7 @@ document
         crypto:sha512 = "cc1a96a6111e5107eb08487e38e6d7f8164b9d1d3f1fc10948bdbcfaea642fe9bfae278c7fc372b65cac7232ea58fd8fb5914014e7b9a5d6200592b12b2a728b" %% xsd:string,
         nidm:filename = "mask.nii.gz" %% xsd:string,
         nidm:filename = "SearchSpace.nii.gz" %% xsd:string,
-        nidm:atCoordinateSpace = 'niiri:coordinate_space_id_3',
+        nidm:inCoordinateSpace = 'niiri:coordinate_space_id_3',
         prov:label = "Search Space Map" %% xsd:string,
         fsl:searchVolumeInVoxels = "45203" %% xsd:int,
         fsl:reselSizeInVoxels = "12.0418" %%xsd:float,
@@ -337,7 +337,7 @@ document
         nidm:filename = "thresh_zstat1.nii.gz" %% xsd:string,
         prov:label = "Excursion Set" %% xsd:string,        
         nidm:visualisation = 'niiri:excursion_set_png_id',
-        nidm:atCoordinateSpace = 'niiri:coordinate_space_id_13'])
+        nidm:inCoordinateSpace = 'niiri:coordinate_space_id_13'])
     entity(niiri:excursion_set_png_id,
       [prov:type = 'nidm:Image',
       prov:location = "file:///path/to/rendered_thresh_zstat1.png" %% xsd:anyURI,

--- a/nidm/nidm-results/fsl/fsl_results.provn
+++ b/nidm/nidm-results/fsl/fsl_results.provn
@@ -44,7 +44,7 @@ document
         nidm:filename = "TStatistic_0001.nii.gz" %% xsd:string,
         nidm:errorDegreesOfFreedom = "73.000000" %% xsd:float,
         nidm:effectDegreesOfFreedom = "1.000000" %% xsd:float,
-        nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+        nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
         crypto:sha512 = "400a2f07d99ed9be06577e6ecc89222cf4b688c654bc89067da558e88b73b97dd1b25e6c98f2a735fa0a1409598cff7e6025bda55abb6b9f5ef65d8d307eeba8"])
 
     entity(niiri:z_statistic_map_id,
@@ -56,7 +56,7 @@ document
         nidm:contrastName = "listening &gt; rest" %% xsd:string,
         nidm:filename = "zstat1.nii.gz" %% xsd:string,
         nidm:filename = "ZStatistic_0001.nii.gz" %% xsd:string,
-        nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+        nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
         crypto:sha512 = "400a2f07d99ed9be06577e6ecc89222cf4b688c654bc89067da558e88b73b97dd1b25e6c98f2a735fa0a1409598cff7e6025bda55abb6b9f5ef65d8d307eeba8"])
    
     entity(niiri:contrast_map_id,
@@ -67,7 +67,7 @@ document
         nidm:contrastName = "listening &gt; rest" %% xsd:string,
         nidm:filename = "cope1.nii.gz" %% xsd:string,
         nidm:filename = "Contrast.nii.gz" %% xsd:string,
-        nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',        
+        nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',        
         crypto:sha512 = "400a2f07d99ed9be06577e6ecc89222cf4b688c654bc89067da558e88b73b97dd1b25e6c98f2a735fa0a1409598cff7e6025bda55abb6b9f5ef65d8d307eeba8"])
 
     entity(niiri:beta_map_id_1,
@@ -77,7 +77,7 @@ document
         prov:label = "Parameter estimate 1" %% xsd:string,
         nidm:filename = "pe1.nii.gz" %% xsd:string,
         nidm:filename = "ParameterEstimate_0001.nii.gz" %% xsd:string,
-        nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+        nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
         crypto:sha512 = "f51b6e01b0463fe7d40782137867a..." %% xsd:string])
   
 
@@ -88,7 +88,7 @@ document
         prov:label = "Parameter estimate 2" %% xsd:string,
         nidm:filename = "pe2.nii.gz" %% xsd:string,
         nidm:filename = "ParameterEstimate_0002.nii.gz" %% xsd:string,
-        nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+        nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
         crypto:sha512 = "p89b6e01b0463fe7d40782137867a..." %% xsd:string])
   
 
@@ -101,7 +101,7 @@ document
         nidm:filename = "ContrastStandardError.nii.gz" %% xsd:string,
         dct:format = "image/nifti",
         prov:label = "Contrast Standard Error Map" %% xsd:string,
-        nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+        nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
         crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
     entity(niiri:map_id_1,
       [prov:type = 'nidm:Map',
@@ -117,7 +117,7 @@ document
       nidm:filename = "GrandMean.nii.gz" %% xsd:string,
       nidm:filename = "mean_func.nii.gz" %% xsd:string,
       nidm:maskedMedian = "115" %% xsd:float,
-      nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+      nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
   
     entity(niiri:residual_mean_squares_map_id,
@@ -127,7 +127,7 @@ document
         prov:label = "Residual Mean Squares Map" %% xsd:string,
         nidm:filename = "ResidualMeanSquares.nii.gz" %% xsd:string,
         nidm:filename = "sigmasquareds.nii.gz" %% xsd:string,
-        nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+        nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
         crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])    
 
   entity(niiri:data_id,
@@ -182,7 +182,7 @@ document
         crypto:sha512 = "400a2f07d99ed9be06577e6ecc89222cf4b688c654bc89067da558e88b73b97dd1b25e6c98f2a735fa0a1409598cff7e6025bda55abb6b9f5ef65d8d307eeba8",
         nidm:filename = "mask.nii.gz" %% xsd:string,
         nidm:filename = "SearchSpace.nii.gz" %% xsd:string,
-        nidm:atCoordinateSpace = 'niiri:coordinate_space_id_2',
+        nidm:inCoordinateSpace = 'niiri:coordinate_space_id_2',
         prov:label = "Search Space Map" %% xsd:string,
         fsl:searchVolumeInVoxels = "45359" %% xsd:int,
         fsl:reselSizeInVoxels = "12.2251" %%xsd:float])
@@ -226,7 +226,7 @@ document
         nidm:filename = "thresh_zstat1.nii.gz" %% xsd:string,
         prov:label = "Excursion Set" %% xsd:string,        
         nidm:visualisation = 'niiri:excursion_set_png_id',
-        nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1'])
+        nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1'])
     entity(niiri:excursion_set_png_id,
       [prov:type = 'nidm:Image',
       prov:location = "file:///path/to/rendered_thresh_zstat1.png" %% xsd:anyURI,

--- a/nidm/nidm-results/nidm-results.owl
+++ b/nidm/nidm-results/nidm-results.owl
@@ -1441,7 +1441,7 @@ fsl:ZStatisticMap rdf:type owl:Class ;
         prov:label = \"Z-statistical Map: listening &gt; rest: zstat1\",
         nidm:contrastName = \"listening &gt; rest\" %% xsd:string,
         nidm:originalFileName = \"zstat1.nii.gz\" %% xsd:string,
-        nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+        nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
         crypto:sha = \"400a2f07d99ed9be06577e6ecc89222cf4b688c654bc89067da558e88b73b97dd1b25e6c98f2a735fa0a1409598cff7e6025bda55abb6b9f5ef65d8d307eeba8\"])
 """ ;
                   
@@ -1549,7 +1549,7 @@ NIDM Concept ID: nidm_10. """ ;
     prov:label = \"Contrast Map: listening > rest\" %% xsd:string,
     nidm:contrastName = \"listening > rest\" %% xsd:string,
     nidm:originalFileName = \"con_0001.img\" %% xsd:string,
-    nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+    nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
     crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" .
 
 
@@ -1570,7 +1570,7 @@ NIDM Concept ID: nidm_12. """ ;
     prov:location = \"file:///path/to/contrastSE.nii\" %% xsd:anyURI,
     prov:label = \"Contrast Standard Error Map\" %% xsd:string,
     nidm:originalFileName = \"contrastSE.nii\" %% xsd:string,
-    nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+    nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
     crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" .
 
 
@@ -1658,7 +1658,7 @@ nidm:CustomMaskMap rdf:type owl:Class ;
       prov:location = \"file:///path/to/custom_mask.nii\" %% xsd:anyURI,
       prov:label = \"Custom mask\" %% xsd:string,
       nidm:originalFileName = \"custom_mask.nii\" %% xsd:string,
-      nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+      nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" ;
                    
                    prov:definition "mask defined by the user to restrain the space in which model fitting is performed." ;
@@ -1731,7 +1731,7 @@ NIDM Concept ID: nidm_29. """ ;
     nidm:clusterLabelsMap = \"file:///path/to/cluster_labels.img\" %% xsd:anyURI,
     spm:maximumIntensityProjection = \"file:///path/to/MIP.png\" %% xsd:anyURI,
     nidm:originalFileName = \"thresh_spmT_0001.img\" %% xsd:string,
-    nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+    nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
     crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" ;
                   
                   prov:definition "Set of map elements surviving a thresholding procedure." .
@@ -2117,7 +2117,7 @@ NIDM Concept ID: nidm_39. """ ;
     prov:location = \"file:///path/to/mask.img\" %% xsd:anyURI,
     prov:label = \"Mask\" %% xsd:string,
     nidm:originalFileName = \"mask.img\" %% xsd:string,
-    nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+    nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
     crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" .
 
 
@@ -2191,7 +2191,7 @@ NIDM Concept ID: nidm_45. """ ;
     prov:location = \"file:///path/to/beta_0001.img\" %% xsd:anyURI,
     prov:label = \"Beta Map 1\" %% xsd:string,
     nidm:originalFileName = \"beta_0001.img\" %% xsd:string,
-    nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+    nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
     crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" ;
                           
                           prov:definition "A map whose value at each location is the estimate of a model parameter." .
@@ -2240,7 +2240,7 @@ NIDM Concept ID: nidm_52. """ ;
     prov:location = \"file:///path/to/ResMS.img\" %% xsd:anyURI,
     prov:label = \"Residual Mean Squares Map\" %% xsd:string,
     nidm:originalFileName = \"ResMS.img\" %% xsd:string,
-    nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+    nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
     crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" .
 
 
@@ -2302,7 +2302,7 @@ NIDM Concept ID: spm_95. """ ;
       prov:location = \"file:///path/to/final_mask.nii\" %% xsd:anyURI,
       prov:label = \"Search Space\" %% xsd:string,
       nidm:originalFileName = \"final_mask.nii\" %% xsd:string,
-      nidm:atCoordinateSpace = 'niiri:coordinate_space_id_2',
+      nidm:inCoordinateSpace = 'niiri:coordinate_space_id_2',
       spm:searchVolumeInVoxels = \"65593\" %% xsd:int,
       spm:searchVolumeInUnits = \"1771011\" %% xsd:float,
       spm:reselSize = \"22.9229643140043\" %% xsd:float,
@@ -2355,7 +2355,7 @@ nidm:StatisticMap rdf:type owl:Class ;
     nidm:originalFileName = \"spmT_0001.img\" %% xsd:string,
     nidm:errorDegreesOfFreedom = \"72.9999999990787\" %% xsd:float,
     nidm:effectDegreesOfFreedom = \"1\" %% xsd:float,
-    nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+    nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
     crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" ;
                   
                   prov:definition "A map whose value at each location is a statistic. " ;
@@ -2376,7 +2376,7 @@ nidm:SubVolumeMap rdf:type owl:Class ;
       prov:location = \"file:///path/to/svc_mask.nii\" %% xsd:anyURI,
       prov:label = \"Sub-volume\" %% xsd:string,
       nidm:originalFileName = \"mask.img\" %% xsd:string,
-      nidm:atCoordinateSpace = 'niiri:coordinate_space_id_2',
+      nidm:inCoordinateSpace = 'niiri:coordinate_space_id_2',
       crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" ;
                   
                   prov:definition "mask defined by the user to restrain the space in which inference is performed." ;
@@ -2488,7 +2488,7 @@ spm:ReselsPerVoxelMap rdf:type owl:Class ;
       prov:location = \"file:///path/to/RPV.img\" %% xsd:anyURI,
       prov:label = \"Resels per Voxel Map\" %% xsd:string,
       nidm:originalFileName = \"RPV.img\" %% xsd:string,
-      nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+      nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" ;
                       
                       prov:definition "A map whose value at each location is the number of resels per voxel. " ;

--- a/nidm/nidm-results/spm/example001/example001_spm_results.provn
+++ b/nidm/nidm-results/spm/example001/example001_spm_results.provn
@@ -30,7 +30,7 @@ document
       nidm:filename = "Mask.nii.gz" %% xsd:string,
       dct:format = "image/nifti",
       prov:label = "Mask" %% xsd:string,
-      nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+      nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = "932fd9f0d55e9822748f4a9b35a0a7f0fe442f3e061e2eda48c2617a2938df50ea84deca8de0725641a0105b712a80a0c8931df9bdf3bef788b1041379d00875" %% xsd:string])
     entity(niiri:map_id_1,
       [prov:type = 'nidm:Map',
@@ -50,7 +50,7 @@ document
       nidm:contrastName = "passive listening > rest" %% xsd:string,
       nidm:errorDegreesOfFreedom = "83.9999999999599" %% xsd:float,
       nidm:effectDegreesOfFreedom = "1" %% xsd:float,
-      nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+      nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = "799e9bbf8c15b35c0098bca468846bf2cd895a3366382b5ceaa953f1e9e576955341a7c86e13e6fe9359da4ff1496a609f55ce9ecff8da2e461365372f2506d6" %% xsd:string])
     entity(niiri:map_id_6,
       [prov:type = 'nidm:Map',
@@ -66,7 +66,7 @@ document
       dct:format = "image/nifti",
       prov:label = "Contrast Map: passive listening > rest" %% xsd:string,
       nidm:contrastName = "passive listening > rest" %% xsd:string,
-      nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+      nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = "f0720b732aaf19c2ec42d0469f8308beb3aa978baf65c7dce6476a0d8e5b2f38c4fa9609f045a536678440feebce9a047e3bd6d59fdb8fb64baae058690bbda2" %% xsd:string])
     entity(niiri:map_id_7,
       [prov:type = 'nidm:Map',
@@ -78,7 +78,7 @@ document
     entity(niiri:beta_map_id_1,
       [prov:type = 'nidm:ParameterEstimateMap',
       prov:label = "Beta Map 1" %% xsd:string,
-      nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1'])
+      nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1'])
       
     entity(niiri:map_id_2,
       [prov:type = 'nidm:Map',
@@ -92,7 +92,7 @@ document
     entity(niiri:beta_map_id_2,
       [prov:type = 'nidm:ParameterEstimateMap',
       prov:label = "Beta Map 2" %% xsd:string,
-      nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1'])
+      nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1'])
     entity(niiri:map_id_3,
       [prov:type = 'nidm:Map',
       nidm:filename = "beta_0002.nii" %% xsd:string,
@@ -108,7 +108,7 @@ document
       nidm:filename = "ContrastStandardError.nii.gz" %% xsd:string,
       dct:format = "image/nifti",
       prov:label = "Contrast Standard Error Map" %% xsd:string,
-      nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+      nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = "f4e3616579fe8b0812469409b1501e391bb17ca6e364f37d622b37fa9014cf1dd89befece07e73cf5bca5b3116f55ac4496751ca990db85e8377001a4be941b2" %% xsd:string])
     entity(niiri:residual_mean_squares_map_id,
       [prov:type = 'nidm:ResidualMeanSquaresMap',
@@ -116,7 +116,7 @@ document
       nidm:filename = "ResidualMeanSquares.nii.gz" %% xsd:string,
       dct:format = "image/nifti",
       prov:label = "Residual Mean Squares Map" %% xsd:string,
-      nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+      nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = "84cd0e608b8763307a1166b88761291e552838d85b58334a69a286060f6489a3b0929a940c3ccac883803455118787ea32e0bb5a6d236a5d6e9e8b6a9f918a6b" %% xsd:string])
     entity(niiri:map_id_4,
       [prov:type = 'nidm:Map',
@@ -131,7 +131,7 @@ document
       dct:format = "image/nifti",
       prov:label = "Grand Mean Map" %% xsd:string,
       nidm:maskedMedian = "132.008995056152" %% xsd:float,
-      nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+      nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = "4d3528031bce4a9c1b994b8124e6e0eddb9df90b49c84787652ed94df8c14c04ec92100a2d8ea86a8df24ba44617aca7457ddcb2f42253fc17e33296a1aea1cb" %% xsd:string])
     entity(niiri:resels_per_voxel_map_id,
       [prov:type = 'spm:ReselsPerVoxelMap',
@@ -139,7 +139,7 @@ document
       nidm:filename = "ReselsPerVoxel.nii.gz" %% xsd:string,
       dct:format = "image/nifti",
       prov:label = "Resels per Voxel Map" %% xsd:string,
-      nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+      nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = "2025dc6c33708b80708c2eba3215fb1149df236fb558a8e8f8f6cf34595fb54734fe5e436db3e192a424d99699dd7feb2f4a9020ceae8e7bcbd881b17825256a" %% xsd:string])
     entity(niiri:map_id_5,
       [prov:type = 'nidm:Map',
@@ -202,7 +202,7 @@ document
       nidm:filename = "SearchSpace.nii.gz" %% xsd:string,
       dct:format = "image/nifti",
       prov:label = "Search Space Map" %% xsd:string,
-      nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+      nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
       spm:searchVolumeInVoxels = "69306" %% xsd:int,
       spm:searchVolumeInUnits = "1871262" %% xsd:float,
       spm:reselSize = "132.907586178202" %% xsd:float,
@@ -256,7 +256,7 @@ document
       nidm:filename = "ExcursionSet.nii.gz",
       nidm:hasClusterLabelsMap = 'niiri:cluster_label_map_id',
       spm:hasMaximumIntensityProjection = 'niiri:maximum_intensity_projection_id',
-      nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+      nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = "d96b82761c299a66978893cab6034f3f8aed25d0a135636b0ffe79f4cf11becce86ba261f7aeb43717f5d0e47ad0b14cfb0402786251e3f2c507890c83b27652" %% xsd:string,
       nidm:numberOfClusters = "5" %% xsd:int,
       nidm:pValue = "2.83510681598e-09" %% xsd:float])

--- a/nidm/nidm-results/spm/example002/spm_results_2contrasts.provn
+++ b/nidm/nidm-results/spm/example002/spm_results_2contrasts.provn
@@ -26,7 +26,7 @@ document
     nidm:statisticType = 'nidm:TStatistic',
     nidm:errorDegreesOfFreedom = "72.9999999990787" %% xsd:float,
     nidm:effectDegreesOfFreedom = "1" %% xsd:float,
-    nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+    nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
     crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
   entity(niiri:map_id_1,
     [prov:type = 'nidm:Map',
@@ -49,7 +49,7 @@ document
     dct:format = "image/nifti",
     prov:label = "Contrast Map: listening > reading" %% xsd:string,
     nidm:contrastName = "listening > reading" %% xsd:string,
-    nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+    nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
     crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
   entity(niiri:map_id_2,
     [prov:type = 'nidm:Map',
@@ -63,7 +63,7 @@ document
     nidm:filename = "ContrastStandardError_0001.nii.gz" %% xsd:string,
     dct:format = "image/nifti",
     prov:label = "Contrast 1 Standard Error Map" %% xsd:string,
-    nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+    nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
     crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
 
 
@@ -77,7 +77,7 @@ document
     nidm:statisticType = 'nidm:TStatistic',
     nidm:errorDegreesOfFreedom = "72.9999999990787" %% xsd:float,
     nidm:effectDegreesOfFreedom = "1" %% xsd:float,
-    nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+    nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
     crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
   entity(niiri:map_id_3,
     [prov:type = 'nidm:Map',
@@ -93,7 +93,7 @@ document
     dct:format = "image/nifti",
     prov:label = "Contrast Map: motor" %% xsd:string,
     nidm:contrastName = "motor" %% xsd:string,
-    nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+    nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
     crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
   entity(niiri:map_id_4,
     [prov:type = 'nidm:Map',
@@ -106,7 +106,7 @@ document
     prov:location = "file:///path/to/ContrastStandardError_0002.nii.gz" %% xsd:anyURI,
     nidm:filename = "ContrastStandardError_0002.nii.gz" %% xsd:string,
     prov:label = "Contrast 2 Standard Error Map" %% xsd:string,
-    nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+    nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
     crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
 
   entity(niiri:contrast_id_2,
@@ -122,7 +122,7 @@ document
     nidm:filename = "ParameterEstimate_0001.nii.gz" %% xsd:string,
     dct:format = "image/nifti",
     prov:label = "Beta Map 1" %% xsd:string,
-    nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+    nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
     crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
   entity(niiri:map_id_5,
     [prov:type = 'nidm:Map',
@@ -135,7 +135,7 @@ document
     nidm:filename = "ParameterEstimate_0002.nii.gz" %% xsd:string,
     dct:format = "image/nifti",
     prov:label = "Beta Map 2" %% xsd:string,
-    nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+    nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
     crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
   entity(niiri:map_id_6,
     [prov:type = 'nidm:Map',
@@ -148,7 +148,7 @@ document
     nidm:filename = "ParameterEstimate_0003.nii.gz" %% xsd:string,
     dct:format = "image/nifti",
     prov:label = "Beta Map 3" %% xsd:string,
-    nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+    nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
     crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
   entity(niiri:map_id_7,
     [prov:type = 'nidm:Map',
@@ -174,7 +174,7 @@ document
     nidm:filename = "ReselsPerVoxel.nii.gz" %% xsd:string,
     dct:format = "image/nifti",
     prov:label = "Resels per Voxel Map" %% xsd:string,
-    nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+    nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
     crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
   entity(niiri:map_id_8,
       [prov:type = 'nidm:Map',
@@ -214,7 +214,7 @@ document
     nidm:filename = "ResidualMeanSquares.nii.gz" %% xsd:string,
     dct:format = "image/nifti",
     prov:label = "Residual Mean Squares Map" %% xsd:string,
-    nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+    nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
     crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
   
   entity(niiri:design_matrix_id,
@@ -234,7 +234,7 @@ document
     nidm:filename = "SearchSpace_0001.nii.gz" %% xsd:string,
     dct:format = "image/nifti",
     prov:label = "Search Space Map" %% xsd:string,
-    nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+    nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
     nidm:randomFieldStationarity = "true" %%xsd:boolean,
     spm:searchVolumeInVoxels = "65593" %% xsd:int,
     spm:searchVolumeInUnits = "1771011" %% xsd:float,
@@ -280,7 +280,7 @@ document
     nidm:filename = "SearchSpace_0003.nii.gz" %% xsd:string,
     dct:format = "image/nifti",
     prov:label = "Search Space Map" %% xsd:string,
-    nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+    nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
     spm:searchVolumeInVoxels = "65593" %% xsd:int,
     spm:searchVolumeInUnits = "1771011" %% xsd:float,
     spm:reselSize = "22.9229643140043" %% xsd:float,
@@ -320,7 +320,7 @@ document
     nidm:filename = "SearchSpace_0002.nii.gz" %% xsd:string,
     dct:format = "image/nifti",
     prov:label = "Search Space Map" %% xsd:string,
-    nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+    nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
     spm:searchVolumeInVoxels = "65593" %% xsd:int,
     spm:searchVolumeInUnits = "1771011" %% xsd:float,
     spm:reselSize = "22.9229643140043" %% xsd:float,

--- a/nidm/nidm-results/spm/example003/spm_results_conjunction.provn
+++ b/nidm/nidm-results/spm/example003/spm_results_conjunction.provn
@@ -26,7 +26,7 @@ document
     nidm:statisticType = 'nidm:TStatistic',
     nidm:errorDegreesOfFreedom = "72.9999999990787" %% xsd:float,
     nidm:effectDegreesOfFreedom = "1" %% xsd:float,
-    nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+    nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
     crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
   entity(niiri:map_id_1,
       [prov:type = 'nidm:Map',
@@ -49,7 +49,7 @@ document
     dct:format = "image/nifti",
     prov:label = "Contrast Map: listening > reading" %% xsd:string,
     nidm:contrastName = "listening > reading" %% xsd:string,
-    nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+    nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
     crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
   entity(niiri:map_id_2,
       [prov:type = 'nidm:Map',
@@ -62,7 +62,7 @@ document
     prov:location = "file:///path/to/ContrastStandardError_0001.nii" %% xsd:anyURI,
     nidm:filename = "ContrastStandardError_0001.nii.gz" %% xsd:string,
     prov:label = "Contrast 1 Standard Error Map" %% xsd:string,
-    nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+    nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
     crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
 
 
@@ -77,7 +77,7 @@ document
     nidm:statisticType = 'nidm:TStatistic',
     nidm:errorDegreesOfFreedom = "72.9999999990787" %% xsd:float,
     nidm:effectDegreesOfFreedom = "1" %% xsd:float,
-    nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+    nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
     crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
   entity(niiri:map_id_3,
       [prov:type = 'nidm:Map',
@@ -94,7 +94,7 @@ document
     dct:format = "image/nifti",
     prov:label = "Contrast Map: motor" %% xsd:string,
     nidm:contrastName = "motor" %% xsd:string,
-    nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+    nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
     crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
   entity(niiri:map_id_4,
       [prov:type = 'nidm:Map',
@@ -108,7 +108,7 @@ document
     nidm:filename = "ContrastStandardError_0002.nii.gz" %% xsd:string,
     dct:format = "image/nifti",
     prov:label = "Contrast 2 Standard Error Map" %% xsd:string,
-    nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+    nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
     crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string]) 
 
 
@@ -125,7 +125,7 @@ document
     nidm:filename = "ParameterEstimate_0001.nii.gz" %% xsd:string,
     dct:format = "image/nifti",
     prov:label = "Beta Map 1" %% xsd:string,
-    nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+    nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
     crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
   entity(niiri:map_id_5,
       [prov:type = 'nidm:Map',
@@ -139,7 +139,7 @@ document
     nidm:filename = "ParameterEstimate_0002.nii.gz" %% xsd:string,
     dct:format = "image/nifti",
     prov:label = "Beta Map 2" %% xsd:string,
-    nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+    nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
     crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
   entity(niiri:map_id_6,
       [prov:type = 'nidm:Map',
@@ -152,7 +152,7 @@ document
     nidm:filename = "ParameterEstimate_0003.nii.gz" %% xsd:string,
     dct:format = "image/nifti",
     prov:label = "Beta Map 3" %% xsd:string,
-    nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+    nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
     crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
   entity(niiri:map_id_7,
       [prov:type = 'nidm:Map',
@@ -178,7 +178,7 @@ document
     nidm:filename = "ReselsPerVoxel.nii.gz" %% xsd:string,
     dct:format = "image/nifti",
     prov:label = "Resels per Voxel Map" %% xsd:string,
-    nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+    nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
     crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
   entity(niiri:map_id_8,
       [prov:type = 'nidm:Map',
@@ -218,7 +218,7 @@ document
     nidm:filename = "ResidualMeanSquares.nii.gz" %% xsd:string,
     dct:format = "image/nifti",
     prov:label = "Residual Mean Squares Map" %% xsd:string,
-    nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+    nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
     crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
   
   entity(niiri:design_matrix_id,
@@ -246,7 +246,7 @@ document
     nidm:filename = "SearchSpace.nii.gz" %% xsd:string,
     dct:format = "image/nifti",
     prov:label = "Search Space Map" %% xsd:string,
-    nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+    nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
     nidm:randomFieldStationarity = "true" %%xsd:boolean,
     spm:searchVolumeInVoxels = "65593" %% xsd:int,
     spm:searchVolumeInUnits = "1771011" %% xsd:float,

--- a/nidm/nidm-results/spm/spm_results.provn
+++ b/nidm/nidm-results/spm/spm_results.provn
@@ -41,7 +41,7 @@ document
       nidm:contrastName = "listening > rest" %% xsd:string,
       nidm:errorDegreesOfFreedom = "72.9999999990787" %% xsd:float,
       nidm:effectDegreesOfFreedom = "1" %% xsd:float,
-      nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+      nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
     entity(niiri:map_id_1,
       [prov:type = 'nidm:Map',
@@ -63,7 +63,7 @@ document
       nidm:filename = "Contrast.nii.gz" %% xsd:string,
       prov:label = "Contrast Map: listening > rest" %% xsd:string,
       nidm:contrastName = "listening > rest" %% xsd:string,
-      nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+      nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
     entity(niiri:map_id_2,
       [prov:type = 'nidm:Map',
@@ -85,7 +85,7 @@ document
       nidm:filename = "Mask.nii.gz" %% xsd:string,
       dct:format = "image/nifti",
       prov:label = "Mask" %% xsd:string,
-      nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+      nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
     entity(niiri:map_id_3,
       [prov:type = 'nidm:Map',
@@ -108,7 +108,7 @@ document
       prov:label = "Beta Map 1" %% xsd:string,
       nidm:filename = "ParameterEstimate_0001.nii.gz" %% xsd:string,
       dct:format = "image/nifti",
-      nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+      nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
     entity(niiri:map_id_4,
       [prov:type = 'nidm:Map',
@@ -131,7 +131,7 @@ document
       nidm:filename = "ParameterEstimate_0002.nii.gz" %% xsd:string,
       dct:format = "image/nifti",
       prov:label = "Beta Map 2" %% xsd:string,
-      nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+      nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
     entity(niiri:map_id_5,
       [prov:type = 'nidm:Map',
@@ -155,7 +155,7 @@ document
       nidm:filename = "ContrastStandardError.nii.gz" %% xsd:string,
       dct:format = "image/nifti",
       prov:label = "Contrast Standard Error Map" %% xsd:string,
-      nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+      nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
     entity(niiri:residual_mean_squares_map_id,
       [prov:type = 'nidm:ResidualMeanSquaresMap',
@@ -163,7 +163,7 @@ document
       nidm:filename = "ResidualMeanSquares.nii.gz" %% xsd:string,
       dct:format = "image/nifti",
       prov:label = "Residual Mean Squares Map" %% xsd:string,
-      nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+      nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
     entity(niiri:grand_mean_map_id,
       [prov:type = 'nidm:GrandMeanMap',
@@ -172,7 +172,7 @@ document
       dct:format = "image/nifti",
       prov:label = "Grand Mean Map" %% xsd:string,
       nidm:maskedMedian = "115" %% xsd:float,
-      nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+      nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
     entity(niiri:resels_per_voxel_map_id,
       [prov:type = 'spm:ReselsPerVoxelMap',
@@ -180,7 +180,7 @@ document
       nidm:filename = "ReselsPerVoxel.nii.gz" %% xsd:string,
       dct:format = "image/nifti",
       prov:label = "Resels per Voxel Map" %% xsd:string,
-      nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+      nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
     entity(niiri:map_id_6,
       [prov:type = 'nidm:Map',
@@ -214,7 +214,7 @@ document
       nidm:filename = "CustomMask.nii.gz" %% xsd:string,
       dct:format = "image/nifti",
       prov:label = "Custom mask" %% xsd:string,
-      nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+      nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
     entity(niiri:map_id_7,
       [prov:type = 'nidm:Map',
@@ -262,7 +262,7 @@ document
       nidm:filename = "SubVolume.nii.gz" %% xsd:string,
       dct:format = "image/nifti",
       prov:label = "Sub-volume Map" %% xsd:string,
-      nidm:atCoordinateSpace = 'niiri:coordinate_space_id_2',
+      nidm:inCoordinateSpace = 'niiri:coordinate_space_id_2',
       crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
     entity(niiri:search_space_id,
       [prov:type = 'nidm:SearchSpaceMap',
@@ -270,7 +270,7 @@ document
       nidm:filename = "SearchSpace.nii.gz" %% xsd:string,
       dct:format = "image/nifti",
       prov:label = "Search Space Map" %% xsd:string,
-      nidm:atCoordinateSpace = 'niiri:coordinate_space_id_2',
+      nidm:inCoordinateSpace = 'niiri:coordinate_space_id_2',
       spm:expectedNumberOfVoxelsPerCluster = "0.553331387916112" %% xsd:float,
       spm:expectedNumberOfClusters = "0.0889172687960151" %% xsd:float,
       spm:heightCriticalThresholdFWE05 = "5.23529984739211" %% xsd:float,
@@ -325,7 +325,7 @@ document
       prov:label = "Excursion Set" %% xsd:string,
       nidm:hasClusterLabelsMap = 'niiri:cluster_label_map_id',
       spm:hasMaximumIntensityProjection = 'niiri:maximum_intensity_projection_id',
-      nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+      nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string,
       nidm:numberOfClusters = "8" %% xsd:int,
       nidm:pValue = "8.95949980872501e-14" %% xsd:float])

--- a/nidm/nidm-results/test/spmexport/example001/spm_nidm.provn
+++ b/nidm/nidm-results/test/spmexport/example001/spm_nidm.provn
@@ -49,7 +49,7 @@ document
         prov:location = "file://./Mask.nii.gz" %% xsd:anyURI,
         prov:label = "Mask" %% xsd:string,
         nidm:filename = "mask" %% xsd:string,
-        nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+        nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
         crypto:sha512 = "c35ef07d92b3d46115276e2b1e0fc02765c406f2272a67cc5b47030920339e5b3e1d763a281d1d85916581570de872e8e9466653c18f9e9f60d6bb4153d47b1b" %% xsd:string])
     wasGeneratedBy(niiri:mask_id_1, niiri:model_pe_id, -)
     entity(niiri:grand_mean_map_id,
@@ -57,25 +57,25 @@ document
         prov:location = "file://./GrandMean.nii.gz" %% xsd:anyURI,
         prov:label = "Grand Mean Map" %% xsd:string,
         nidm:maskedMedian = "123.283493041992" %% xsd:float,
-        nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+        nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
         crypto:sha512 = "7200b6b4afdfb1fdf99cbe142af146d9179196c3bd4fc506cf4931b0ea8b0a5216bccca85389d06ff1429cef569b42c533ae40dce29dbb44f295265cbfd91512" %% xsd:string])
     wasGeneratedBy(niiri:grand_mean_map_id, niiri:model_pe_id, -)
     entity(niiri:beta_map_id_1,
         [prov:type = 'nidm:ParameterEstimateMap',
         prov:label = "Beta Map 1" %% xsd:string,
-        nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1'])
+        nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1'])
     wasGeneratedBy(niiri:beta_map_id_1, niiri:model_pe_id, -)
     entity(niiri:beta_map_id_2,
         [prov:type = 'nidm:ParameterEstimateMap',
         prov:label = "Beta Map 2" %% xsd:string,
-        nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1'])
+        nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1'])
     wasGeneratedBy(niiri:beta_map_id_2, niiri:model_pe_id, -)
     entity(niiri:residual_mean_squares_map_id,
         [prov:type = 'nidm:ResidualMeanSquaresMap',
         prov:location = "file://./ResidualMeanSquares.nii.gz" %% xsd:anyURI,
         prov:label = "Residual Mean Squares Map" %% xsd:string,
         nidm:filename = "ResMS" %% xsd:string,
-        nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+        nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
         crypto:sha512 = "3bbc9146b44651ea6316119aadc317f85bd1444ad2aaca7b1ca0cca40af8f76b2caae92f48acc39f4f0b7c26271ed68ec7a53383b8e7e14efd7726521f48cdae" %% xsd:string])
     wasGeneratedBy(niiri:residual_mean_squares_map_id, niiri:model_pe_id, -)
     entity(niiri:resels_per_voxel_map_id,
@@ -83,7 +83,7 @@ document
         prov:location = "file://./ReselsPerVoxel.nii.gz" %% xsd:anyURI,
         prov:label = "Resels per Voxel Map" %% xsd:string,
         nidm:filename = "RPV" %% xsd:string,
-        nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+        nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
         crypto:sha512 = "c81a8ca3f059be8cd0b66f5aca8b99c324b772659dc994ca5f64ed05887c048a54895ed6a0659b8041d6a4581422ba8e4a08cb7d3151c992b639c4a3833a718a" %% xsd:string])
     wasGeneratedBy(niiri:resels_per_voxel_map_id, niiri:model_pe_id, -)
     entity(niiri:contrast_id,
@@ -111,7 +111,7 @@ document
         nidm:filename = "spmT_0001" %% xsd:string,
         nidm:errorDegreesOfFreedom = "83.9999999999599" %% xsd:float,
         nidm:effectDegreesOfFreedom = "1" %% xsd:float,
-        nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+        nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
         crypto:sha512 = "8f50ac5ac9fcd08c36f8a6dec28a454069398641fee4b192e643151e385a6e74cbf3883392f2ef09451bdda12a63f25ddf83579c163109ef9afb20b092a06a1d" %% xsd:string])
     wasGeneratedBy(niiri:statistic_map_id, niiri:contrast_estimation_id, -)
     entity(niiri:contrast_map_id,
@@ -120,14 +120,14 @@ document
         prov:label = "Contrast Map: passive listening > rest" %% xsd:string,
         nidm:contrastName = "passive listening > rest" %% xsd:string,
         nidm:filename = "con_0001" %% xsd:string,
-        nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+        nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
         crypto:sha512 = "9345242c26f80f10b3b37f79fd4dfc0a95a8358d1c240aa7888fc10dd5ec000bc15c3dd05e6cef4db7669803acc31fe4ebb78f87e99999f161dac865b743148c" %% xsd:string])
     wasGeneratedBy(niiri:contrast_map_id, niiri:contrast_estimation_id, -)
     entity(niiri:contrast_standard_error_map_id,
         [prov:type = 'nidm:ContrastStandardErrorMap',
         prov:location = "file://./ContrastStandardError.nii.gz" %% xsd:anyURI,
         prov:label = "Contrast Standard Error Map" %% xsd:string,
-        nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+        nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
         crypto:sha512 = "e2637e3d48c5aa023471dddb5f63866617f4953a079ff8e60bb5e20fa006f48a5f4f2899cf25c1840a5e31593d73af8aef4c16ca30fe4da9eca8756b9f5ad6b7" %% xsd:string])
     wasGeneratedBy(niiri:contrast_standard_error_map_id, niiri:contrast_estimation_id, -)
     entity(niiri:height_threshold_id,
@@ -159,7 +159,7 @@ document
         prov:location = "file://./Mask.nii.gz" %% xsd:anyURI,
         prov:label = "Search Space Map" %% xsd:string,
         nidm:filename = "mask" %% xsd:string,
-        nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+        nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
         spm:searchVolumeInVoxels = "69306" %% xsd:int,
         spm:searchVolumeInProductOfUnits = "1871262" %% xsd:float,
         spm:reselSize = "132.907586178202" %% xsd:float,
@@ -188,7 +188,7 @@ document
         nidm:pValue = "2.83510681597932e-09" %% xsd:float,
         nidm:clusterLabelsMap = 'niiri:cluster_label_map_id',
         spm:hasMaximumIntensityProjection = 'niiri:maximum_intensity_projection_id',
-        nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+        nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
         crypto:sha512 = "d96b82761c299a66978893cab6034f3f8aed25d0a135636b0ffe79f4cf11becce86ba261f7aeb43717f5d0e47ad0b14cfb0402786251e3f2c507890c83b27652" %% xsd:string])
     entity(niiri:cluster_label_map_id,
       [prov:type = 'nidm:ClusterLabelsMap',


### PR DESCRIPTION
**Term**: `atCoordinateSpace`
**Current definition**: "Attribute between a SpatialImage entity and a CoordinateSpace entity that is used to associate spatial metadata with a physical file."
**Original comment**: [link](https://docs.google.com/spreadsheets/d/16pC2cDsdxlzv2CzlNMtStqt5-xHwDEsU6MjZVxWhrE4/edit?disco=AAAAAJYs7Y4)

---

@nicholsn `19:07 18 Apr`
How is this? Note: we will need to define `SpatialImage` (or a similar term) that is the parent of all Maps, etc.

@JessicaTurner `20:14 21 Apr`
Is `atCoordinateSpace` the only possible association between spatial data and a physical file?

@cmaumet `11:01 25 Apr`
I would say yes. Currently, `atCoordinateSpace` is the only attribute found in a "Map" entity which is associated with a `CoordinateSpace` value.

@cmaumet `11:20 25 Apr`
Could our "Map" term be used in place of `SpatialImage`?

@nicholsn `17:37 25 Apr`
You could, but is Map the only type of Entity with CoordinateSpace metadata? I would argue that most all image types (DICOM, NIfTI, etc.) have a CoordinateSpace and the definition should reflect that. 

The suggestion here is that the attribute `atCoordinateSpace` is not specific to Map, but to the "parent" of Map, which I'm calling `SpatialImage`, but we could call it something else. 

Note that children can inherit the attributes (properties) of a parent class, so atCoordinateSpace is valid for SpatialImage, Map, DICOM, etc.

@satra `20:36 25 Apr`
also perhaps: `inCoordinateSpace`

@nicholsn `22:07 25 Apr`
I like `inCoordinateSpace`, might as well make a clean break from `atLocation`

@cmaumet `12:18 1 May`
For now Map is the only type of Entity with `CoordinateSpace`.

I found out that the term `SpatialImage` is used in nibabel: http://nipy.org/nibabel/generated/nibabel.spatialimages.SpatialImage.html#nibabel.spatialimages.SpatialImage
and is very similar in meaning to our Map, so maybe re-naming Map in SpatialImage would make sense.

The only thing is that we have to be careful in keeping the possibility to model surfacic data (and not being limited to image data...).
Show less

@satra `12:46 1 May`
i would stay away from `SpatialImage`, unless we wanted to make it specific and create a hierarchy. in SPM, this "Map" could be a time-series, a time-frequency representation, a volume or surface. and as such `CoordinateSpace` would have many different `units`, `dimensions` and `coordinatesystems`
