### PR TITLE
Definition of "PeakDefinitionCriteria"

### DIFF
--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -134,9 +134,9 @@ nidm:hasClusterLabelsMap rdf:type owl:ObjectProperty ;
 
 nidm:hasConnectivityCriterion rdf:type owl:ObjectProperty ;
                               
-                              prov:definition "Property that associates a ConnectivityCriterion with a ClusterDefinitionCriteria." ;
-                              
                               obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/201." ;
+                              
+                              prov:definition "Property that associates a ConnectivityCriterion with a ClusterDefinitionCriteria." ;
                               
                               obo:IAO_0000114 obo:IAO_0000122 ;
                               
@@ -188,9 +188,9 @@ nidm:hasNoiseDistribution rdf:type owl:ObjectProperty ;
 
 nidm:inCoordinateSpace rdf:type owl:ObjectProperty ;
                        
-                       nidm:termEditor "Discussed in https://github.com/incf-nidash/nidm/pull/171 by NN JT CM SG KH TN." ;
-                       
                        prov:definition "Property of a DataArray to associate a CoordinateSpace with a physical file." ;
+                       
+                       nidm:termEditor "Discussed in https://github.com/incf-nidash/nidm/pull/171 by NN JT CM SG KH TN." ;
                        
                        obo:IAO_0000114 obo:IAO_0000122 ;
                        
@@ -258,11 +258,11 @@ nidm:varianceSpatialModel rdf:type owl:ObjectProperty ;
 
 nidm:visualisation rdf:type owl:ObjectProperty ;
                    
-                   prov:definition "Graphical representation of an entity." ;
+                   iao:IAO_0000112 "file:///path/to/design_matrix.png" ;
                    
                    iao:IAO_0000116 "Range: Path to an image (e.g.png) not found." ;
                    
-                   iao:IAO_0000112 "file:///path/to/design_matrix.png" ;
+                   prov:definition "Graphical representation of an entity." ;
                    
                    obo:IAO_0000114 obo:IAO_0000120 ;
                    
@@ -289,11 +289,11 @@ nidm:withEstimationMethod rdf:type owl:ObjectProperty ;
 
 spm:hasMaximumIntensityProjection rdf:type owl:ObjectProperty ;
                                   
-                                  prov:definition "Maximum intensity projection of a map." ;
+                                  iao:IAO_0000116 "Range: Path to an image (e.g.png)." ;
                                   
                                   iao:IAO_0000112 "file:///path/to/MIP.png" ;
                                   
-                                  iao:IAO_0000116 "Range: Path to an image (e.g.png)." ;
+                                  prov:definition "Maximum intensity projection of a map." ;
                                   
                                   obo:IAO_0000114 obo:IAO_0000120 ;
                                   
@@ -386,9 +386,9 @@ dct:format rdf:type owl:DatatypeProperty ;
 
 fsl:coordinate1InVoxels rdf:type owl:DatatypeProperty ;
                         
-                        iao:IAO_0000112 "-60" ;
-                        
                         prov:definition "Coordinate along the first dimension in voxels." ;
+                        
+                        iao:IAO_0000112 "-60" ;
                         
                         obo:IAO_0000114 obo:IAO_0000120 ;
                         
@@ -402,9 +402,9 @@ fsl:coordinate1InVoxels rdf:type owl:DatatypeProperty ;
 
 fsl:coordinate2InVoxels rdf:type owl:DatatypeProperty ;
                         
-                        prov:definition "Coordinate along the second dimension in voxels." ;
-                        
                         iao:IAO_0000112 "-28" ;
+                        
+                        prov:definition "Coordinate along the second dimension in voxels." ;
                         
                         obo:IAO_0000114 obo:IAO_0000120 ;
                         
@@ -523,9 +523,9 @@ nidm:clusterSizeInVertices rdf:type owl:DatatypeProperty ;
 
 nidm:clusterSizeInVoxels rdf:type owl:DatatypeProperty ;
                          
-                         iao:IAO_0000112 "18" ;
-                         
                          prov:definition "Number of voxels that make up the cluster." ;
+                         
+                         iao:IAO_0000112 "18" ;
                          
                          obo:IAO_0000114 obo:IAO_0000125 ;
                          
@@ -540,9 +540,9 @@ nidm:clusterSizeInVoxels rdf:type owl:DatatypeProperty ;
 
 nidm:contrastName rdf:type owl:DatatypeProperty ;
                   
-                  iao:IAO_0000112 "\"Listening > Rest\"" ;
-                  
                   prov:definition "Name of the contrast." ;
+                  
+                  iao:IAO_0000112 "\"Listening > Rest\"" ;
                   
                   obo:IAO_0000114 obo:IAO_0000120 ;
                   
@@ -558,11 +558,11 @@ nidm:contrastName rdf:type owl:DatatypeProperty ;
 
 nidm:coordinate1 rdf:type owl:DatatypeProperty ;
                  
-                 prov:definition "Coordinate along the first dimension in voxel units." ;
+                 iao:IAO_0000116 "Under discussion at: https://github.com/incf-nidash/nidm/issues/145" ;
                  
                  iao:IAO_0000112 "-60" ;
                  
-                 iao:IAO_0000116 "Under discussion at: https://github.com/incf-nidash/nidm/issues/145" ;
+                 prov:definition "Coordinate along the first dimension in voxel units." ;
                  
                  obo:IAO_0000114 obo:IAO_0000120 ;
                  
@@ -576,9 +576,9 @@ nidm:coordinate1 rdf:type owl:DatatypeProperty ;
 
 nidm:coordinate2 rdf:type owl:DatatypeProperty ;
                  
-                 iao:IAO_0000112 "-28" ;
-                 
                  prov:definition "Coordinate along the second dimension in voxel units." ;
+                 
+                 iao:IAO_0000112 "-28" ;
                  
                  obo:IAO_0000114 obo:IAO_0000120 ;
                  
@@ -608,12 +608,13 @@ nidm:coordinate3 rdf:type owl:DatatypeProperty ;
 
 nidm:dimensionsInVoxels rdf:type owl:DatatypeProperty ;
                         
+                        iao:IAO_0000116 "Range: Vector of integers." ;
+                        
                         prov:definition "Dimensions of some N-dimensional data." ;
                         
-                        iao:IAO_0000112 "[64 64 20]" ;
+                        iao:IAO_0000116 "Under discussion at: https://github.com/incf-nidash/nidm/issues/146" ;
                         
-                        iao:IAO_0000116 "Under discussion at: https://github.com/incf-nidash/nidm/issues/146" ,
-                                        "Range: Vector of integers." ;
+                        iao:IAO_0000112 "[64 64 20]" ;
                         
                         obo:IAO_0000114 obo:IAO_0000120 ;
                         
@@ -627,9 +628,9 @@ nidm:dimensionsInVoxels rdf:type owl:DatatypeProperty ;
 
 nidm:effectDegreesOfFreedom rdf:type owl:DatatypeProperty ;
                             
-                            prov:definition "Degrees of freedom of the effect." ;
-                            
                             iao:IAO_0000112 "1" ;
+                            
+                            prov:definition "Degrees of freedom of the effect." ;
                             
                             obo:IAO_0000114 obo:IAO_0000120 ;
                             
@@ -648,9 +649,9 @@ nidm:effectDegreesOfFreedom rdf:type owl:DatatypeProperty ;
 
 nidm:equivalentZStatistic rdf:type owl:DatatypeProperty ;
                           
-                          prov:definition "Statistic value transformed into Z units; the output of a process which takes a non-normal statistic and transforms it to an equivalent z score." ;
-                          
                           iao:IAO_0000112 "3.5" ;
+                          
+                          prov:definition "Statistic value transformed into Z units; the output of a process which takes a non-normal statistic and transforms it to an equivalent z score." ;
                           
                           obo:IAO_0000114 obo:IAO_0000120 ;
                           
@@ -729,9 +730,9 @@ nidm:globalNullDegree rdf:type owl:DatatypeProperty ;
 
 nidm:grandMeanScaling rdf:type owl:DatatypeProperty ;
                       
-                      prov:definition "Binary flag defining whether the data was scaled. Specifically, \"grand mean scaling\" refers to multipliciation of every voxel in every scan by a common value.  Grand mean scaling is essential for first-level fMRI, to transform the arbitrary MRI units, but is generally not used with second level analyses." ;
-                      
                       iao:IAO_0000112 "TRUE" ;
+                      
+                      prov:definition "Binary flag defining whether the data was scaled. Specifically, \"grand mean scaling\" refers to multipliciation of every voxel in every scan by a common value.  Grand mean scaling is essential for first-level fMRI, to transform the arbitrary MRI units, but is generally not used with second level analyses." ;
                       
                       obo:IAO_0000114 obo:IAO_0000125 ;
                       
@@ -757,13 +758,13 @@ nidm:inWorldCoordinateSystem rdf:type owl:DatatypeProperty ;
 
 nidm:maskedMedian rdf:type owl:DatatypeProperty ;
                   
-                  nidm:termEditor "TN, Naming discussed at: https://github.com/incf-nidash/nidm/issues/70" ;
-                  
-                  iao:IAO_0000112 "155.23" ;
+                  prov:definition "Median value considering only in-mask voxels. Useful diagnostic when computed on grand mean image when grandMeanScaling is TRUE, as the median should be close to targetIntensity." ;
                   
                   rdfs:seeAlso "http://purl.obolibrary.org/obo/OBI_0200119" ;
                   
-                  prov:definition "Median value considering only in-mask voxels. Useful diagnostic when computed on grand mean image when grandMeanScaling is TRUE, as the median should be close to targetIntensity." ;
+                  iao:IAO_0000112 "155.23" ;
+                  
+                  nidm:termEditor "TN, Naming discussed at: https://github.com/incf-nidash/nidm/issues/70" ;
                   
                   obo:IAO_0000114 obo:IAO_0000125 ;
                   
@@ -779,6 +780,8 @@ nidm:maxNumberOfPeaksPerCluster rdf:type owl:DatatypeProperty ;
                                 
                                 prov:definition "Maximum number of peaks to be reported after inference within a cluster." ;
                                 
+                                obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/200." ;
+                                
                                 obo:IAO_0000114 obo:IAO_0000122 ;
                                 
                                 rdfs:domain nidm:PeakDefinitionCriteria ;
@@ -793,6 +796,8 @@ nidm:minDistanceBetweenPeaks rdf:type owl:DatatypeProperty ;
                              
                              prov:definition "Minimum distance between two peaks to be reported after inference." ;
                              
+                             obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/200." ;
+                             
                              obo:IAO_0000114 obo:IAO_0000122 ;
                              
                              rdfs:domain nidm:PeakDefinitionCriteria ;
@@ -805,13 +810,13 @@ nidm:minDistanceBetweenPeaks rdf:type owl:DatatypeProperty ;
 
 nidm:noiseFWHM rdf:type owl:DatatypeProperty ;
                
-               rdfs:seeAlso "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#Full_Width_at_Half_Maximum" ;
+               prov:definition "Estimated Full Width at Half Maximum of the noise distribution." ;
                
                nidm:termEditor "Under discussion at https://github.com/incf-nidash/nidm/issues/173" ;
                
-               prov:definition "Estimated Full Width at Half Maximum of the noise distribution." ;
-               
                iao:IAO_0000112 "2.35" ;
+               
+               rdfs:seeAlso "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#Full_Width_at_Half_Maximum" ;
                
                obo:IAO_0000114 obo:IAO_0000120 .
 
@@ -853,11 +858,11 @@ nidm:pValue rdf:type owl:DatatypeProperty ;
             
             owl:sameAs "http://purl.obolibrary.org/obo/OBI_0000175"^^xsd:anyURI ;
             
-            iao:IAO_0000112 "8.95E-14" ;
-            
             rdfs:seeAlso """http://purl.obolibrary.org/obo/IAO_0000121
 http://purl.obolibrary.org/obo/OBI_0000175
 http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#P-Value""" ;
+            
+            iao:IAO_0000112 "8.95E-14" ;
             
             obo:IAO_0000114 obo:IAO_0000122 ;
             
@@ -878,13 +883,13 @@ http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#P-Value""" ;
 
 nidm:pValueFWER rdf:type owl:DatatypeProperty ;
                 
-                owl:sameAs "This definition is from OBI. Please update this note if the definition is modified." ;
+                iao:IAO_0000112 "0.05" ;
                 
-                prov:definition "\"A quantitative confidence value resulting from a multiple testing error correction method which adjusts the p-value used as input to control for Type I error in the context of multiple pairwise tests\"" ;
+                owl:sameAs "This definition is from OBI. Please update this note if the definition is modified." ;
                 
                 rdfs:seeAlso "Synonym of \"nidm:pFWE\"" ;
                 
-                iao:IAO_0000112 "0.05" ;
+                prov:definition "\"A quantitative confidence value resulting from a multiple testing error correction method which adjusts the p-value used as input to control for Type I error in the context of multiple pairwise tests\"" ;
                 
                 obo:IAO_0000114 obo:IAO_0000423 ;
                 
@@ -908,11 +913,11 @@ nidm:pValueFWER rdf:type owl:DatatypeProperty ;
 
 nidm:pValueUncorrected rdf:type owl:DatatypeProperty ;
                        
-                       rdfs:seeAlso "http://purl.obolibrary.org/obo/IAO_0000121" ;
+                       prov:definition "A p-value reported without correction for multiple testing.        " ;
                        
                        iao:IAO_0000112 "0.0542" ;
                        
-                       prov:definition "A p-value reported without correction for multiple testing.        " ;
+                       rdfs:seeAlso "http://purl.obolibrary.org/obo/IAO_0000121" ;
                        
                        obo:IAO_0000114 obo:IAO_0000423 ;
                        
@@ -936,9 +941,9 @@ nidm:pValueUncorrected rdf:type owl:DatatypeProperty ;
 
 nidm:qValueFDR rdf:type owl:DatatypeProperty ;
                
-               owl:sameAs "http://purl.obolibrary.org/obo/OBI_0001442" ;
-               
                iao:IAO_0000112 "0.000154" ;
+               
+               owl:sameAs "http://purl.obolibrary.org/obo/OBI_0001442" ;
                
                prov:definition "A quantitative confidence value that measures the minimum false discovery rate that is incurred when calling that test significant. To compute q-values, it is necessary to know the p-value produced by a test and possibly set a false discovery rate level (same as OBI_0001442)." ;
                
@@ -964,9 +969,9 @@ nidm:qValueFDR rdf:type owl:DatatypeProperty ;
 
 nidm:randomFieldStationarity rdf:type owl:DatatypeProperty ;
                              
-                             prov:definition "Is the random field assumed to be stationary across the entire search volume?" ;
-                             
                              nidm:termEditor "Under discussion at https://github.com/incf-nidash/nidm/issues/130" ;
+                             
+                             prov:definition "Is the random field assumed to be stationary across the entire search volume?" ;
                              
                              obo:IAO_0000114 obo:IAO_0000120 ;
                              
@@ -980,9 +985,9 @@ nidm:randomFieldStationarity rdf:type owl:DatatypeProperty ;
 
 nidm:softwareVersion rdf:type owl:DatatypeProperty ;
                      
-                     iao:IAO_0000112 "SPM99, SPM2, SPM5, SPM8, SPM12b, FSL5.0.0" ;
-                     
                      prov:definition "Name and number that specifies the software version." ;
+                     
+                     iao:IAO_0000112 "SPM99, SPM2, SPM5, SPM8, SPM12b, FSL5.0.0" ;
                      
                      obo:IAO_0000114 obo:IAO_0000125 ;
                      
@@ -1017,13 +1022,13 @@ nidm:targetIntensity rdf:type owl:DatatypeProperty ;
 
 nidm:userSpecifiedThresholdType rdf:type owl:DatatypeProperty ;
                                 
-                                prov:definition "Type of method used to define a threshold (e.g. statistic value, uncorrected P-value or corrected P-value)." ;
+                                nidm:termEditor "Discussed in https://github.com/incf-nidash/nidm/pull/150" ;
                                 
                                 iao:IAO_0000116 "Range is currently string but should be limited to {'nidm:pValueFWER' not found'nidm:pValueFDR' not found'nidm:pValueUncorrected';'nidm:statistic'}?" ;
                                 
                                 iao:IAO_0000112 "nidm:pValueFWER" ;
                                 
-                                nidm:termEditor "Discussed in https://github.com/incf-nidash/nidm/pull/150" ;
+                                prov:definition "Type of method used to define a threshold (e.g. statistic value, uncorrected P-value or corrected P-value)." ;
                                 
                                 obo:IAO_0000114 obo:IAO_0000428 ;
                                 
@@ -1052,9 +1057,9 @@ nidm:voxelSize rdf:type owl:DatatypeProperty ;
                
                iao:IAO_0000112 "[2 2 4]" ;
                
-               prov:definition "3D size of a voxel measured in voxelUnits." ;
-               
                iao:IAO_0000116 "Range: Vector of floats." ;
+               
+               prov:definition "3D size of a voxel measured in voxelUnits." ;
                
                rdfs:seeAlso """http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C95003 
 """ ;
@@ -1071,13 +1076,13 @@ nidm:voxelSize rdf:type owl:DatatypeProperty ;
 
 nidm:voxelToWorldMapping rdf:type owl:DatatypeProperty ;
                          
-                         iao:IAO_0000112 "[3 0 0 0;0 3 0 0;0 0 3 0; 0 0 0 1] " ;
-                         
-                         iao:IAO_0000116 "Range: Matrix of float." ;
+                         prov:definition "Homogeneous transformation matrix to map from voxel coordinate system to world coordinate system." ;
                          
                          nidm:termEditor "Discussed in https://github.com/incf-nidash/nidm/pull/148" ;
                          
-                         prov:definition "Homogeneous transformation matrix to map from voxel coordinate system to world coordinate system." ;
+                         iao:IAO_0000112 "[3 0 0 0;0 3 0 0;0 0 3 0; 0 0 0 1] " ;
+                         
+                         iao:IAO_0000116 "Range: Matrix of float." ;
                          
                          obo:IAO_0000114 obo:IAO_0000122 ;
                          
@@ -1093,9 +1098,9 @@ nidm:voxelUnits rdf:type owl:DatatypeProperty ;
                 
                 iao:IAO_0000116 "Range: Vector of strings." ;
                 
-                iao:IAO_0000112 "{'mm' 'mm' 's'}" ;
-                
                 prov:definition "Units associated with each dimensions of some N-dimensional data." ;
+                
+                iao:IAO_0000112 "{'mm' 'mm' 's'}" ;
                 
                 nidm:termEditor "Under discussion at https://github.com/incf-nidash/nidm/issues/147" ;
                 
@@ -1111,11 +1116,11 @@ nidm:voxelUnits rdf:type owl:DatatypeProperty ;
 
 spm:clusterSizeInResels rdf:type owl:DatatypeProperty ;
                         
-                        prov:definition "Size of cluster measured in resels." ;
+                        iao:IAO_0000112 "13" ;
                         
                         nidm:termEditor "Under discussion at: https://github.com/incf-nidash/nidm/issues/127" ;
                         
-                        iao:IAO_0000112 "13" ;
+                        prov:definition "Size of cluster measured in resels." ;
                         
                         obo:IAO_0000114 obo:IAO_0000122 ;
                         
@@ -1214,9 +1219,9 @@ spm:heightCriticalThresholdFDR05 rdf:type owl:DatatypeProperty ;
 
 spm:heightCriticalThresholdFWE05 rdf:type owl:DatatypeProperty ;
                                  
-                                 iao:IAO_0000112 "4.913" ;
-                                 
                                  prov:definition "Peak statistic threshold corrected for family-wise error at a level of alpha = 0.05. " ;
+                                 
+                                 iao:IAO_0000112 "4.913" ;
                                  
                                  obo:IAO_0000114 obo:IAO_0000122 ;
                                  
@@ -1232,9 +1237,9 @@ spm:noiseFWHMInUnits rdf:type owl:DatatypeProperty ;
                      
                      iao:IAO_0000112 "[8.87, 8.89, 7.83]" ;
                      
-                     iao:IAO_0000116 "Range: Vector of positive floats." ;
-                     
                      prov:definition "Estimated Full Width at Half Maximum of the noise distribution in world units." ;
+                     
+                     iao:IAO_0000116 "Range: Vector of positive floats." ;
                      
                      obo:IAO_0000114 obo:IAO_0000120 ;
                      
@@ -1250,11 +1255,11 @@ spm:noiseFWHMInUnits rdf:type owl:DatatypeProperty ;
 
 spm:noiseFWHMInVertices rdf:type owl:DatatypeProperty ;
                         
-                        iao:IAO_0000112 "[2.95, 2.96, 2.61]" ;
-                        
                         iao:IAO_0000116 "Range: Vector of positive floats." ;
                         
                         prov:definition "Estimated Full Width at Half Maximum of the noise distribution in world vertices." ;
+                        
+                        iao:IAO_0000112 "[2.95, 2.96, 2.61]" ;
                         
                         obo:IAO_0000114 obo:IAO_0000120 ;
                         
@@ -1268,13 +1273,13 @@ spm:noiseFWHMInVertices rdf:type owl:DatatypeProperty ;
 
 spm:noiseFWHMInVoxels rdf:type owl:DatatypeProperty ;
                       
-                      iao:IAO_0000116 "Range: Vector of positive floats." ;
-                      
-                      rdfs:seeAlso "Synonyms of or close match with nidm:NoiseFWHM" ;
-                      
                       iao:IAO_0000112 "[3.7 3.7 3.1]" ;
                       
                       prov:definition "Estimated Full Width at Half Maximum of the noise distribution in voxels." ;
+                      
+                      iao:IAO_0000116 "Range: Vector of positive floats." ;
+                      
+                      rdfs:seeAlso "Synonyms of or close match with nidm:NoiseFWHM" ;
                       
                       obo:IAO_0000114 obo:IAO_0000120 ;
                       
@@ -1313,9 +1318,9 @@ spm:searchVolumeInResels rdf:type owl:DatatypeProperty ;
                          
                          prov:definition "Total number of resels within the search volume." ;
                          
-                         iao:IAO_0000112 "151.3" ;
-                         
                          rdfs:seeAlso "Synonyms of nidm:volumeInResels" ;
+                         
+                         iao:IAO_0000112 "151.3" ;
                          
                          rdfs:domain nidm:SearchSpaceMap ;
                          
@@ -1332,14 +1337,14 @@ spm:searchVolumeInResels rdf:type owl:DatatypeProperty ;
 
 spm:searchVolumeInUnits rdf:type owl:DatatypeProperty ;
                         
+                        prov:definition "The volume of the searched region in units determined by the current coordinate space units (e.g., mm^3 for axis units of mm in a three dimensional image, sec.Hz for a time by frequency two dimensional image)." ;
+                        
+                        iao:IAO_0000112 "1771011" ;
+                        
                         nidm:termEditor "Discussed at https://github.com/incf-nidash/nidm/pull/131" ;
                         
                         iao:IAO_0000116 """Context: volumeInVoxels nidm_0025. Range: Positivefloat not found. BIRNLex or 
 NIDM Concept ID: spm_84. """ ;
-                        
-                        prov:definition "The volume of the searched region in units determined by the current coordinate space units (e.g., mm^3 for axis units of mm in a three dimensional image, sec.Hz for a time by frequency two dimensional image)." ;
-                        
-                        iao:IAO_0000112 "1771011" ;
                         
                         obo:IAO_0000114 obo:IAO_0000122 ;
                         
@@ -1358,9 +1363,9 @@ NIDM Concept ID: spm_84. """ ;
 
 spm:searchVolumeInVertices rdf:type owl:DatatypeProperty ;
                            
-                           iao:IAO_0000112 "151.3" ;
-                           
                            prov:definition "Total number of vertices within the search volume." ;
+                           
+                           iao:IAO_0000112 "151.3" ;
                            
                            obo:IAO_0000114 obo:IAO_0000120 ;
                            
@@ -1379,13 +1384,13 @@ spm:searchVolumeInVertices rdf:type owl:DatatypeProperty ;
 
 spm:searchVolumeInVoxels rdf:type owl:DatatypeProperty ;
                          
-                         iao:IAO_0000116 "Check if this can be merged with fsl:searchVolumeInVoxels" ;
+                         rdfs:seeAlso "Synonyms of nidm:volumeInVoxels" ;
                          
-                         iao:IAO_0000112 "68656" ;
+                         iao:IAO_0000116 "Check if this can be merged with fsl:searchVolumeInVoxels" ;
                          
                          prov:definition "Total number of voxels within the search volume." ;
                          
-                         rdfs:seeAlso "Synonyms of nidm:volumeInVoxels" ;
+                         iao:IAO_0000112 "68656" ;
                          
                          obo:IAO_0000114 obo:IAO_0000124 ;
                          
@@ -1399,13 +1404,13 @@ spm:searchVolumeInVoxels rdf:type owl:DatatypeProperty ;
 
 spm:searchVolumeReselsGeometry rdf:type owl:DatatypeProperty ;
                                
-                               iao:IAO_0000116 "Range: Vector of 1 positive integer and 3 positive floats." ;
-                               
-                               prov:definition "Description of geometry of search volume.  As per Worsley et al. [ http://www.ncbi.nlm.nih.gov/pubmed/20408186 ], the first element is the Euler Characteristic of the search volume, the second element is twice the average caliper diameter, the third element is half the surface area, and the fourth element is the volume.  With the exception of the first element (which is a unitless integer) all quantities are in units of Resels." ;
-                               
                                iao:IAO_0000112 "[6 68.8 589.1 1475.5]" ;
                                
+                               iao:IAO_0000116 "Range: Vector of 1 positive integer and 3 positive floats." ;
+                               
                                rdfs:seeAlso "http://www.ncbi.nlm.nih.gov/pubmed/20408186" ;
+                               
+                               prov:definition "Description of geometry of search volume.  As per Worsley et al. [ http://www.ncbi.nlm.nih.gov/pubmed/20408186 ], the first element is the Euler Characteristic of the search volume, the second element is twice the average caliper diameter, the third element is half the surface area, and the fourth element is the volume.  With the exception of the first element (which is a unitless integer) all quantities are in units of Resels." ;
                                
                                obo:IAO_0000114 obo:IAO_0000125 ;
                                
@@ -1470,10 +1475,10 @@ spm:smallestSignifClusterSizeInVoxelsFDR05 rdf:type owl:DatatypeProperty ;
 
 spm:smallestSignifClusterSizeInVoxelsFWE05 rdf:type owl:DatatypeProperty ;
                                            
-                                           iao:IAO_0000112 "1" ;
-                                           
                                            prov:definition """Smallest cluster size in voxels significant at family-wise error corrected alpha value of 0.05. 
 """ ;
+                                           
+                                           iao:IAO_0000112 "1" ;
                                            
                                            obo:IAO_0000114 obo:IAO_0000125 ;
                                            
@@ -1487,9 +1492,9 @@ spm:smallestSignifClusterSizeInVoxelsFWE05 rdf:type owl:DatatypeProperty ;
 
 spm:softwareRevision rdf:type owl:DatatypeProperty ;
                      
-                     iao:IAO_0000112 "5417" ;
-                     
                      prov:definition "revision number of a piece of software." ;
+                     
+                     iao:IAO_0000112 "5417" ;
                      
                      obo:IAO_0000114 obo:IAO_0000120 ;
                      
@@ -1524,14 +1529,14 @@ fsl:CenterOfGravity rdf:type owl:Class ;
                     
                     rdfs:subClassOf prov:Entity ;
                     
-                    rdfs:seeAlso "http://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Cluster" ;
-                    
                     prov:definition "Centre Of Gravity for the cluster, equivalent to the concept of Centre Of Gravity for a object with distributed mass, where intensity substitutes for mass in this case (definition from http://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Cluster)" ;
                     
                     iao:IAO_0000112 """entity(niiri:center_of_gravity_1,
         [prov:type = 'fsl:centerOfGravity',
         prov:label = \"Center of gravity 1\",
         prov:location = 'niiri:COG_coordinate_0001'])""" ;
+                    
+                    rdfs:seeAlso "http://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Cluster" ;
                     
                     obo:IAO_0000114 obo:IAO_0000120 .
 
@@ -1641,9 +1646,9 @@ nidm:ConjunctionInference rdf:type owl:Class ;
                           
                           rdfs:subClassOf nidm:Inference ;
                           
-                          iao:IAO_0000116 "Term discussed in https://github.com/incf-nidash/nidm/pull/134." ;
-                          
                           prov:definition "Statistically testing for the joint significance of multiple effects, with emphasis on rejecting all (instead of one or more) of the respective null hypotheses." ;
+                          
+                          iao:IAO_0000116 "Term discussed in https://github.com/incf-nidash/nidm/pull/134." ;
                           
                           obo:IAO_0000114 obo:IAO_0000122 .
 
@@ -1671,9 +1676,9 @@ nidm:ContrastEstimation rdf:type owl:Class ;
                         
                         rdfs:subClassOf prov:Activity ;
                         
-                        prov:definition "The process of estimating a contrast from the estimated parameters of statistical model." ;
-                        
                         iao:IAO_0000116 "Under discussion at: https://github.com/ISA-tools/stato/issues/23" ;
+                        
+                        prov:definition "The process of estimating a contrast from the estimated parameters of statistical model." ;
                         
                         iao:IAO_0000112 """activity(niiri:contrast_estimation_id,
     [prov:type = 'nidm:ContrastEstimation',
@@ -1710,6 +1715,8 @@ nidm:ContrastStandardErrorMap rdf:type owl:Class ;
                               
                               rdfs:subClassOf nidm:Map ;
                               
+                              prov:definition "A map whose value at each location is the standard error of a given contrast." ;
+                              
                               iao:IAO_0000112 """entity(niiri:contrast_standard_error_map_id,
     [prov:type = 'nidm:ContrastStandardErrorMap',
     prov:location = \"file:///path/to/contrastSE.nii\" %% xsd:anyURI,
@@ -1717,8 +1724,6 @@ nidm:ContrastStandardErrorMap rdf:type owl:Class ;
     nidm:originalFileName = \"contrastSE.nii\" %% xsd:string,
     nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
     crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" ;
-                              
-                              prov:definition "A map whose value at each location is the standard error of a given contrast." ;
                               
                               obo:IAO_0000114 obo:IAO_0000125 .
 
@@ -1730,7 +1735,8 @@ nidm:ContrastWeights rdf:type owl:Class ;
                      
                      rdfs:subClassOf prov:Entity ;
                      
-                     prov:definition "Vector defining the linear combination associated with a particular contrast. " ;
+                     iao:IAO_0000116 "Range: Vector of integers not found." ,
+                                     "Under discussion at: https://github.com/ISA-tools/stato/issues/23" ;
                      
                      iao:IAO_0000112 """\"entity(niiri:t_contrast_id,
     [prov:type = 'nidm:TContrastWeights',
@@ -1738,8 +1744,7 @@ nidm:ContrastWeights rdf:type owl:Class ;
     prov:label = \"\"Contrast: Listening > Rest\"\" %% xsd:string,
     prov:value = \"\"[1, 0, 0]\"\" %% xsd:string])\"""" ;
                      
-                     iao:IAO_0000116 "Under discussion at: https://github.com/ISA-tools/stato/issues/23" ,
-                                     "Range: Vector of integers not found." ;
+                     prov:definition "Vector defining the linear combination associated with a particular contrast. " ;
                      
                      obo:IAO_0000114 obo:IAO_0000423 .
 
@@ -1824,12 +1829,6 @@ nidm:Data rdf:type owl:Class ;
           
           rdfs:subClassOf prov:Entity ;
           
-          owl:sameAs "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C25474" ;
-          
-          iao:IAO_0000116 "This definition is from NCIT. Please update this note if the definition is modified." ;
-          
-          prov:definition "\"A collection or single item of factual information, derived from measurement or research, from which conclusions may be drawn.\"" ;
-          
           iao:IAO_0000112 """entity(niiri:data_id,
     [prov:type = 'nidm:Data',
     prov:type = 'prov:Collection',
@@ -1837,6 +1836,12 @@ nidm:Data rdf:type owl:Class ;
     nidm:grandMeanScaling = \"true\" %%xsd:boolean,
     nidm:targetIntensity = \"100\" %% xsd:float,
     nidm:intraMaskMedian = \"115.32\" %% xsd:float])""" ;
+          
+          owl:sameAs "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C25474" ;
+          
+          prov:definition "\"A collection or single item of factual information, derived from measurement or research, from which conclusions may be drawn.\"" ;
+          
+          iao:IAO_0000116 "This definition is from NCIT. Please update this note if the definition is modified." ;
           
           obo:IAO_0000114 obo:IAO_0000125 .
 
@@ -1848,8 +1853,6 @@ nidm:DesignMatrix rdf:type owl:Class ;
                   
                   rdfs:subClassOf prov:Entity ;
                   
-                  prov:definition "A matrix of values defining the explanatory variables used in a regression model.  Each column corresponds to one explanatory variable, each row corresponds to one observation." ;
-                  
                   iao:IAO_0000112 """entity(niiri:design_matrix_id,
     [prov:type = 'nidm:DesignMatrix',
     prov:location = \"file:///path/to/design_matrix.csv\" %% xsd:anyURI,
@@ -1857,9 +1860,11 @@ nidm:DesignMatrix rdf:type owl:Class ;
     prov:label = \"Design Matrix\" %% xsd:string,
     nidm:originalFileName = \"design_matrix.csv\" %% xsd:string])""" ;
                   
+                  nidm:termEditor "TN" ;
+                  
                   rdfs:seeAlso "stato:design matrix" ;
                   
-                  nidm:termEditor "TN" ;
+                  prov:definition "A matrix of values defining the explanatory variables used in a regression model.  Each column corresponds to one explanatory variable, each row corresponds to one observation." ;
                   
                   obo:IAO_0000114 obo:IAO_0000125 .
 
@@ -1871,9 +1876,9 @@ nidm:DisplayMaskMap rdf:type owl:Class ;
                     
                     rdfs:subClassOf nidm:Map ;
                     
-                    rdfs:comment "Mask defined by the user to restrain the space in which inference results are reported. This mask does not affect the search volume used for multiple-testing correction; e.g. it does not alter voxel-wise corrected p-values." ;
-                    
                     nidm:termEditor "Discussed in https://github.com/incf-nidash/nidm/pull/157" ;
+                    
+                    rdfs:comment "Mask defined by the user to restrain the space in which inference results are reported. This mask does not affect the search volume used for multiple-testing correction; e.g. it does not alter voxel-wise corrected p-values." ;
                     
                     obo:IAO_0000114 obo:IAO_0000122 .
 
@@ -1917,9 +1922,9 @@ nidm:ExchangeableError rdf:type owl:Class ;
                        
                        rdfs:subClassOf nidm:ErrorDependence ;
                        
-                       rdfs:comment "Under gaussianity assumption this is equivalent to compound symmetry but not in general." ;
-                       
                        nidm:termEditor "TN; Under discussion at https://github.com/ISA-tools/stato/issues/28" ;
+                       
+                       rdfs:comment "Under gaussianity assumption this is equivalent to compound symmetry but not in general." ;
                        
                        obo:IAO_0000114 obo:IAO_0000423 .
 
@@ -1931,6 +1936,10 @@ nidm:ExcursionSet rdf:type owl:Class ;
                   
                   rdfs:subClassOf nidm:Map ;
                   
+                  prov:definition "Set of map elements surviving a thresholding procedure." ;
+                  
+                  iao:IAO_0000116 "Discussed in the Neuroimaging terms spreadsheet." ;
+                  
                   iao:IAO_0000112 """entity(niiri:excursion_set_id,
     [prov:type = 'nidm:ExcursionSet',
     prov:location = \"file:///path/to/thresh_spmT_0001.img\" %% xsd:anyURI,
@@ -1940,10 +1949,6 @@ nidm:ExcursionSet rdf:type owl:Class ;
     nidm:originalFileName = \"thresh_spmT_0001.img\" %% xsd:string,
     nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
     crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" ;
-                  
-                  iao:IAO_0000116 "Discussed in the Neuroimaging terms spreadsheet." ;
-                  
-                  prov:definition "Set of map elements surviving a thresholding procedure." ;
                   
                   obo:IAO_0000114 obo:IAO_0000125 .
 
@@ -1955,9 +1960,6 @@ nidm:ExtentThreshold rdf:type owl:Class ;
                      
                      rdfs:subClassOf prov:Entity ;
                      
-                     prov:definition """A numerical value that establishes a bound on a range of cluster-sizes. / [from extentThresh:]        Minimum cluster size used when thresholding a statistic image        5voxels
-""" ;
-                     
                      iao:IAO_0000112 """entity(niiri:extent_threshold_id,
     [prov:type = 'nidm:ExtentThreshold',
     prov:label = \"Extent Threshold: k>=0\" %% xsd:string,
@@ -1965,6 +1967,9 @@ nidm:ExtentThreshold rdf:type owl:Class ;
     spm:clusterSizeInResels = \"0\" %% xsd:float,
     nidm:pValueUncorrected = \"1\" %% xsd:float,
     nidm:pValueFWER = \"1\" %% xsd:float])""" ;
+                     
+                     prov:definition """A numerical value that establishes a bound on a range of cluster-sizes. / [from extentThresh:]        Minimum cluster size used when thresholding a statistic image        5voxels
+""" ;
                      
                      obo:IAO_0000114 obo:IAO_0000120 .
 
@@ -2022,9 +2027,9 @@ nidm:GeneralizedLeastSquares rdf:type owl:Class ;
                              
                              rdfs:subClassOf nidm:EstimationMethod ;
                              
-                             rdfs:comment "GLS (both heteroscedasticity and dependence accounted for) OLS is a special case of WLS & GLS; WLS is a special case of GLS." ;
+                             prov:definition "FIXME" ;
                              
-                             prov:definition "FIXME" .
+                             rdfs:comment "GLS (both heteroscedasticity and dependence accounted for) OLS is a special case of WLS & GLS; WLS is a special case of GLS." .
 
 
 
@@ -2089,11 +2094,11 @@ nidm:Inference rdf:type owl:Class ;
                
                rdfs:subClassOf prov:Activity ;
                
-               prov:definition "Statistical inference is a process of drawing conclusions following data analysis using statistical methods (statistical tests) and evaluating whether to reject or accept null hypothesis. (definition from STATO)." ;
-               
                iao:IAO_0000112 """activity(niiri:inference_id,
     [prov:type = 'nidm:Inference',
     prov:label = \"Inference\"])""" ;
+               
+               prov:definition "Statistical inference is a process of drawing conclusions following data analysis using statistical methods (statistical tests) and evaluating whether to reject or accept null hypothesis. (definition from STATO)." ;
                
                owl:sameAs "http://purl.obolibrary.org/obo/STATO_0000299" ;
                
@@ -2107,8 +2112,6 @@ nidm:InferenceMaskMap rdf:type owl:Class ;
                       
                       rdfs:subClassOf nidm:Map ;
                       
-                      prov:definition "mask defined by the user to restrain the space in which inference is performed." ;
-                      
                       iao:IAO_0000112 """entity(niiri:sub_volume_id,
       [prov:type = 'nidm:SubVolumeMap',
       prov:location = \"file:///path/to/svc_mask.nii\" %% xsd:anyURI,
@@ -2118,7 +2121,9 @@ nidm:InferenceMaskMap rdf:type owl:Class ;
       crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" ;
                       
                       iao:IAO_0000116 """BIRNLex or 
-NIDM Concept ID: nidm_101. """ .
+NIDM Concept ID: nidm_101. """ ;
+                      
+                      prov:definition "mask defined by the user to restrain the space in which inference is performed." .
 
 
 
@@ -2142,9 +2147,9 @@ nidm:Map rdf:type owl:Class ;
          
          rdfs:subClassOf prov:Entity ;
          
-         prov:definition "Ordered set of values corresponding to the discrete sampling of some process (e.g. brain MRI data measured on a regular 3D lattice; or brain cortical surface data measured irregularly over the cortex)." ;
-         
          iao:IAO_0000116 "Discussed in https://github.com/incf-nidash/nidm/pull/149" ;
+         
+         prov:definition "Ordered set of values corresponding to the discrete sampling of some process (e.g. brain MRI data measured on a regular 3D lattice; or brain cortical surface data measured irregularly over the cortex)." ;
          
          obo:IAO_0000114 obo:IAO_0000122 .
 
@@ -2188,11 +2193,11 @@ nidm:ModelParametersEstimation rdf:type owl:Class ;
                                
                                rdfs:subClassOf prov:Activity ;
                                
-                               iao:IAO_0000116 "Under discussion at: https://github.com/incf-nidash/nidm/issues/141" ;
-                               
                                iao:IAO_0000112 """activity(niiri:model_pe_id,
     [prov:type = 'nidm:ModelParametersEstimation',
     prov:label = \"Model parameters estimation\"])""" ;
+                               
+                               iao:IAO_0000116 "Under discussion at: https://github.com/incf-nidash/nidm/issues/141" ;
                                
                                rdfs:seeAlso "stato:model parameter estimation" ;
                                
@@ -2250,9 +2255,9 @@ nidm:OrdinaryLeastSquares rdf:type owl:Class ;
                           
                           rdfs:subClassOf nidm:EstimationMethod ;
                           
-                          prov:definition "FIXME" ;
+                          rdfs:comment "OLS (no heteroscedasticity or dependence accounted for)" ;
                           
-                          rdfs:comment "OLS (no heteroscedasticity or dependence accounted for)" .
+                          prov:definition "FIXME" .
 
 
 
@@ -2262,8 +2267,6 @@ nidm:ParameterEstimateMap rdf:type owl:Class ;
                           
                           rdfs:subClassOf nidm:Map ;
                           
-                          iao:IAO_0000116 "Under discussion at: https://github.com/incf-nidash/nidm/issues/141 (see also https://github.com/ISA-tools/stato/issues/18)" ;
-                          
                           iao:IAO_0000112 """entity(niiri:parameter_estimate_map_id_1,
     [prov:type = 'nidm:ParameterEstimateMap',
     prov:location = \"file:///path/to/beta_0001.img\" %% xsd:anyURI,
@@ -2271,6 +2274,8 @@ nidm:ParameterEstimateMap rdf:type owl:Class ;
     nidm:originalFileName = \"beta_0001.img\" %% xsd:string,
     nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
     crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" ;
+                          
+                          iao:IAO_0000116 "Under discussion at: https://github.com/incf-nidash/nidm/issues/141 (see also https://github.com/ISA-tools/stato/issues/18)" ;
                           
                           prov:definition "A map whose value at each location is the estimate of a model parameter." ;
                           
@@ -2284,8 +2289,6 @@ nidm:Peak rdf:type owl:Class ;
           
           rdfs:subClassOf prov:Entity ;
           
-          prov:definition "Statistic defined at the peak-level in an excursion set. FIXME (now Peak instead of PeakStatistic)" ;
-          
           iao:IAO_0000112 """entity(niiri:peak_0001,
     [prov:type = 'nidm:Peak',
     prov:label = \"Peak Statistic: 0001\" %% xsd:string,
@@ -2295,6 +2298,8 @@ nidm:Peak rdf:type owl:Class ;
     nidm:pValueUncorrected = \"4.44089209850063e-16\" %% xsd:float,
     nidm:pValueFWER = \"0\" %% xsd:float,
     nidm:qValueFDR = \"6.3705194444993e-11\" %% xsd:float])""" ;
+          
+          prov:definition "Statistic defined at the peak-level in an excursion set. FIXME (now Peak instead of PeakStatistic)" ;
           
           obo:IAO_0000114 obo:IAO_0000120 .
 
@@ -2306,9 +2311,9 @@ nidm:PeakDefinitionCriteria rdf:type owl:Class ;
                             
                             rdfs:subClassOf prov:Entity ;
                             
-                            nidm:termEditor "CM" ;
-                            
                             prov:definition "Set of criterion specified a priori to define the peaks reported after inference (e.g. maximum number of peaks within a cluster, minimum distance between peaks)." ;
+                            
+                            nidm:termEditor "Discussed in https://github.com/incf-nidash/nidm/pull/200." ;
                             
                             obo:IAO_0000114 obo:IAO_0000122 .
 
@@ -2347,9 +2352,11 @@ nidm:ResidualMeanSquaresMap rdf:type owl:Class ;
                             iao:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_52. """ ;
                             
+                            prov:definition "A map whose value at each location is the residual of the mean squares fit to the data." ;
+                            
                             rdfs:seeAlso "This is a map of \"residuals\" as defined at http://bioportal.bioontology.org/ontologies/STATO/?p=classes&conceptid=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FSTATO_0000234 " ;
                             
-                            prov:definition "A map whose value at each location is the residual of the mean squares fit to the data." ;
+                            nidm:termEditor "KH" ;
                             
                             iao:IAO_0000112 """entity(niiri:residual_mean_squares_map_id,
     [prov:type = 'nidm:ResidualMeanSquaresMap',
@@ -2358,8 +2365,6 @@ NIDM Concept ID: nidm_52. """ ;
     nidm:originalFileName = \"ResMS.img\" %% xsd:string,
     nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
     crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" ;
-                            
-                            nidm:termEditor "KH" ;
                             
                             obo:IAO_0000114 obo:IAO_0000125 .
 
@@ -2371,9 +2376,9 @@ nidm:RobustIterativelyReweighedLeastSquares rdf:type owl:Class ;
                                             
                                             rdfs:subClassOf nidm:EstimationMethod ;
                                             
-                                            rdfs:comment "used for automatically down-weighting outliers, using some given influence function (e.g. Huber; see [1] for a neuroimaging application)." ;
+                                            prov:definition "FIXME" ;
                                             
-                                            prov:definition "FIXME" .
+                                            rdfs:comment "used for automatically down-weighting outliers, using some given influence function (e.g. Huber; see [1] for a neuroimaging application)." .
 
 
 
@@ -2407,6 +2412,10 @@ nidm:SearchSpaceMap rdf:type owl:Class ;
                     
                     rdfs:subClassOf nidm:Map ;
                     
+                    prov:definition "mask in which the inference was performed." ;
+                    
+                    rdfs:seeAlso "http://purl.obolibrary.org/obo/OBI_0000235" ;
+                    
                     iao:IAO_0000112 """entity(niiri:search_space_id,
       [prov:type = 'nidm:SearchSpaceMap',
       prov:location = \"file:///path/to/final_mask.nii\" %% xsd:anyURI,
@@ -2428,10 +2437,6 @@ nidm:SearchSpaceMap rdf:type owl:Class ;
       spm:smallestSignifClusterSizeInVoxelsFWE05 = \"1\" %% xsd:float,
       spm:smallestSignifClusterSizeInVoxelsFDR05 = \"3\" %% xsd:float
       crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" ;
-                    
-                    rdfs:seeAlso "http://purl.obolibrary.org/obo/OBI_0000235" ;
-                    
-                    prov:definition "mask in which the inference was performed." ;
                     
                     obo:IAO_0000114 obo:IAO_0000120 .
 
@@ -2495,10 +2500,10 @@ nidm:StandardizedCoordinateSystem rdf:type owl:Class ;
                                   
                                   rdfs:subClassOf nidm:WorldCoordinateSystem ;
                                   
-                                  rdfs:comment "FIXME. This definition needs to be re-worked and reviewed." ,
-                                               "This is meant to be used for retrospective export when exact template is unknown." ;
-                                  
                                   prov:definition "Parent of all reference spaces except \"Subject\"." ;
+                                  
+                                  rdfs:comment "This is meant to be used for retrospective export when exact template is unknown." ,
+                                               "FIXME. This definition needs to be re-worked and reviewed." ;
                                   
                                   obo:IAO_0000114 obo:IAO_0000120 .
 
@@ -2571,9 +2576,9 @@ nidm:TalairachCoordinateSystem rdf:type owl:Class ;
                                
                                rdfs:subClassOf nidm:StandardizedCoordinateSystem ;
                                
-                               prov:definition "Reference space defined by the dissected brain used for the Talairach and Tournoux atlas." ;
-                               
                                rdfs:seeAlso "http://www.talairach.org/" ;
+                               
+                               prov:definition "Reference space defined by the dissected brain used for the Talairach and Tournoux atlas." ;
                                
                                obo:IAO_0000114 obo:IAO_0000120 .
 
@@ -2599,9 +2604,9 @@ nidm:VoxelConnectivityCriterion rdf:type owl:Class ;
                                 
                                 rdfs:subClassOf nidm:ConnectivityCriterion ;
                                 
-                                prov:definition "The criterion used to characterize two voxels as 'connected'. In three dimensions voxels that are connected can share a voxel face (6-connected), face or edge (18-connectec), or face, edge, or corner (26-connected)." ;
-                                
                                 obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/201." ;
+                                
+                                prov:definition "The criterion used to characterize two voxels as 'connected'. In three dimensions voxels that are connected can share a voxel face (6-connected), face or edge (18-connectec), or face, edge, or corner (26-connected)." ;
                                 
                                 obo:IAO_0000114 obo:IAO_0000122 .
 
@@ -2613,9 +2618,9 @@ nidm:WeightedLeastSquares rdf:type owl:Class ;
                           
                           rdfs:subClassOf nidm:EstimationMethod ;
                           
-                          rdfs:comment "WLS (heteroscedasticity accounted for, but no dependence)" ;
+                          prov:definition "FIXME" ;
                           
-                          prov:definition "FIXME" .
+                          rdfs:comment "WLS (heteroscedasticity accounted for, but no dependence)" .
 
 
 
@@ -2657,8 +2662,6 @@ spm:ReselsPerVoxelMap rdf:type owl:Class ;
                       
                       rdfs:subClassOf nidm:Map ;
                       
-                      prov:definition "A map whose value at each location is the number of resels per voxel. " ;
-                      
                       iao:IAO_0000112 """entity(niiri:resels_per_voxel_map_id,
       [prov:type = 'spm:ReselsPerVoxelMap',
       prov:location = \"file:///path/to/RPV.img\" %% xsd:anyURI,
@@ -2666,6 +2669,8 @@ spm:ReselsPerVoxelMap rdf:type owl:Class ;
       nidm:originalFileName = \"RPV.img\" %% xsd:string,
       nidm:inCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" ;
+                      
+                      prov:definition "A map whose value at each location is the number of resels per voxel. " ;
                       
                       obo:IAO_0000114 obo:IAO_0000120 .
 
@@ -2727,13 +2732,12 @@ prov:SoftwareAgent rdf:type owl:Class ;
 nidm:Colin27CoordinateSystem rdf:type nidm:StandardizedCoordinateSystem ,
                                       owl:NamedIndividual ;
                              
-                             rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/Colin27Highres" ;
-                             
-                             rdfs:comment "used in SPM96 (cf. http://imaging.mrc-cbu.cam.ac.uk/imaging/MniTalairach)" ;
-                             
                              prov:definition "Coordinate system defined by the \"stereotaxic average of 27 T1-weighted MRI scans of the same individual\"." ;
                              
-                             rdfs:comment "FIXME. This definition needs to be re-worked and reviewed." ;
+                             rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/Colin27Highres" ;
+                             
+                             rdfs:comment "used in SPM96 (cf. http://imaging.mrc-cbu.cam.ac.uk/imaging/MniTalairach)" ,
+                                          "FIXME. This definition needs to be re-worked and reviewed." ;
                              
                              obo:IAO_0000114 obo:IAO_0000120 .
 
@@ -2770,11 +2774,11 @@ nidm:Icbm452Warp5CoordinateSystem rdf:type nidm:MNICoordinateSystem ,
 nidm:IcbmMni152LinearCoordinateSystem rdf:type nidm:MNICoordinateSystem ,
                                                owl:NamedIndividual ;
                                       
-                                      prov:definition "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, linearly transformed to Talairach space\"." ;
-                                      
                                       rdfs:comment "used in SPM99 to SPM8 (cf. http://imaging.mrc-cbu.cam.ac.uk/imaging/MniTalairach and spm8/spm_templates.man)" ;
                                       
                                       rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152Lin" ;
+                                      
+                                      prov:definition "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, linearly transformed to Talairach space\"." ;
                                       
                                       obo:IAO_0000114 obo:IAO_0000120 .
 
@@ -2785,9 +2789,9 @@ nidm:IcbmMni152LinearCoordinateSystem rdf:type nidm:MNICoordinateSystem ,
 nidm:IcbmMni152NonLinear2009aAsymmetricCoordinateSystem rdf:type nidm:MNICoordinateSystem ,
                                                                  owl:NamedIndividual ;
                                                         
-                                                        rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009" ;
-                                                        
                                                         prov:definition "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." ;
+                                                        
+                                                        rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009" ;
                                                         
                                                         obo:IAO_0000114 obo:IAO_0000120 .
 
@@ -2798,9 +2802,9 @@ nidm:IcbmMni152NonLinear2009aAsymmetricCoordinateSystem rdf:type nidm:MNICoordin
 nidm:IcbmMni152NonLinear2009aSymmetricCoordinateSystem rdf:type nidm:MNICoordinateSystem ,
                                                                 owl:NamedIndividual ;
                                                        
-                                                       rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009" ;
-                                                       
                                                        prov:definition "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." ;
+                                                       
+                                                       rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009" ;
                                                        
                                                        obo:IAO_0000114 obo:IAO_0000120 .
 
@@ -2837,11 +2841,11 @@ nidm:IcbmMni152NonLinear2009bSymmetricCoordinateSystem rdf:type nidm:MNICoordina
 nidm:IcbmMni152NonLinear2009cAsymmetricCoordinateSystem rdf:type nidm:MNICoordinateSystem ,
                                                                  owl:NamedIndividual ;
                                                         
-                                                        rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009" ;
+                                                        rdfs:comment "Used in DARTEL toolbox in SPM12b (cf. spm12b/spm_templates.man)" ;
                                                         
                                                         prov:definition "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." ;
                                                         
-                                                        rdfs:comment "Used in DARTEL toolbox in SPM12b (cf. spm12b/spm_templates.man)" ;
+                                                        rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009" ;
                                                         
                                                         obo:IAO_0000114 obo:IAO_0000120 .
 
@@ -2867,9 +2871,9 @@ nidm:IcbmMni152NonLinear6thGenerationCoordinateSystem rdf:type nidm:MNICoordinat
                                                       
                                                       rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin6"^^xsd:anyURI ;
                                                       
-                                                      prov:definition "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, linearly and non-linearly (6 iterations) transformed to form a symmetric model in Talairach space\"" ;
-                                                      
                                                       rdfs:comment "Used in FSL (cf. http://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Atlases)" ;
+                                                      
+                                                      prov:definition "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, linearly and non-linearly (6 iterations) transformed to form a symmetric model in Talairach space\"" ;
                                                       
                                                       obo:IAO_0000114 obo:IAO_0000120 .
 
@@ -2882,9 +2886,9 @@ nidm:Ixi549CoordinateSystem rdf:type nidm:MNICoordinateSystem ,
                             
                             prov:definition "Coordinate system defined by the average of the \"549 [...] subjects from the IXI dataset\" linearly transformed to ICBM MNI 452." ;
                             
-                            rdfs:comment "Used in SPM12b (cf. spm12b/spm_templates.man)" ;
-                            
                             rdfs:seeAlso "http://biomedic.doc.ic.ac.uk/brain-development/index.php?n=Main.Datasets" ;
+                            
+                            rdfs:comment "Used in SPM12b (cf. spm12b/spm_templates.man)" ;
                             
                             obo:IAO_0000114 obo:IAO_0000120 .
 
@@ -2902,14 +2906,15 @@ nidm:Mni305CoordinateSystem rdf:type nidm:MNICoordinateSystem ,
                             obo:IAO_0000114 obo:IAO_0000120 .
 
 
+
 ###  http://www.incf.org/ns/nidash/nidm#pixel4connected
 
 nidm:pixel4connected rdf:type nidm:PixelConnectivityCriterion ,
                               owl:NamedIndividual ;
                      
-                     prov:definition "A pair of pixels are 4-Connected if they share an edge." ;
-                     
                      obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/201." ;
+                     
+                     prov:definition "A pair of pixels are 4-Connected if they share an edge." ;
                      
                      obo:IAO_0000114 obo:IAO_0000122 .
 
@@ -2920,9 +2925,9 @@ nidm:pixel4connected rdf:type nidm:PixelConnectivityCriterion ,
 nidm:pixel8connected rdf:type nidm:PixelConnectivityCriterion ,
                               owl:NamedIndividual ;
                      
-                     obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/201." ;
-                     
                      prov:definition "A pair of pixels are 8-Connected if they share an edge or corner." ;
+                     
+                     obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/201." ;
                      
                      obo:IAO_0000114 obo:IAO_0000122 .
 
@@ -2933,9 +2938,9 @@ nidm:pixel8connected rdf:type nidm:PixelConnectivityCriterion ,
 nidm:voxel18connected rdf:type nidm:VoxelConnectivityCriterion ,
                                owl:NamedIndividual ;
                       
-                      obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/201." ;
-                      
                       prov:definition "A pair of voxels are 18-Connected if they share a face or edge." ;
+                      
+                      obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/201." ;
                       
                       obo:IAO_0000114 obo:IAO_0000122 .
 
@@ -2959,9 +2964,9 @@ nidm:voxel26connected rdf:type nidm:VoxelConnectivityCriterion ,
 nidm:voxel6connected rdf:type nidm:VoxelConnectivityCriterion ,
                               owl:NamedIndividual ;
                      
-                     obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/201." ;
-                     
                      prov:definition "A pair of voxels are 6-Connected if they share a face." ;
+                     
+                     obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/201." ;
                      
                      obo:IAO_0000114 obo:IAO_0000122 .
 


### PR DESCRIPTION
Following #186, here are some suggested definitions: 

**PeakDefinitionCriteria**: "Set of criterion specified a priori to define the peaks reported after inference (e.g. maximum number of peaks within a cluster, minimum distance between peaks)."
