### PR TITLE
Definition of "Inference"

### DIFF
--- a/nidm/nidm-results/terms/README.md
+++ b/nidm/nidm-results/terms/README.md
@@ -37,10 +37,6 @@
 </tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
-    <td><b>nidm:Inference: </b>Statistical inference is a process of drawing conclusions following data analysis using statistical methods (statistical tests) and evaluating whether to reject or accept null hypothesis. (definition from STATO).</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
     <td><b>nidm:ResidualMeanSquaresMap: </b>A map whose value at each location is the residual of the mean squares fit to the data. (editor: KH)</td>
 </tr>
 <tr>

--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -1669,8 +1669,8 @@ nidm:ConnectivityCriterion3D rdf:type owl:Class ;
                              
                              owl:equivalentClass [ rdf:type owl:Class ;
                                                    owl:oneOf ( nidm:connected6In3D
-                                                               nidm:connected18In3D
                                                                nidm:connected26In3D
+                                                               nidm:connected18In3D
                                                              )
                                                  ] ;
                              
@@ -2112,7 +2112,7 @@ nidm:Inference rdf:type owl:Class ;
                
                owl:sameAs "http://purl.obolibrary.org/obo/STATO_0000299" ;
                
-               obo:IAO_0000114 obo:IAO_0000125 .
+               obo:IAO_0000114 obo:IAO_0000122 .
 
 
 


### PR DESCRIPTION
**Term**: `Inference`
**Definition**: "The process of inferring the excursion set from a statistical map.".
**Original comment**: [link](https://docs.google.com/spreadsheets/d/16pC2cDsdxlzv2CzlNMtStqt5-xHwDEsU6MjZVxWhrE4/edit?disco=AAAAAGsYjh0)
**Current link**:  [nidm-results.owl/Inference](https://github.com/incf-nidash/nidm/blob/master/nidm/nidm-results/nidm-results.owl#L2013-L2026)

---

@khelm `20:20 9 Apr`
Can this be defined without the word inferring?

@nicholsn `21:24 18 Apr`
Also, Inference is a generic concept and the definition should reflect that. Why not use the definition from NCBI? (http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C75591)

"The process by which conclusions are derived from stated facts by the application of logical rules."
Show less

@JessicaTurner `20:46 22 Apr`
Well now, we're in nidm, and here the inference refers to a particular kind of inference, not just any old inference. I think it could be helpful to be specific, in this context.

@cmaumet `16:44 23 Apr`
I agree with Jessica, the NCBI definition seems a bit too broad in our context. 

What we may need is a definition of "statistical inference". I remember we mentioned a statistics ontology before but could not find it again in the minutes...

@nicholsn `19:22 24 Apr`
The stats ontology is under development and called STATO (https://github.com/ISA-tools/stato)... I requested that they add "Design Matrix" and "Contrast" - you can follow that discussion here: https://github.com/ISA-tools/stato/issues/9#issuecomment-41302654

@nicholsn `20:07 24 Apr`
Also requested "Statistical Inference": https://github.com/ISA-tools/stato/issues/12

@cmaumet `12:38 25 Apr`
Great! Nolan: thanks a lot for the reference and for requesting the new terms. I have added a few pointers to this ontology (e.g. "model parameter estimate") as we could probably re-use a couple of their definitions.

@nicholsn `18:52 8 May`
FYI, this is now incorporated. Please take a look at: STATO_0000299: statistical inference
