### PR TITLE
Rename inference mask in "InferenceMaskMap"

### DIFF
--- a/nidm/nidm-results/spm/spm_results.provn
+++ b/nidm/nidm-results/spm/spm_results.provn
@@ -270,11 +270,11 @@ document
     wasGeneratedBy(niiri:contrast_standard_error_map_id, niiri:contrast_estimation_id,-)
     wasGeneratedBy(niiri:statistic_map_id, niiri:contrast_estimation_id,-)
     entity(niiri:sub_volume_id,
-      [prov:type = 'nidm:SubVolumeMap',
-      prov:location = "file:///path/to/SubVolume.nii.gz" %% xsd:anyURI,
-      nidm:filename = "SubVolume.nii.gz" %% xsd:string,
+      [prov:type = 'nidm:InferenceMaskMap',
+      prov:location = "file:///path/to/InferenceMask.nii.gz" %% xsd:anyURI,
+      nidm:filename = "InferenceMask.nii.gz" %% xsd:string,
       dct:format = "image/nifti",
-      prov:label = "Sub-volume Map" %% xsd:string,
+      prov:label = "Inference Mask Map" %% xsd:string,
       nidm:inCoordinateSpace = 'niiri:coordinate_space_id_2',
       crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])
     entity(niiri:search_space_id,

--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -2172,6 +2172,27 @@ nidm:Inference rdf:type owl:Class ;
 
 
 
+###  http://www.incf.org/ns/nidash/nidm#InferenceMaskMap
+
+nidm:InferenceMaskMap rdf:type owl:Class ;
+                      
+                      rdfs:subClassOf nidm:Map ;
+                      
+                      prov:definition "mask defined by the user to restrain the space in which inference is performed." ;
+                      
+                      iao:IAO_0000112 """entity(niiri:sub_volume_id,
+      [prov:type = 'nidm:SubVolumeMap',
+      prov:location = \"file:///path/to/svc_mask.nii\" %% xsd:anyURI,
+      prov:label = \"Sub-volume\" %% xsd:string,
+      nidm:originalFileName = \"mask.img\" %% xsd:string,
+      nidm:inCoordinateSpace = 'niiri:coordinate_space_id_2',
+      crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" ;
+                      
+                      iao:IAO_0000116 """BIRNLex or 
+NIDM Concept ID: nidm_101. """ .
+
+
+
 ###  http://www.incf.org/ns/nidash/nidm#Ixi549Space
 
 nidm:Ixi549Space rdf:type owl:Class ;
@@ -2666,26 +2687,6 @@ nidm:StatisticMap rdf:type owl:Class ;
     crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" ;
                   
                   prov:definition "A map whose value at each location is a statistic. " .
-
-
-
-###  http://www.incf.org/ns/nidash/nidm#SubVolumeMap
-
-nidm:SubVolumeMap rdf:type owl:Class ;
-                  
-                  rdfs:subClassOf nidm:Map ;
-                  
-                  prov:definition "mask defined by the user to restrain the space in which inference is performed." ;
-                  
-                  iao:IAO_0000112 """entity(niiri:sub_volume_id,
-      [prov:type = 'nidm:SubVolumeMap',
-      prov:location = \"file:///path/to/svc_mask.nii\" %% xsd:anyURI,
-      prov:label = \"Sub-volume\" %% xsd:string,
-      nidm:originalFileName = \"mask.img\" %% xsd:string,
-      nidm:inCoordinateSpace = 'niiri:coordinate_space_id_2',
-      crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" ;
-                  
-                  nidm:curationStatus "nidm:MetadataIncomplete" .
 
 
 


### PR DESCRIPTION
Following discussions in NIDASH call on September 22nd ([Minutes](https://docs.google.com/document/d/1VmHvlXFYuFwaZwdou0zhSdtoj1vQjxAGICyeoAKvl8Q/edit?usp=sharing)) and at #157, this pull request rename the Mask entity used for small volume correction in `InferenceMaskMap`.
