### PR TITLE
Defintion of "noise dependence" terms -> "error dependence"

### DIFF
--- a/nidm/nidm-results/fsl/example001/fsl_nidm.provn
+++ b/nidm/nidm-results/fsl/example001/fsl_nidm.provn
@@ -281,7 +281,7 @@ document
       nidm:hasNoiseDistribution = 'nidm:GaussianDistribution',
       nidm:noiseVarianceHomogeneous = "true" %%xsd:boolean,
       nidm:varianceSpatialModel = 'nidm:SpatiallyLocal',
-      nidm:hasNoiseDependence = 'nidm:IndependentNoise',
+      nidm:hasErrorDependence = 'nidm:IndependentError',
       nidm:dependenceSpatialModel = 'nidm:SpatiallyLocal'])
     used(niiri:model_parameters_estimation_id, niiri:noise_model_id,-)
 

--- a/nidm/nidm-results/fsl/fsl_results.provn
+++ b/nidm/nidm-results/fsl/fsl_results.provn
@@ -169,7 +169,7 @@ document
       nidm:hasNoiseDistribution = 'nidm:GaussianDistribution',
       nidm:noiseVarianceHomogeneous = "true" %%xsd:boolean,
       nidm:varianceSpatialModel = 'nidm:SpatiallyLocal',
-      nidm:hasNoiseDependence = 'nidm:IndependentNoise',
+      nidm:hasErrorDependence = 'nidm:IndependentError',
       nidm:dependenceSpatialModel = 'nidm:SpatiallyLocal'])
     used(niiri:model_pe_id, niiri:noise_model_id,-)
 

--- a/nidm/nidm-results/spm/example001/example001_spm_results.provn
+++ b/nidm/nidm-results/spm/example001/example001_spm_results.provn
@@ -176,7 +176,7 @@ document
       nidm:hasNoiseDistribution = 'nidm:GaussianDistribution',
       nidm:noiseVarianceHomogeneous = "true" %%xsd:boolean,
       nidm:varianceSpatialModel = 'nidm:SpatiallyLocal',
-      nidm:hasNoiseDependence = 'nidm:IndependentNoise',
+      nidm:hasErrorDependence = 'nidm:IndependentError',
       nidm:dependenceSpatialModel = 'nidm:SpatiallyLocal'])
     used(niiri:model_pe_id, niiri:noise_model_id,-)
 

--- a/nidm/nidm-results/spm/example002/spm_results_2contrasts.provn
+++ b/nidm/nidm-results/spm/example002/spm_results_2contrasts.provn
@@ -161,7 +161,7 @@ document
       nidm:hasNoiseDistribution = 'nidm:GaussianDistribution',
       nidm:noiseVarianceHomogeneous = "true" %%xsd:boolean,
       nidm:varianceSpatialModel = 'nidm:SpatiallyLocal',
-      nidm:hasNoiseDependence = 'nidm:IndependentNoise',
+      nidm:hasErrorDependence = 'nidm:IndependentError',
       nidm:dependenceSpatialModel = 'nidm:SpatiallyLocal'])
   used(niiri:model_fitting_id, niiri:noise_model_id,-)
   

--- a/nidm/nidm-results/spm/example003/spm_results_conjunction.provn
+++ b/nidm/nidm-results/spm/example003/spm_results_conjunction.provn
@@ -165,7 +165,7 @@ document
       nidm:hasNoiseDistribution = 'nidm:GaussianDistribution',
       nidm:noiseVarianceHomogeneous = "true" %%xsd:boolean,
       nidm:varianceSpatialModel = 'nidm:SpatiallyLocal',
-      nidm:hasNoiseDependence = 'nidm:IndependentNoise',
+      nidm:hasErrorDependence = 'nidm:IndependentError',
       nidm:dependenceSpatialModel = 'nidm:SpatiallyLocal'])
     used(niiri:model_fitting_id, niiri:noise_model_id,-)
   

--- a/nidm/nidm-results/spm/spm_results.provn
+++ b/nidm/nidm-results/spm/spm_results.provn
@@ -235,7 +235,7 @@ document
       nidm:hasNoiseDistribution = 'nidm:GaussianDistribution',
       nidm:noiseVarianceHomogeneous = "true" %%xsd:boolean,
       nidm:varianceSpatialModel = 'nidm:SpatiallyLocal',
-      nidm:hasNoiseDependence = 'nidm:IndependentNoise',
+      nidm:hasErrorDependence = 'nidm:IndependentError',
       nidm:dependenceSpatialModel = 'nidm:SpatiallyLocal'])
     used(niiri:model_pe_id, niiri:noise_model_id,-)
     

--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -128,6 +128,20 @@ nidm:hasClusterLabelsMap rdf:type owl:ObjectProperty ;
 
 
 
+###  http://www.incf.org/ns/nidash/nidm#hasErrorDependence
+
+nidm:hasErrorDependence rdf:type owl:ObjectProperty ;
+                        
+                        prov:definition "Property that associates an ErrorDependence with an ErrorModel." ;
+                        
+                        nidm:curationStatus "nidm:ReadyForRelease" ;
+                        
+                        rdfs:range nidm:ErrorDependence ;
+                        
+                        rdfs:domain nidm:ErrorModel .
+
+
+
 ###  http://www.incf.org/ns/nidash/nidm#hasMapHeader
 
 nidm:hasMapHeader rdf:type owl:ObjectProperty ;
@@ -137,18 +151,6 @@ nidm:hasMapHeader rdf:type owl:ObjectProperty ;
                   rdfs:domain nidm:Map ;
                   
                   rdfs:range nidm:MapHeader .
-
-
-
-###  http://www.incf.org/ns/nidash/nidm#hasNoiseDependence
-
-nidm:hasNoiseDependence rdf:type owl:ObjectProperty ;
-                        
-                        prov:definition "FIXME" ;
-                        
-                        rdfs:domain nidm:ErrorModel ;
-                        
-                        rdfs:range nidm:NoiseDependence .
 
 
 
@@ -1540,13 +1542,15 @@ fsl:ZStatisticMap rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#ArbitrarilyCorrelatedNoise
+###  http://www.incf.org/ns/nidash/nidm#ArbitrarilyCorrelatedError
 
-nidm:ArbitrarilyCorrelatedNoise rdf:type owl:Class ;
+nidm:ArbitrarilyCorrelatedError rdf:type owl:Class ;
                                 
-                                rdfs:subClassOf nidm:NoiseDependence ;
+                                rdfs:subClassOf nidm:ErrorDependence ;
                                 
-                                prov:definition "FIXME" .
+                                nidm:termEditor "TN; Under discussion at https://github.com/ISA-tools/stato/issues/28" ;
+                                
+                                nidm:curationStatus "nidm:ToBeReplacedByExternalOntologyTerm" .
 
 
 
@@ -1600,13 +1604,15 @@ nidm:Colin27CoordinateSystem rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#CompoundSymmetricNoise
+###  http://www.incf.org/ns/nidash/nidm#CompoundSymmetricError
 
-nidm:CompoundSymmetricNoise rdf:type owl:Class ;
+nidm:CompoundSymmetricError rdf:type owl:Class ;
                             
-                            rdfs:subClassOf nidm:NoiseDependence ;
+                            rdfs:subClassOf nidm:ErrorDependence ;
                             
-                            prov:definition "FIXME" .
+                            nidm:curationStatus "nidm:ToBeReplacedByExternalOntologyTerm" ;
+                            
+                            nidm:termEditor "TN; Under discussion at https://github.com/ISA-tools/stato/issues/28" .
 
 
 
@@ -1834,6 +1840,18 @@ nidm:DesignMatrix rdf:type owl:Class ;
 
 
 
+###  http://www.incf.org/ns/nidash/nidm#ErrorDependence
+
+nidm:ErrorDependence rdf:type owl:Class ;
+                     
+                     rdfs:subClassOf prov:Entity ;
+                     
+                     prov:definition "Dependence structure of the error, used as part of model estimation." ;
+                     
+                     nidm:curationStatus "nidm:ReadyForRelease" .
+
+
+
 ###  http://www.incf.org/ns/nidash/nidm#ErrorModel
 
 nidm:ErrorModel rdf:type owl:Class ;
@@ -1854,15 +1872,17 @@ nidm:EstimationMethod rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#ExchangeableNoise
+###  http://www.incf.org/ns/nidash/nidm#ExchangeableError
 
-nidm:ExchangeableNoise rdf:type owl:Class ;
+nidm:ExchangeableError rdf:type owl:Class ;
                        
-                       rdfs:subClassOf nidm:NoiseDependence ;
+                       rdfs:subClassOf nidm:ErrorDependence ;
                        
-                       prov:definition "FIXME" ;
+                       nidm:curationStatus "nidm:ToBeReplacedByExternalOntologyTerm" ;
                        
-                       rdfs:comment "Under gaussianity assumption this is equivalent to compound symmetry but not in general." .
+                       rdfs:comment "Under gaussianity assumption this is equivalent to compound symmetry but not in general." ;
+                       
+                       nidm:termEditor "TN; Under discussion at https://github.com/ISA-tools/stato/issues/28" .
 
 
 
@@ -2158,13 +2178,15 @@ nidm:Image rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#IndependentNoise
+###  http://www.incf.org/ns/nidash/nidm#IndependentError
 
-nidm:IndependentNoise rdf:type owl:Class ;
+nidm:IndependentError rdf:type owl:Class ;
                       
-                      rdfs:subClassOf nidm:NoiseDependence ;
+                      rdfs:subClassOf nidm:ErrorDependence ;
                       
-                      prov:definition "FIXME" .
+                      nidm:termEditor "TN; Under discussion at https://github.com/ISA-tools/stato/issues/28" ;
+                      
+                      nidm:curationStatus "nidm:ToBeReplacedByExternalOntologyTerm" .
 
 
 
@@ -2313,16 +2335,6 @@ nidm:NIDMObjectModel rdf:type owl:Class ;
                      rdfs:subClassOf prov:Entity ;
                      
                      nidm:curationStatus "nidm:Uncurated" .
-
-
-
-###  http://www.incf.org/ns/nidash/nidm#NoiseDependence
-
-nidm:NoiseDependence rdf:type owl:Class ;
-                     
-                     rdfs:subClassOf prov:Entity ;
-                     
-                     prov:definition "FIXME" .
 
 
 
@@ -2571,13 +2583,15 @@ nidm:SearchSpaceMap rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#SeriallyCorrelatedNoise
+###  http://www.incf.org/ns/nidash/nidm#SeriallyCorrelatedError
 
-nidm:SeriallyCorrelatedNoise rdf:type owl:Class ;
+nidm:SeriallyCorrelatedError rdf:type owl:Class ;
                              
-                             rdfs:subClassOf nidm:NoiseDependence ;
+                             rdfs:subClassOf nidm:ErrorDependence ;
                              
-                             prov:definition "FIXME" .
+                             nidm:curationStatus "nidm:ToBeReplacedByExternalOntologyTerm" ;
+                             
+                             nidm:termEditor "TN; Under discussion at https://github.com/ISA-tools/stato/issues/28" .
 
 
 


### PR DESCRIPTION
This issue is a companion for #176 to define the terms created to model noise dependence structures, namely:
- `nidm:hasNoiseDependence`
- `nidm:NoiseDependence`

( `nidm:IndependentNoise`, `nidm:CompoundSymmetryNoise`, `nidm:SeriallyCorrelatedNoise`, `nidm:ArbitrarilyCorrelatedNoise` and `nidm:ExchangeableNoise` discussed at STATO issue ISA-tools/stato#28).

Proposed definitions:
- **nidm:hasNoiseDependence**: "Property that associates a NoiseDependence with a NoiseModel "
- **nidm:NoiseDependence**: "Noise dependence model used to represent the dependence structure between observations used in the model parameters estimation."

Please let me know what you think. @nicholst: would you like to comment on those definitions?
