### PR TITLE
fix: removing remaining curation status as strings

### DIFF
--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -1541,7 +1541,7 @@ fsl:ContrastVarianceMap rdf:type owl:Class ;
                         
                         rdfs:subClassOf nidm:Map ;
                         
-                        nidm:curationStatus "nidm:Uncurated" .
+                        obo:IAO_0000114 obo:IAO_0000124 .
 
 
 
@@ -2071,6 +2071,7 @@ nidm:HeightThreshold rdf:type owl:Class ;
     nidm:pValueFWER = \"0.05\" %% xsd:float])""" ;
                      
                      obo:IAO_0000114 obo:IAO_0000125 .
+
 
 
 ###  http://www.incf.org/ns/nidash/nidm#Image
@@ -2699,12 +2700,11 @@ prov:SoftwareAgent rdf:type owl:Class ;
 #
 #################################################################
 
+
 ###  http://www.incf.org/ns/nidash/nidm#Colin27CoordinateSystem
 
 nidm:Colin27CoordinateSystem rdf:type nidm:StandardizedCoordinateSystem ,
                                       owl:NamedIndividual ;
-                             
-                             nidm:curationStatus "nidm:MetadataIncomplete" ;
                              
                              rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/Colin27Highres" ;
                              
@@ -2712,7 +2712,9 @@ nidm:Colin27CoordinateSystem rdf:type nidm:StandardizedCoordinateSystem ,
                              
                              prov:definition "Coordinate system defined by the \"stereotaxic average of 27 T1-weighted MRI scans of the same individual\"." ;
                              
-                             rdfs:comment "FIXME. This definition needs to be re-worked and reviewed." .
+                             rdfs:comment "FIXME. This definition needs to be re-worked and reviewed." ;
+                             
+                             obo:IAO_0000114 obo:IAO_0000123 .
 
 
 
@@ -2725,7 +2727,7 @@ nidm:Icbm452AirCoordinateSystem rdf:type nidm:MNICoordinateSystem ,
                                 
                                 prov:definition "Coordinate system defined by the \"average of 452 T1-weighted MRIs of normal young adult brains\" with \"linear transforms of the subjects into the atlas space using a 12-parameter affine transformation\"" ;
                                 
-                                nidm:curationStatus "nidm:MetadataIncomplete" .
+                                obo:IAO_0000114 obo:IAO_0000123 .
 
 
 
@@ -2738,7 +2740,7 @@ nidm:Icbm452Warp5CoordinateSystem rdf:type nidm:MNICoordinateSystem ,
                                   
                                   prov:definition "Coordinate system defined by the \"average of 452 T1-weighted MRIs of normal young adult brains\" \"based on a 5th order polynomial transformation into the atlas space\"" ;
                                   
-                                  nidm:curationStatus "nidm:MetadataIncomplete" .
+                                  obo:IAO_0000114 obo:IAO_0000123 .
 
 
 
@@ -2749,11 +2751,11 @@ nidm:IcbmMni152LinearCoordinateSystem rdf:type nidm:MNICoordinateSystem ,
                                       
                                       prov:definition "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, linearly transformed to Talairach space\"." ;
                                       
-                                      nidm:curationStatus "nidm:MetadataIncomplete" ;
-                                      
                                       rdfs:comment "used in SPM99 to SPM8 (cf. http://imaging.mrc-cbu.cam.ac.uk/imaging/MniTalairach and spm8/spm_templates.man)" ;
                                       
-                                      rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152Lin" .
+                                      rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152Lin" ;
+                                      
+                                      obo:IAO_0000114 obo:IAO_0000123 .
 
 
 
@@ -2764,9 +2766,9 @@ nidm:IcbmMni152NonLinear2009aAsymmetricCoordinateSystem rdf:type nidm:MNICoordin
                                                         
                                                         rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009" ;
                                                         
-                                                        nidm:curationStatus "nidm:MetadataIncomplete" ;
+                                                        prov:definition "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." ;
                                                         
-                                                        prov:definition "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." .
+                                                        obo:IAO_0000114 obo:IAO_0000123 .
 
 
 
@@ -2775,11 +2777,11 @@ nidm:IcbmMni152NonLinear2009aAsymmetricCoordinateSystem rdf:type nidm:MNICoordin
 nidm:IcbmMni152NonLinear2009aSymmetricCoordinateSystem rdf:type nidm:MNICoordinateSystem ,
                                                                 owl:NamedIndividual ;
                                                        
-                                                       nidm:curationStatus "nidm:MetadataIncomplete" ;
-                                                       
                                                        rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009" ;
                                                        
-                                                       prov:definition "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." .
+                                                       prov:definition "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." ;
+                                                       
+                                                       obo:IAO_0000114 obo:IAO_0000123 .
 
 
 
@@ -2788,11 +2790,11 @@ nidm:IcbmMni152NonLinear2009aSymmetricCoordinateSystem rdf:type nidm:MNICoordina
 nidm:IcbmMni152NonLinear2009bAsymmetricCoordinateSystem rdf:type nidm:MNICoordinateSystem ,
                                                                  owl:NamedIndividual ;
                                                         
-                                                        nidm:curationStatus "nidm:MetadataIncomplete" ;
-                                                        
                                                         rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009" ;
                                                         
-                                                        prov:definition "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." .
+                                                        prov:definition "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." ;
+                                                        
+                                                        obo:IAO_0000114 obo:IAO_0000123 .
 
 
 
@@ -2805,7 +2807,7 @@ nidm:IcbmMni152NonLinear2009bSymmetricCoordinateSystem rdf:type nidm:MNICoordina
                                                        
                                                        rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009" ;
                                                        
-                                                       nidm:curationStatus "nidm:MetadataIncomplete" .
+                                                       obo:IAO_0000114 obo:IAO_0000123 .
 
 
 
@@ -2816,11 +2818,11 @@ nidm:IcbmMni152NonLinear2009cAsymmetricCoordinateSystem rdf:type nidm:MNICoordin
                                                         
                                                         rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009" ;
                                                         
-                                                        nidm:curationStatus "nidm:MetadataIncomplete" ;
-                                                        
                                                         prov:definition "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." ;
                                                         
-                                                        rdfs:comment "Used in DARTEL toolbox in SPM12b (cf. spm12b/spm_templates.man)" .
+                                                        rdfs:comment "Used in DARTEL toolbox in SPM12b (cf. spm12b/spm_templates.man)" ;
+                                                        
+                                                        obo:IAO_0000114 obo:IAO_0000123 .
 
 
 
@@ -2833,7 +2835,7 @@ nidm:IcbmMni152NonLinear2009cSymmetricCoordinateSystem rdf:type nidm:MNICoordina
                                                        
                                                        prov:definition "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." ;
                                                        
-                                                       nidm:curationStatus "nidm:MetadataIncomplete" .
+                                                       obo:IAO_0000114 obo:IAO_0000123 .
 
 
 
@@ -2844,11 +2846,11 @@ nidm:IcbmMni152NonLinear6thGenerationCoordinateSystem rdf:type nidm:MNICoordinat
                                                       
                                                       rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin6"^^xsd:anyURI ;
                                                       
-                                                      nidm:curationStatus "nidm:MetadataIncomplete" ;
-                                                      
                                                       prov:definition "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, linearly and non-linearly (6 iterations) transformed to form a symmetric model in Talairach space\"" ;
                                                       
-                                                      rdfs:comment "Used in FSL (cf. http://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Atlases)" .
+                                                      rdfs:comment "Used in FSL (cf. http://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Atlases)" ;
+                                                      
+                                                      obo:IAO_0000114 obo:IAO_0000123 .
 
 
 
@@ -2859,11 +2861,11 @@ nidm:Ixi549CoordinateSystem rdf:type nidm:MNICoordinateSystem ,
                             
                             prov:definition "Coordinate system defined by the average of the \"549 [...] subjects from the IXI dataset\" linearly transformed to ICBM MNI 452." ;
                             
-                            nidm:curationStatus "nidm:MetadataIncomplete" ;
-                            
                             rdfs:comment "Used in SPM12b (cf. spm12b/spm_templates.man)" ;
                             
-                            rdfs:seeAlso "http://biomedic.doc.ic.ac.uk/brain-development/index.php?n=Main.Datasets" .
+                            rdfs:seeAlso "http://biomedic.doc.ic.ac.uk/brain-development/index.php?n=Main.Datasets" ;
+                            
+                            obo:IAO_0000114 obo:IAO_0000123 .
 
 
 
@@ -2874,9 +2876,9 @@ nidm:Mni305CoordinateSystem rdf:type nidm:MNICoordinateSystem ,
                             
                             rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/MNI305" ;
                             
-                            nidm:curationStatus "nidm:MetadataIncomplete" ;
+                            prov:definition "Coordinate system defined by the \"average of 305 T1-weighted MRI scans, linearly transformed to Talairach space\"." ;
                             
-                            prov:definition "Coordinate system defined by the \"average of 305 T1-weighted MRI scans, linearly transformed to Talairach space\"." .
+                            obo:IAO_0000114 obo:IAO_0000123 .
 
 
 


### PR DESCRIPTION
Following re-use of OBI terms for curation status in #199, #202 and #204 had not been updated before merge.

This commit remove remaining manually defined curation status newly introduced in #202 and #204.
