### PR TITLE
Refining the definition of FWHM, and defining FSL's equivalent measure

### DIFF
--- a/nidm/nidm-results/terms/README.md
+++ b/nidm/nidm-results/terms/README.md
@@ -245,27 +245,6 @@ Thank you in advance for taking part in NIDM-Results term curation!
     <td>nidm:NIDM_0000068 </td>
     <td></td>
 </tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/orange.png?raw=true"/>  </td>
-    <td>Under discussion at: <a href="https://github.com/incf-nidash/nidm/pull/214">#214</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q=noiseFWHMInUnits"> [more] </a></td>
-    <td><b>spm:noiseFWHMInUnits: </b>Estimated Full Width at Half Maximum of the noise distribution in world units</td>
-    <td>nidm:NIDM_0000068 </td>
-    <td>xsd:string </td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/orange.png?raw=true"/>  </td>
-    <td>Under discussion at: <a href="https://github.com/incf-nidash/nidm/pull/214">#214</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q=noiseFWHMInVertices"> [more] </a></td>
-    <td><b>spm:noiseFWHMInVertices: </b>Estimated Full Width at Half Maximum of the noise distribution in world vertices</td>
-    <td>nidm:NIDM_0000054 </td>
-    <td></td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/orange.png?raw=true"/>  </td>
-    <td>Under discussion at: <a href="https://github.com/incf-nidash/nidm/pull/214">#214</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q=noiseFWHMInVoxels"> [more] </a></td>
-    <td><b>spm:noiseFWHMInVoxels: </b>Estimated Full Width at Half Maximum of the noise distribution in voxels</td>
-    <td>nidm:NIDM_0000068 </td>
-    <td>xsd:string </td>
-</tr>
 </table><h2>Individuals</h2>
 <table>
 <tr><th>Curation Status</th><th>Issue/PR</th><th>Term</th><th>Type</th></tr>

--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -1461,15 +1461,16 @@ spm:driftCutoffPeriod rdf:type owl:DatatypeProperty ;
 
 spm:noiseFWHMInUnits rdf:type owl:DatatypeProperty ;
                      
-                     obo:IAO_0000116 "Under discussion at: https://github.com/incf-nidash/nidm/pull/214" ;
+                     rdfs:label "noise FWHM In Units" ;
                      
                      rdfs:comment "Range: Vector of positive floats." ;
                      
                      obo:IAO_0000112 "[8.87, 8.89, 7.83]" ;
                      
-                     obo:IAO_0000115 "Estimated Full Width at Half Maximum of the noise distribution in world units." ;
+                     obo:IAO_0000115 "Estimated Full Width at Half Maximum of the spatial smoothness of the noise process in world units (e.g. mm^2 or mm^3, in subject or atlas space)." ;
+                     obo:IAO_0000116 "Discussed at: https://github.com/incf-nidash/nidm/pull/214" ;
                      
-                     obo:IAO_0000114 obo:IAO_0000120 ;
+                     obo:IAO_0000114 obo:IAO_0000122 ;
                      
                      rdfs:domain nidm:NIDM_0000068 ;
                      
@@ -1483,15 +1484,17 @@ spm:noiseFWHMInUnits rdf:type owl:DatatypeProperty ;
 
 spm:noiseFWHMInVertices rdf:type owl:DatatypeProperty ;
                         
+                        rdfs:label "noise FWHM In Vertices" ;
+                        
                         rdfs:comment "Range: Vector of positive floats." ;
                         
-                        obo:IAO_0000115 "Estimated Full Width at Half Maximum of the noise distribution in world vertices." ;
+                        obo:IAO_0000115 "Estimated Full Width at Half Maximum of the spatial smoothness of the noise process in vertices." ;
                         
-                        obo:IAO_0000116 "Under discussion at: https://github.com/incf-nidash/nidm/pull/214" ;
+                        obo:IAO_0000116 "Discussed at: https://github.com/incf-nidash/nidm/pull/214" ;
                         
                         obo:IAO_0000112 "[2.95, 2.96, 2.61]" ;
                         
-                        obo:IAO_0000114 obo:IAO_0000120 ;
+                        obo:IAO_0000114 obo:IAO_0000122 ;
                         
                         rdfs:domain nidm:NIDM_0000054 ;
                         
@@ -1504,16 +1507,19 @@ spm:noiseFWHMInVertices rdf:type owl:DatatypeProperty ;
 spm:noiseFWHMInVoxels rdf:type owl:DatatypeProperty ;
                       
                       obo:IAO_0000112 "[3.7 3.7 3.1]" ;
+                      rdfs:label "noise FWHM In Voxels" ;
                       
-                      obo:IAO_0000115 "Estimated Full Width at Half Maximum of the noise distribution in voxels." ;
+                      obo:IAO_0000115 "Estimated Full Width at Half Maximum of the spatial smoothness of the noise process in voxels." ;
                       
-                      obo:IAO_0000116 "Under discussion at: https://github.com/incf-nidash/nidm/pull/214" ;
                       
                       rdfs:seeAlso "Synonyms of or close match with nidm:NoiseFWHM" ;
                       
                       rdfs:comment "Range: Vector of positive floats." ;
                       
-                      obo:IAO_0000114 obo:IAO_0000120 ;
+                      obo:IAO_0000116 "Discussed at: https://github.com/incf-nidash/nidm/pull/214" ;
+                      
+                      
+                      obo:IAO_0000114 obo:IAO_0000122 ;
                       
                       rdfs:domain nidm:NIDM_0000068 ;
                       


### PR DESCRIPTION
Following discussions with @cmaumet, motivated by development of the FSL results model, we realised that our term definitions for noise spatial smoothness (aka FWHM) were a bit ropey.  This issue proposes some revisions to the SPM smoothness terms *and* proposes some new terms for the FSL parameters.

The present terms `spm:noiseFWHMInUnits`, `spm:noiseFWHMInVertices` and `spm:noiseFWHMInVoxels` are ambiguous because they make no mention of *space*, and as such one could take FHWM to be a description of the univariate noise variance!  

Current descriptions, as pulled from [terms README](https://github.com/incf-nidash/nidm/blob/master/nidm/nidm-results/terms/README.md): 

* **spm:noiseFWHMInUnits**: Estimated Full Width at Half Maximum of the noise distribution in world units.
* **spm:noiseFWHMInVertices**: Estimated Full Width at Half Maximum of the noise distribution in world vertices.	nidm:MaskMap	
* **spm:noiseFWHMInVoxels**: Estimated Full Width at Half Maximum of the noise distribution in voxels.	

I propose just inserting a "spatial smoothness" for clarity, and changing "distribution" -> "process", since smoothness/FWHM is really about the *spatial* properties of the process, and not the distribution of the process (at a single point, which is how we've mostly otherwise been using "distribution"):

* **spm:noiseFWHMInUnits**: Estimated Full Width at Half Maximum **spatial smoothness of the noise process** in world units.
* **spm:noiseFWHMInVertices**: Estimated Full Width at Half Maximum **spatial smoothness of the noise process** in world vertices.	
* **spm:noiseFWHMInVoxels**: Estimated Full Width at Half Maximum **spatial smoothness of the noise process** in voxels.	


**For FSL**, noise smoothness is never represented, rather only its inversely-related cousin "Determinant Lambda Hat" measure (in LaTeX, this is the essential RFT parameter $|\Lambda|$, its $|\hat{\Lambda}|$ estimator specifically).  For this I propose

* **fsl:noiseRoughnessInVoxels**:  Estimated spatial roughness of the noise process in voxel units, as measured by the determinant of the Lambda matrix (Lambda is the variance-covariance matrix of spatial derivatives of the noise process).

Is this too in the weeds?  It's accurate, though :)
