### PR TITLE
Add analysis mask in FSL

### DIFF
--- a/nidm/nidm-results/fsl/example001/fsl_nidm.provn
+++ b/nidm/nidm-results/fsl/example001/fsl_nidm.provn
@@ -232,8 +232,8 @@ document
       nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = "cc1a96a6111e5107eb08487e38e6d7f8164b9d1d3f1fc10948bdbcfaea642fe9bfae278c7fc372b65cac7232ea58fd8fb5914014e7b9a5d6200592b12b2a728b" %% xsd:string])
     wasGeneratedBy(niiri:mask_id_1, niiri:model_parameters_estimation_id,-)
-    used(niiri:contrast_estimation_id, niiri:mask_id_1)
-    used(niiri:inference_id, niiri:mask_id_1)
+    used(niiri:contrast_estimation_id, niiri:mask_id_1,-)
+    used(niiri:inference_id, niiri:mask_id_1,-)
   
     entity(niiri:residual_mean_squares_map_id,
         [prov:type = 'nidm:ResidualMeanSquaresMap',

--- a/nidm/nidm-results/fsl/fsl_results.provn
+++ b/nidm/nidm-results/fsl/fsl_results.provn
@@ -119,8 +119,8 @@ document
       nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
     wasGeneratedBy(niiri:mask_id_1, niiri:model_pe_id,-)
-    used(niiri:contrast_estimation_id, niiri:mask_id_1)
-    used(niiri:inference_id, niiri:mask_id_1)
+    used(niiri:contrast_estimation_id, niiri:mask_id_1,-)
+    used(niiri:inference_id, niiri:mask_id_1,-)
 
     entity(niiri:grand_mean_map_id,
       [prov:type = 'nidm:GrandMeanMap',


### PR DESCRIPTION
This pull request is a fix to the FSL data model to include the analysis mask (output of `parameter model estimation` and input of `contrast estimation` and `inference`). 

This is similar to what is in SPM model and is needed in order to differentiate with the mask in the `SearchSpace` entity (final mask including filtering/contrast masking, cf #157).
