### PR TITLE
Defintion of "ConjunctionInference"

### DIFF
--- a/nidm/nidm-results/nidm-results.owl
+++ b/nidm/nidm-results/nidm-results.owl
@@ -1507,7 +1507,7 @@ nidm:ConjunctionInference rdf:type owl:Class ;
                           rdfs:subClassOf nidm:Inference ,
                                           prov:Activity ;
                           
-                          prov:definition "Inference testing for the joint significance of all effects." ;
+                          prov:definition "Statistically testing for the joint significance of multiple effects, with emphasis on rejecting all (instead of one or more) of the respective null hypotheses." ;
                           
                           iao:IAO_0000116 """Range: - not found. BIRNLex or 
 NIDM Concept ID: nidm_8. """ .
@@ -1560,18 +1560,18 @@ nidm:ContrastStandardErrorMap rdf:type owl:Class ;
                               
                               rdfs:subClassOf nidm:Map ;
                               
-                              prov:definition "A map whose value at each location is the standard error of a given contrast." ;
-                              
-                              iao:IAO_0000116 """BIRNLex or 
-NIDM Concept ID: nidm_12. """ ;
-                              
                               iao:IAO_0000112 """entity(niiri:contrast_standard_error_map_id,
     [prov:type = 'nidm:ContrastStandardErrorMap',
     prov:location = \"file:///path/to/contrastSE.nii\" %% xsd:anyURI,
     prov:label = \"Contrast Standard Error Map\" %% xsd:string,
     nidm:originalFileName = \"contrastSE.nii\" %% xsd:string,
     nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
-    crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" .
+    crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" ;
+                              
+                              prov:definition "A map whose value at each location is the standard error of a given contrast." ;
+                              
+                              iao:IAO_0000116 """BIRNLex or 
+NIDM Concept ID: nidm_12. """ .
 
 
 
@@ -1719,9 +1719,6 @@ nidm:ExcursionSet rdf:type owl:Class ;
                   
                   rdfs:subClassOf nidm:Map ;
                   
-                  iao:IAO_0000116 """BIRNLex or 
-NIDM Concept ID: nidm_29. """ ;
-                  
                   iao:IAO_0000112 """entity(niiri:excursion_set_id,
     [prov:type = 'nidm:ExcursionSet',
     prov:location = \"file:///path/to/thresh_spmT_0001.img\" %% xsd:anyURI,
@@ -1731,6 +1728,9 @@ NIDM Concept ID: nidm_29. """ ;
     nidm:originalFileName = \"thresh_spmT_0001.img\" %% xsd:string,
     nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
     crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" ;
+                  
+                  iao:IAO_0000116 """BIRNLex or 
+NIDM Concept ID: nidm_29. """ ;
                   
                   prov:definition "Set of map elements surviving a thresholding procedure." .
 
@@ -2293,8 +2293,6 @@ NIDM Concept ID: nidm_100. """ ,
                                     """BIRNLex or 
 NIDM Concept ID: spm_95. """ ;
                     
-                    rdfs:seeAlso "http://purl.obolibrary.org/obo/OBI_0000235" ;
-                    
                     iao:IAO_0000112 """entity(niiri:search_space_id,
       [prov:type = 'nidm:SearchSpaceMap',
       prov:location = \"file:///path/to/final_mask.nii\" %% xsd:anyURI,
@@ -2310,6 +2308,8 @@ NIDM Concept ID: spm_95. """ ;
       spm:noiseFWHMInUnits = \"[8.87643567497404, 8.89885340008753, 7.83541276878791]\" %% xsd:string,
       nidm:randomFieldStationarity = 'spm:nonStationaryRandomField',
       crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" ;
+                    
+                    rdfs:seeAlso "http://purl.obolibrary.org/obo/OBI_0000235" ;
                     
                     prov:definition "mask in which the inference was performed." .
 
@@ -2369,18 +2369,18 @@ nidm:SubVolumeMap rdf:type owl:Class ;
                   
                   rdfs:subClassOf nidm:Map ;
                   
+                  prov:definition "mask defined by the user to restrain the space in which inference is performed." ;
+                  
+                  iao:IAO_0000116 """BIRNLex or 
+NIDM Concept ID: nidm_101. """ ;
+                  
                   iao:IAO_0000112 """entity(niiri:sub_volume_id,
       [prov:type = 'nidm:SubVolumeMap',
       prov:location = \"file:///path/to/svc_mask.nii\" %% xsd:anyURI,
       prov:label = \"Sub-volume\" %% xsd:string,
       nidm:originalFileName = \"mask.img\" %% xsd:string,
       nidm:inCoordinateSpace = 'niiri:coordinate_space_id_2',
-      crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" ;
-                  
-                  prov:definition "mask defined by the user to restrain the space in which inference is performed." ;
-                  
-                  iao:IAO_0000116 """BIRNLex or 
-NIDM Concept ID: nidm_101. """ .
+      crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" .
 
 
 
@@ -2481,6 +2481,8 @@ spm:ReselsPerVoxelMap rdf:type owl:Class ;
                       
                       rdfs:subClassOf nidm:Map ;
                       
+                      prov:definition "A map whose value at each location is the number of resels per voxel. " ;
+                      
                       iao:IAO_0000112 """entity(niiri:resels_per_voxel_map_id,
       [prov:type = 'spm:ReselsPerVoxelMap',
       prov:location = \"file:///path/to/RPV.img\" %% xsd:anyURI,
@@ -2488,8 +2490,6 @@ spm:ReselsPerVoxelMap rdf:type owl:Class ;
       nidm:originalFileName = \"RPV.img\" %% xsd:string,
       nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" ;
-                      
-                      prov:definition "A map whose value at each location is the number of resels per voxel. " ;
                       
                       iao:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: spm_83. """ .


### PR DESCRIPTION
**Term**: `ConjunctionInference`
**Definition**: "Inference testing for the joint significance of all effects".
**Original comment**: [link](https://docs.google.com/spreadsheets/d/16pC2cDsdxlzv2CzlNMtStqt5-xHwDEsU6MjZVxWhrE4/edit?disco=AAAAAGsYjhg)
**Current link**:  [nidm-results.owl/ConjunctionInference](https://github.com/incf-nidash/nidm/blob/master/nidm/nidm-results/nidm-results.owl#L1268-L1278)

---

@khelm `19:15 9 Apr`
Is this a flag that lets you know that conjunction testing has been done?

@JessicaTurner `20:16 21 Apr`
I'm with Karl--what Is this? Is it a map, a statistic, a bag of things?

@cmaumet `10:57 25 Apr`
I have just corrected the "prov:type" to "Activity". The "ConjunctionInference" activity can be used in place of the standard "Inference" activity when joint significance is required. Does it make more sense?
