### PR TITLE
A few fixes in FSL ground truth

### DIFF
--- a/nidm/nidm-results/fsl/example001/fsl_nidm.provn
+++ b/nidm/nidm-results/fsl/example001/fsl_nidm.provn
@@ -218,6 +218,7 @@ document
     entity(niiri:d4de4b20b2d408cd8d825ac0edb6030a,
       [prov:type = 'nidm:Map',
       nidm:filename = "varcope1.nii.gz" %% xsd:string,
+      nidm:inCoordinateSpace = 'niiri:coordinate_space_id_9',
       crypto:sha512 = "7d183bbacc0b99cd1db84174d32445457f532bca9f774fdcc53bc1d0faa5e7d250a1abf03864bd90b30f96f5a7516e0056104a729a565019b0f254a8a7bced1e" %% xsd:string])
     wasDerivedFrom(niiri:contrast_standard_error_map_id_1, niiri:d4de4b20b2d408cd8d825ac0edb6030a)
   

--- a/nidm/nidm-results/fsl/fsl_results.provn
+++ b/nidm/nidm-results/fsl/fsl_results.provn
@@ -105,6 +105,7 @@ document
         crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
     entity(niiri:map_id_1,
       [prov:type = 'nidm:Map',
+      nidm:inCoordinateSpace = 'niiri:coordinate_space_id_9',
       nidm:filename = "varcope1.nii.gz" %% xsd:string,
       crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
     wasDerivedFrom(niiri:contrast_standard_error_map_id, niiri:map_id_1)


### PR DESCRIPTION
This pull request implements small fixes in FSL ground truth, identified when testing the FSL export tool at [incf-nidash/nidm-results_fsl](https://github.com/cmaumet/nidm-results_fsl) (this is similar to what was done for SPM in #160, #161 and #175).
