### PR TITLE
Definition of "userSpecifiedThresholdType"

### DIFF
--- a/nidm/nidm-results/nidm-results.owl
+++ b/nidm/nidm-results/nidm-results.owl
@@ -918,7 +918,7 @@ nidm:userSpecifiedThresholdType rdf:type owl:DatatypeProperty ;
                                 iao:IAO_0000116 """Range: {'nidm:pValueFWER' not found'nidm:pValueFDR' not found'nidm:pValueUncorrected';'nidm:statistic'} not found. BIRNLex or 
 NIDM Concept ID: nidm_65. """ ;
                                 
-                                prov:definition "Type of method used to define height threshold (e.g. statistic value, uncorrected P-value or corrected P-value)." ;
+                                prov:definition "Type of method used to define a threshold (e.g. statistic value, uncorrected P-value or corrected P-value)." ;
                                 
                                 iao:IAO_0000112 "nidm:pValueFWER" ;
                                 


### PR DESCRIPTION
**Term**: `userSpecifiedThresholdType`
**Current definition**: "Type (p-value either corrected or uncorrected or statistic) of the user-defined height threshold."
**Original comment**: [link](https://docs.google.com/spreadsheets/d/16pC2cDsdxlzv2CzlNMtStqt5-xHwDEsU6MjZVxWhrE4/edit?disco=AAAAAGsYji8)

---

@khelm `20:38 9 Apr`
Couldn't you just say "Type of statistic used to define a threshold"

@nicholsn `21:10 18 Apr`
+1

@JessicaTurner `21:42 21 Apr`
I really don't think we lose anything by giving examples. I know it's not canonical but we are trying to make it easy for users, not difficult.
