### PR TITLE
Re-use STATO estimation methods

### DIFF
--- a/doc/content/specs/nidm-experiment_dev.html
+++ b/doc/content/specs/nidm-experiment_dev.html
@@ -213,162 +213,162 @@
         <!-- HERE ------------- Beginning of PROV Entities ------------- -->
         
                         <tr>
-                            <td><a title="nidm:InvestigationProcess">nidm:InvestigationProcess</a>
+                            <td><a title="nidme:InvestigationProcess">nidme:InvestigationProcess</a>
                             </td>
                     
                                 <td rowspan="2" style="text-align: center;">NIDM-Experiment Types<br/>                                 (PROV Activity)</td>
                         
-                                <td><a>nidm:InvestigationProcess</a></td>
+                                <td><a>nidme:InvestigationProcess</a></td>
                             </tr>
                 
                         <tr>
-                            <td><a title="nidm:ModelSpecification">nidm:ModelSpecification</a>
+                            <td><a title="nidme:ModelSpecification">nidme:ModelSpecification</a>
                             </td>
                     
-                                <td><a>nidm:ModelSpecification</a></td>
+                                <td><a>nidme:ModelSpecification</a></td>
                             </tr>
                 
                         <tr>
-                            <td><a title="nidm:Condition">nidm:Condition</a>
+                            <td><a title="nidme:Condition">nidme:Condition</a>
                             </td>
                     
                                 <td rowspan="6" style="text-align: center;">NIDM-Experiment Types<br/>                                 (PROV Entity)</td>
                         
-                                <td><a>nidm:Condition</a></td>
+                                <td><a>nidme:Condition</a></td>
                             </tr>
                 
                         <tr>
-                            <td><a title="nidm:Contrast">nidm:Contrast</a>
+                            <td><a title="nidme:Contrast">nidme:Contrast</a>
                             </td>
                     
-                                <td><a>nidm:Contrast</a></td>
+                                <td><a>nidme:Contrast</a></td>
                             </tr>
                 
                         <tr>
-                            <td><a title="nidm:Group">nidm:Group</a>
+                            <td><a title="nidme:Group">nidme:Group</a>
                             </td>
                     
-                                <td><a>nidm:Group</a></td>
+                                <td><a>nidme:Group</a></td>
                             </tr>
                 
                         <tr>
-                            <td><a title="nidm:InvestigationCollection">nidm:InvestigationCollection</a>
+                            <td><a title="nidme:InvestigationCollection">nidme:InvestigationCollection</a>
                             </td>
                     
-                                <td><a>nidm:InvestigationCollection</a></td>
+                                <td><a>nidme:InvestigationCollection</a></td>
                             </tr>
                 
                         <tr>
-                            <td><a title="nidm:Model">nidm:Model</a>
+                            <td><a title="nidme:Model">nidme:Model</a>
                             </td>
                     
-                                <td><a>nidm:Model</a></td>
+                                <td><a>nidme:Model</a></td>
                             </tr>
                 
                         <tr>
-                            <td><a title="nidm:Task">nidm:Task</a>
+                            <td><a title="nidme:Task">nidme:Task</a>
                             </td>
                     
-                                <td><a>nidm:Task</a></td>
+                                <td><a>nidme:Task</a></td>
                             </tr>
                 
                 </tbody>
                 </table>
             </div>
-            <!-- nidm:InvestigationProcess -->
-            <section id="section-nidm:InvestigationProcess"> 
-                <h1 label="nidm:InvestigationProcess">nidm:InvestigationProcess</h1>
+            <!-- nidme:InvestigationProcess -->
+            <section id="section-nidme:InvestigationProcess"> 
+                <h1 label="nidme:InvestigationProcess">nidme:InvestigationProcess</h1>
                 <div class="glossary-ref">
-                    A <dfn>nidm:InvestigationProcess</dfn>                    <sup><a title="nidm:InvestigationProcess">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidm:InvestigationProcess</a> is a prov:Activity. 
+                    A <dfn>nidme:InvestigationProcess</dfn>                    <sup><a title="nidme:InvestigationProcess">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidme:InvestigationProcess</a> is a prov:Activity. 
                 </div>
                 <p></p>
-                <div class="attributes" id="attributes-nidm:InvestigationProcess"> A <a>nidm:InvestigationProcess</a> has attributes:
+                <div class="attributes" id="attributes-nidme:InvestigationProcess"> A <a>nidme:InvestigationProcess</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:InvestigationProcess.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:InvestigationProcess.</li>
+                    <li><span class="attribute" id="nidme:InvestigationProcess.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidme:InvestigationProcess.</li>
                       
             </section>
-            <!-- nidm:ModelSpecification -->
-            <section id="section-nidm:ModelSpecification"> 
-                <h1 label="nidm:ModelSpecification">nidm:ModelSpecification</h1>
+            <!-- nidme:ModelSpecification -->
+            <section id="section-nidme:ModelSpecification"> 
+                <h1 label="nidme:ModelSpecification">nidme:ModelSpecification</h1>
                 <div class="glossary-ref">
-                    A <dfn>nidm:ModelSpecification</dfn>                    <sup><a title="nidm:ModelSpecification">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidm:ModelSpecification</a> is a prov:Activity. 
+                    A <dfn>nidme:ModelSpecification</dfn>                    <sup><a title="nidme:ModelSpecification">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidme:ModelSpecification</a> is a prov:Activity. 
                 </div>
                 <p></p>
-                <div class="attributes" id="attributes-nidm:ModelSpecification"> A <a>nidm:ModelSpecification</a> has attributes:
+                <div class="attributes" id="attributes-nidme:ModelSpecification"> A <a>nidme:ModelSpecification</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:ModelSpecification.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:ModelSpecification.</li>
+                    <li><span class="attribute" id="nidme:ModelSpecification.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidme:ModelSpecification.</li>
                       
             </section>
-            <!-- nidm:Condition -->
-            <section id="section-nidm:Condition"> 
-                <h1 label="nidm:Condition">nidm:Condition</h1>
+            <!-- nidme:Condition -->
+            <section id="section-nidme:Condition"> 
+                <h1 label="nidme:Condition">nidme:Condition</h1>
                 <div class="glossary-ref">
-                    A <dfn>nidm:Condition</dfn>                    <sup><a title="nidm:Condition">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidm:Condition</a> is a prov:Entity. 
+                    A <dfn>nidme:Condition</dfn>                    <sup><a title="nidme:Condition">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidme:Condition</a> is a prov:Entity. 
                 </div>
                 <p></p>
-                <div class="attributes" id="attributes-nidm:Condition"> A <a>nidm:Condition</a> has attributes:
+                <div class="attributes" id="attributes-nidme:Condition"> A <a>nidme:Condition</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:Condition.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:Condition.</li>
+                    <li><span class="attribute" id="nidme:Condition.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidme:Condition.</li>
                       
             </section>
-            <!-- nidm:Contrast -->
-            <section id="section-nidm:Contrast"> 
-                <h1 label="nidm:Contrast">nidm:Contrast</h1>
+            <!-- nidme:Contrast -->
+            <section id="section-nidme:Contrast"> 
+                <h1 label="nidme:Contrast">nidme:Contrast</h1>
                 <div class="glossary-ref">
-                    A <dfn>nidm:Contrast</dfn>                    <sup><a title="nidm:Contrast">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidm:Contrast</a> is a prov:Entity. 
+                    A <dfn>nidme:Contrast</dfn>                    <sup><a title="nidme:Contrast">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidme:Contrast</a> is a prov:Entity. 
                 </div>
                 <p></p>
-                <div class="attributes" id="attributes-nidm:Contrast"> A <a>nidm:Contrast</a> has attributes:
+                <div class="attributes" id="attributes-nidme:Contrast"> A <a>nidme:Contrast</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:Contrast.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:Contrast.</li>
+                    <li><span class="attribute" id="nidme:Contrast.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidme:Contrast.</li>
                       
             </section>
-            <!-- nidm:Group -->
-            <section id="section-nidm:Group"> 
-                <h1 label="nidm:Group">nidm:Group</h1>
+            <!-- nidme:Group -->
+            <section id="section-nidme:Group"> 
+                <h1 label="nidme:Group">nidme:Group</h1>
                 <div class="glossary-ref">
-                    A <dfn>nidm:Group</dfn>                    <sup><a title="nidm:Group">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidm:Group</a> is a prov:Entity. 
+                    A <dfn>nidme:Group</dfn>                    <sup><a title="nidme:Group">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidme:Group</a> is a prov:Entity. 
                 </div>
                 <p></p>
-                <div class="attributes" id="attributes-nidm:Group"> A <a>nidm:Group</a> has attributes:
+                <div class="attributes" id="attributes-nidme:Group"> A <a>nidme:Group</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:Group.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:Group.</li>
+                    <li><span class="attribute" id="nidme:Group.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidme:Group.</li>
                       
             </section>
-            <!-- nidm:InvestigationCollection -->
-            <section id="section-nidm:InvestigationCollection"> 
-                <h1 label="nidm:InvestigationCollection">nidm:InvestigationCollection</h1>
+            <!-- nidme:InvestigationCollection -->
+            <section id="section-nidme:InvestigationCollection"> 
+                <h1 label="nidme:InvestigationCollection">nidme:InvestigationCollection</h1>
                 <div class="glossary-ref">
-                    A <dfn>nidm:InvestigationCollection</dfn>                    <sup><a title="nidm:InvestigationCollection">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidm:InvestigationCollection</a> is a prov:Entity. 
+                    A <dfn>nidme:InvestigationCollection</dfn>                    <sup><a title="nidme:InvestigationCollection">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidme:InvestigationCollection</a> is a prov:Entity. 
                 </div>
                 <p></p>
-                <div class="attributes" id="attributes-nidm:InvestigationCollection"> A <a>nidm:InvestigationCollection</a> has attributes:
+                <div class="attributes" id="attributes-nidme:InvestigationCollection"> A <a>nidme:InvestigationCollection</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:InvestigationCollection.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:InvestigationCollection.</li>
+                    <li><span class="attribute" id="nidme:InvestigationCollection.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidme:InvestigationCollection.</li>
                       
             </section>
-            <!-- nidm:Model -->
-            <section id="section-nidm:Model"> 
-                <h1 label="nidm:Model">nidm:Model</h1>
+            <!-- nidme:Model -->
+            <section id="section-nidme:Model"> 
+                <h1 label="nidme:Model">nidme:Model</h1>
                 <div class="glossary-ref">
-                    A <dfn>nidm:Model</dfn>                    <sup><a title="nidm:Model">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidm:Model</a> is a prov:Entity. 
+                    A <dfn>nidme:Model</dfn>                    <sup><a title="nidme:Model">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidme:Model</a> is a prov:Entity. 
                 </div>
                 <p></p>
-                <div class="attributes" id="attributes-nidm:Model"> A <a>nidm:Model</a> has attributes:
+                <div class="attributes" id="attributes-nidme:Model"> A <a>nidme:Model</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:Model.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:Model.</li>
+                    <li><span class="attribute" id="nidme:Model.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidme:Model.</li>
                       
             </section>
-            <!-- nidm:Task -->
-            <section id="section-nidm:Task"> 
-                <h1 label="nidm:Task">nidm:Task</h1>
+            <!-- nidme:Task -->
+            <section id="section-nidme:Task"> 
+                <h1 label="nidme:Task">nidme:Task</h1>
                 <div class="glossary-ref">
-                    A <dfn>nidm:Task</dfn>                    <sup><a title="nidm:Task">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidm:Task</a> is a prov:Entity. 
+                    A <dfn>nidme:Task</dfn>                    <sup><a title="nidme:Task">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidme:Task</a> is a prov:Entity. 
                 </div>
                 <p></p>
-                <div class="attributes" id="attributes-nidm:Task"> A <a>nidm:Task</a> has attributes:
+                <div class="attributes" id="attributes-nidme:Task"> A <a>nidme:Task</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:Task.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:Task.</li>
+                    <li><span class="attribute" id="nidme:Task.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidme:Task.</li>
                       
             </section>
             </section>
@@ -386,48 +386,48 @@
         <!-- HERE ------------- Beginning of PROV Entities ------------- -->
         
                         <tr>
-                            <td><a title="nidm:SessionAcquisition">nidm:SessionAcquisition</a>
+                            <td><a title="nidme:SessionAcquisition">nidme:SessionAcquisition</a>
                             </td>
                     
                                 <td rowspan="1" style="text-align: center;">NIDM-Experiment Types<br/>                                 (PROV Activity)</td>
                         
-                                <td><a>nidm:SessionAcquisition</a></td>
+                                <td><a>nidme:SessionAcquisition</a></td>
                             </tr>
                 
                         <tr>
-                            <td><a title="nidm:DataCollection">nidm:DataCollection</a>
+                            <td><a title="nidme:DataCollection">nidme:DataCollection</a>
                             </td>
                     
                                 <td rowspan="1" style="text-align: center;">NIDM-Experiment Types<br/>                                 (PROV Entity)</td>
                         
-                                <td><a>nidm:DataCollection</a></td>
+                                <td><a>nidme:DataCollection</a></td>
                             </tr>
                 
                 </tbody>
                 </table>
             </div>
-            <!-- nidm:SessionAcquisition -->
-            <section id="section-nidm:SessionAcquisition"> 
-                <h1 label="nidm:SessionAcquisition">nidm:SessionAcquisition</h1>
+            <!-- nidme:SessionAcquisition -->
+            <section id="section-nidme:SessionAcquisition"> 
+                <h1 label="nidme:SessionAcquisition">nidme:SessionAcquisition</h1>
                 <div class="glossary-ref">
-                    A <dfn>nidm:SessionAcquisition</dfn>                    <sup><a title="nidm:SessionAcquisition">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidm:SessionAcquisition</a> is a prov:Activity. 
+                    A <dfn>nidme:SessionAcquisition</dfn>                    <sup><a title="nidme:SessionAcquisition">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidme:SessionAcquisition</a> is a prov:Activity. 
                 </div>
                 <p></p>
-                <div class="attributes" id="attributes-nidm:SessionAcquisition"> A <a>nidm:SessionAcquisition</a> has attributes:
+                <div class="attributes" id="attributes-nidme:SessionAcquisition"> A <a>nidme:SessionAcquisition</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:SessionAcquisition.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:SessionAcquisition.</li>
+                    <li><span class="attribute" id="nidme:SessionAcquisition.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidme:SessionAcquisition.</li>
                       
             </section>
-            <!-- nidm:DataCollection -->
-            <section id="section-nidm:DataCollection"> 
-                <h1 label="nidm:DataCollection">nidm:DataCollection</h1>
+            <!-- nidme:DataCollection -->
+            <section id="section-nidme:DataCollection"> 
+                <h1 label="nidme:DataCollection">nidme:DataCollection</h1>
                 <div class="glossary-ref">
-                    A <dfn>nidm:DataCollection</dfn>                    <sup><a title="nidm:DataCollection">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidm:DataCollection</a> is a prov:Entity. 
+                    A <dfn>nidme:DataCollection</dfn>                    <sup><a title="nidme:DataCollection">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidme:DataCollection</a> is a prov:Entity. 
                 </div>
                 <p></p>
-                <div class="attributes" id="attributes-nidm:DataCollection"> A <a>nidm:DataCollection</a> has attributes:
+                <div class="attributes" id="attributes-nidme:DataCollection"> A <a>nidme:DataCollection</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:DataCollection.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:DataCollection.</li>
+                    <li><span class="attribute" id="nidme:DataCollection.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidme:DataCollection.</li>
                       
             </section>
             </section>
@@ -445,138 +445,138 @@
         <!-- HERE ------------- Beginning of PROV Entities ------------- -->
         
                         <tr>
-                            <td><a title="nidm:MRScanner">nidm:MRScanner</a>
+                            <td><a title="nidme:MRScanner">nidme:MRScanner</a>
                             </td>
                     
                                 <td rowspan="2" style="text-align: center;">NIDM-Experiment Types<br/>                                 (PROV Agent)</td>
                         
-                                <td><a>nidm:MRScanner</a></td>
+                                <td><a>nidme:MRScanner</a></td>
                             </tr>
                 
                         <tr>
-                            <td><a title="nidm:PresentationSoftware">nidm:PresentationSoftware</a>
+                            <td><a title="nidme:PresentationSoftware">nidme:PresentationSoftware</a>
                             </td>
                     
-                                <td><a>nidm:PresentationSoftware</a></td>
+                                <td><a>nidme:PresentationSoftware</a></td>
                             </tr>
                 
                         <tr>
-                            <td><a title="nidm:AnatomyImagingAcquisition">nidm:AnatomyImagingAcquisition</a>
+                            <td><a title="nidme:AnatomyImagingAcquisition">nidme:AnatomyImagingAcquisition</a>
                             </td>
                     
                                 <td rowspan="1" style="text-align: center;">NIDM-Experiment Types<br/>                                 (PROV Activity)</td>
                         
-                                <td><a>nidm:AnatomyImagingAcquisition</a></td>
+                                <td><a>nidme:AnatomyImagingAcquisition</a></td>
                             </tr>
                 
                         <tr>
-                            <td><a title="nidm:AnatomicalScan">nidm:AnatomicalScan</a>
+                            <td><a title="nidme:AnatomicalScan">nidme:AnatomicalScan</a>
                             </td>
                     
                                 <td rowspan="3" style="text-align: center;">NIDM-Experiment Types<br/>                                 (PROV Entity)</td>
                         
-                                <td><a>nidm:AnatomicalScan</a></td>
+                                <td><a>nidme:AnatomicalScan</a></td>
                             </tr>
                 
                         <tr>
-                            <td><a title="nidm:BehaviorAndConsitionOnsets">nidm:BehaviorAndConsitionOnsets</a>
+                            <td><a title="nidme:BehaviorAndConsitionOnsets">nidme:BehaviorAndConsitionOnsets</a>
                             </td>
                     
-                                <td><a>nidm:BehaviorAndConsitionOnsets</a></td>
+                                <td><a>nidme:BehaviorAndConsitionOnsets</a></td>
                             </tr>
                 
                         <tr>
-                            <td><a title="nidm:FunctionalScan">nidm:FunctionalScan</a>
+                            <td><a title="nidme:FunctionalScan">nidme:FunctionalScan</a>
                             </td>
                     
-                                <td><a>nidm:FunctionalScan</a></td>
+                                <td><a>nidme:FunctionalScan</a></td>
                             </tr>
                 
                 </tbody>
                 </table>
             </div>
-            <!-- nidm:MRScanner -->
-            <section id="section-nidm:MRScanner"> 
-                <h1 label="nidm:MRScanner">nidm:MRScanner</h1>
+            <!-- nidme:MRScanner -->
+            <section id="section-nidme:MRScanner"> 
+                <h1 label="nidme:MRScanner">nidme:MRScanner</h1>
                 <div class="glossary-ref">
-                    A <dfn>nidm:MRScanner</dfn>                    <sup><a title="nidm:MRScanner">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidm:MRScanner</a> is a prov:Agent. 
+                    A <dfn>nidme:MRScanner</dfn>                    <sup><a title="nidme:MRScanner">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidme:MRScanner</a> is a prov:Agent. 
                 </div>
                 <p></p>
-                <div class="attributes" id="attributes-nidm:MRScanner"> A <a>nidm:MRScanner</a> has attributes:
+                <div class="attributes" id="attributes-nidme:MRScanner"> A <a>nidme:MRScanner</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:MRScanner.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:MRScanner.</li>
+                    <li><span class="attribute" id="nidme:MRScanner.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidme:MRScanner.</li>
                       
             </section>
-            <!-- nidm:PresentationSoftware -->
-            <section id="section-nidm:PresentationSoftware"> 
-                <h1 label="nidm:PresentationSoftware">nidm:PresentationSoftware</h1>
+            <!-- nidme:PresentationSoftware -->
+            <section id="section-nidme:PresentationSoftware"> 
+                <h1 label="nidme:PresentationSoftware">nidme:PresentationSoftware</h1>
                 <div class="glossary-ref">
-                    A <dfn>nidm:PresentationSoftware</dfn>                    <sup><a title="nidm:PresentationSoftware">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidm:PresentationSoftware</a> is a prov:Agent. 
+                    A <dfn>nidme:PresentationSoftware</dfn>                    <sup><a title="nidme:PresentationSoftware">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidme:PresentationSoftware</a> is a prov:Agent. 
                 </div>
                 <p></p>
-                <div class="attributes" id="attributes-nidm:PresentationSoftware"> A <a>nidm:PresentationSoftware</a> has attributes:
+                <div class="attributes" id="attributes-nidme:PresentationSoftware"> A <a>nidme:PresentationSoftware</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:PresentationSoftware.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:PresentationSoftware.</li>
+                    <li><span class="attribute" id="nidme:PresentationSoftware.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidme:PresentationSoftware.</li>
                       
             </section>
-            <!-- nidm:AnatomyImagingAcquisition -->
-            <section id="section-nidm:AnatomyImagingAcquisition"> 
-                <h1 label="nidm:AnatomyImagingAcquisition">nidm:AnatomyImagingAcquisition</h1>
+            <!-- nidme:AnatomyImagingAcquisition -->
+            <section id="section-nidme:AnatomyImagingAcquisition"> 
+                <h1 label="nidme:AnatomyImagingAcquisition">nidme:AnatomyImagingAcquisition</h1>
                 <div class="glossary-ref">
-                    A <dfn>nidm:AnatomyImagingAcquisition</dfn>                    <sup><a title="nidm:AnatomyImagingAcquisition">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidm:AnatomyImagingAcquisition</a> is a prov:Activity. 
+                    A <dfn>nidme:AnatomyImagingAcquisition</dfn>                    <sup><a title="nidme:AnatomyImagingAcquisition">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidme:AnatomyImagingAcquisition</a> is a prov:Activity. 
                 </div>
                 <p></p>
-                <div class="attributes" id="attributes-nidm:AnatomyImagingAcquisition"> A <a>nidm:AnatomyImagingAcquisition</a> has attributes:
+                <div class="attributes" id="attributes-nidme:AnatomyImagingAcquisition"> A <a>nidme:AnatomyImagingAcquisition</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:AnatomyImagingAcquisition.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:AnatomyImagingAcquisition.</li>
+                    <li><span class="attribute" id="nidme:AnatomyImagingAcquisition.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidme:AnatomyImagingAcquisition.</li>
                       
             </section>
-            <!-- nidm:AnatomicalScan -->
-            <section id="section-nidm:AnatomicalScan"> 
-                <h1 label="nidm:AnatomicalScan">nidm:AnatomicalScan</h1>
+            <!-- nidme:AnatomicalScan -->
+            <section id="section-nidme:AnatomicalScan"> 
+                <h1 label="nidme:AnatomicalScan">nidme:AnatomicalScan</h1>
                 <div class="glossary-ref">
-                    A <dfn>nidm:AnatomicalScan</dfn>                    <sup><a title="nidm:AnatomicalScan">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidm:AnatomicalScan</a> is a prov:Entity. 
+                    A <dfn>nidme:AnatomicalScan</dfn>                    <sup><a title="nidme:AnatomicalScan">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidme:AnatomicalScan</a> is a prov:Entity. 
                 </div>
                 <p></p>
-                <div class="attributes" id="attributes-nidm:AnatomicalScan"> A <a>nidm:AnatomicalScan</a> has attributes:
+                <div class="attributes" id="attributes-nidme:AnatomicalScan"> A <a>nidme:AnatomicalScan</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:AnatomicalScan.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:AnatomicalScan.</li>
+                    <li><span class="attribute" id="nidme:AnatomicalScan.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidme:AnatomicalScan.</li>
                       
             </section>
-            <!-- nidm:BehaviorAndConsitionOnsets -->
-            <section id="section-nidm:BehaviorAndConsitionOnsets"> 
-                <h1 label="nidm:BehaviorAndConsitionOnsets">nidm:BehaviorAndConsitionOnsets</h1>
+            <!-- nidme:BehaviorAndConsitionOnsets -->
+            <section id="section-nidme:BehaviorAndConsitionOnsets"> 
+                <h1 label="nidme:BehaviorAndConsitionOnsets">nidme:BehaviorAndConsitionOnsets</h1>
                 <div class="glossary-ref">
-                    A <dfn>nidm:BehaviorAndConsitionOnsets</dfn>                    <sup><a title="nidm:BehaviorAndConsitionOnsets">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidm:BehaviorAndConsitionOnsets</a> is a prov:Entity. 
+                    A <dfn>nidme:BehaviorAndConsitionOnsets</dfn>                    <sup><a title="nidme:BehaviorAndConsitionOnsets">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidme:BehaviorAndConsitionOnsets</a> is a prov:Entity. 
                 </div>
                 <p></p>
-                <div class="attributes" id="attributes-nidm:BehaviorAndConsitionOnsets"> A <a>nidm:BehaviorAndConsitionOnsets</a> has attributes:
+                <div class="attributes" id="attributes-nidme:BehaviorAndConsitionOnsets"> A <a>nidme:BehaviorAndConsitionOnsets</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:BehaviorAndConsitionOnsets.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:BehaviorAndConsitionOnsets.</li>
+                    <li><span class="attribute" id="nidme:BehaviorAndConsitionOnsets.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidme:BehaviorAndConsitionOnsets.</li>
                       
             </section>
-            <!-- nidm:FunctionalScan -->
-            <section id="section-nidm:FunctionalScan"> 
-                <h1 label="nidm:FunctionalScan">nidm:FunctionalScan</h1>
+            <!-- nidme:FunctionalScan -->
+            <section id="section-nidme:FunctionalScan"> 
+                <h1 label="nidme:FunctionalScan">nidme:FunctionalScan</h1>
                 <div class="glossary-ref">
-                    A <dfn>nidm:FunctionalScan</dfn>                    <sup><a title="nidm:FunctionalScan">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidm:FunctionalScan</a> is a prov:Entity. 
+                    A <dfn>nidme:FunctionalScan</dfn>                    <sup><a title="nidme:FunctionalScan">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidme:FunctionalScan</a> is a prov:Entity. 
                 </div>
                 <p></p>
-                <div class="attributes" id="attributes-nidm:FunctionalScan"> A <a>nidm:FunctionalScan</a> has attributes:
+                <div class="attributes" id="attributes-nidme:FunctionalScan"> A <a>nidme:FunctionalScan</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:FunctionalScan.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:FunctionalScan.</li>
+                    <li><span class="attribute" id="nidme:FunctionalScan.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidme:FunctionalScan.</li>
                       
             </section>
-            <!-- nidm:TaskBasedImagingAcquisition -->
-            <section id="section-nidm:TaskBasedImagingAcquisition"> 
-                <h1 label="nidm:TaskBasedImagingAcquisition">nidm:TaskBasedImagingAcquisition</h1>
+            <!-- nidme:TaskBasedImagingAcquisition -->
+            <section id="section-nidme:TaskBasedImagingAcquisition"> 
+                <h1 label="nidme:TaskBasedImagingAcquisition">nidme:TaskBasedImagingAcquisition</h1>
                 <div class="glossary-ref">
-                    A <dfn>nidm:TaskBasedImagingAcquisition</dfn>                    <sup><a title="nidm:TaskBasedImagingAcquisition">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidm:TaskBasedImagingAcquisition</a> is. 
+                    A <dfn>nidme:TaskBasedImagingAcquisition</dfn>                    <sup><a title="nidme:TaskBasedImagingAcquisition">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidme:TaskBasedImagingAcquisition</a> is. 
                 </div>
                 <p></p>
-                <div class="attributes" id="attributes-nidm:TaskBasedImagingAcquisition"> A <a>nidm:TaskBasedImagingAcquisition</a> has attributes:
+                <div class="attributes" id="attributes-nidme:TaskBasedImagingAcquisition"> A <a>nidme:TaskBasedImagingAcquisition</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:TaskBasedImagingAcquisition.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:TaskBasedImagingAcquisition.</li>
+                    <li><span class="attribute" id="nidme:TaskBasedImagingAcquisition.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidme:TaskBasedImagingAcquisition.</li>
                       
             </section>
             </section>
@@ -594,27 +594,27 @@
         <!-- HERE ------------- Beginning of PROV Entities ------------- -->
         
                         <tr>
-                            <td><a title="nidm:'Project Object'">nidm:'Project Object'</a>
+                            <td><a title="nidme:'Project Object'">nidme:'Project Object'</a>
                             </td>
                     
                                 <td rowspan="1" style="text-align: center;">NIDM-Experiment Types<br/>                                 (PROV Entity)</td>
                         
-                                <td><a>nidm:'Project Object'</a></td>
+                                <td><a>nidme:'Project Object'</a></td>
                             </tr>
                 
                 </tbody>
                 </table>
             </div>
-            <!-- nidm:'Project Object' -->
-            <section id="section-nidm:'Project Object'"> 
-                <h1 label="nidm:'Project Object'">nidm:'Project Object'</h1>
+            <!-- nidme:'Project Object' -->
+            <section id="section-nidme:'Project Object'"> 
+                <h1 label="nidme:'Project Object'">nidme:'Project Object'</h1>
                 <div class="glossary-ref">
-                    A <dfn>nidm:'Project Object'</dfn>                    <sup><a title="nidm:'Project Object'">                    <span class="diamond">&#9826;</span></a></sup> is a project object is an entity that represents administrative information about one or more studies. <a>nidm:'Project Object'</a> is a prov:Entity. 
+                    A <dfn>nidme:'Project Object'</dfn>                    <sup><a title="nidme:'Project Object'">                    <span class="diamond">&#9826;</span></a></sup> is a project object is an entity that represents administrative information about one or more studies. <a>nidme:'Project Object'</a> is a prov:Entity. 
                 </div>
                 <p></p>
-                <div class="attributes" id="attributes-nidm:'Project Object'"> A <a>nidm:'Project Object'</a> has attributes:
+                <div class="attributes" id="attributes-nidme:'Project Object'"> A <a>nidme:'Project Object'</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:'Project Object'.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:'Project Object'.</li>
+                    <li><span class="attribute" id="nidme:'Project Object'.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidme:'Project Object'.</li>
                       
             </section>
             </section>
@@ -632,27 +632,27 @@
         <!-- HERE ------------- Beginning of PROV Entities ------------- -->
         
                         <tr>
-                            <td><a title="nidm:'Study Object'">nidm:'Study Object'</a>
+                            <td><a title="nidme:'Study Object'">nidme:'Study Object'</a>
                             </td>
                     
                                 <td rowspan="1" style="text-align: center;">NIDM-Experiment Types<br/>                                 (PROV Entity)</td>
                         
-                                <td><a>nidm:'Study Object'</a></td>
+                                <td><a>nidme:'Study Object'</a></td>
                             </tr>
                 
                 </tbody>
                 </table>
             </div>
-            <!-- nidm:'Study Object' -->
-            <section id="section-nidm:'Study Object'"> 
-                <h1 label="nidm:'Study Object'">nidm:'Study Object'</h1>
+            <!-- nidme:'Study Object' -->
+            <section id="section-nidme:'Study Object'"> 
+                <h1 label="nidme:'Study Object'">nidme:'Study Object'</h1>
                 <div class="glossary-ref">
-                    A <dfn>nidm:'Study Object'</dfn>                    <sup><a title="nidm:'Study Object'">                    <span class="diamond">&#9826;</span></a></sup> is a study object is an entity that represents one or more acquisitions that take place during the same temporal epoch. <a>nidm:'Study Object'</a> is a prov:Entity. 
+                    A <dfn>nidme:'Study Object'</dfn>                    <sup><a title="nidme:'Study Object'">                    <span class="diamond">&#9826;</span></a></sup> is a study object is an entity that represents one or more acquisitions that take place during the same temporal epoch. <a>nidme:'Study Object'</a> is a prov:Entity. 
                 </div>
                 <p></p>
-                <div class="attributes" id="attributes-nidm:'Study Object'"> A <a>nidm:'Study Object'</a> has attributes:
+                <div class="attributes" id="attributes-nidme:'Study Object'"> A <a>nidme:'Study Object'</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:'Study Object'.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:'Study Object'.</li>
+                    <li><span class="attribute" id="nidme:'Study Object'.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidme:'Study Object'.</li>
                       
             </section>
             </section>
@@ -670,27 +670,27 @@
         <!-- HERE ------------- Beginning of PROV Entities ------------- -->
         
                         <tr>
-                            <td><a title="nidm:'Acquisition Object'">nidm:'Acquisition Object'</a>
+                            <td><a title="nidme:'Acquisition Object'">nidme:'Acquisition Object'</a>
                             </td>
                     
                                 <td rowspan="1" style="text-align: center;">NIDM-Experiment Types<br/>                                 (PROV Entity)</td>
                         
-                                <td><a>nidm:'Acquisition Object'</a></td>
+                                <td><a>nidme:'Acquisition Object'</a></td>
                             </tr>
                 
                 </tbody>
                 </table>
             </div>
-            <!-- nidm:'Acquisition Object' -->
-            <section id="section-nidm:'Acquisition Object'"> 
-                <h1 label="nidm:'Acquisition Object'">nidm:'Acquisition Object'</h1>
+            <!-- nidme:'Acquisition Object' -->
+            <section id="section-nidme:'Acquisition Object'"> 
+                <h1 label="nidme:'Acquisition Object'">nidme:'Acquisition Object'</h1>
                 <div class="glossary-ref">
-                    A <dfn>nidm:'Acquisition Object'</dfn>                    <sup><a title="nidm:'Acquisition Object'">                    <span class="diamond">&#9826;</span></a></sup> is an acquisition object is an entity that represents a single stream of data, where multiple acquisitions in the same study take place simultaneously. For example, fMRI and physiological recordings. <a>nidm:'Acquisition Object'</a> is a prov:Entity. 
+                    A <dfn>nidme:'Acquisition Object'</dfn>                    <sup><a title="nidme:'Acquisition Object'">                    <span class="diamond">&#9826;</span></a></sup> is an acquisition object is an entity that represents a single stream of data, where multiple acquisitions in the same study take place simultaneously. For example, fMRI and physiological recordings. <a>nidme:'Acquisition Object'</a> is a prov:Entity. 
                 </div>
                 <p></p>
-                <div class="attributes" id="attributes-nidm:'Acquisition Object'"> A <a>nidm:'Acquisition Object'</a> has attributes:
+                <div class="attributes" id="attributes-nidme:'Acquisition Object'"> A <a>nidme:'Acquisition Object'</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:'Acquisition Object'.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:'Acquisition Object'.</li>
+                    <li><span class="attribute" id="nidme:'Acquisition Object'.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidme:'Acquisition Object'.</li>
                       
             </section>
             </section>
@@ -708,65 +708,65 @@
         <!-- HERE ------------- Beginning of PROV Entities ------------- -->
         
                         <tr>
-                            <td><a title="nidm:'Baseline Protocol'">nidm:'Baseline Protocol'</a>
+                            <td><a title="nidme:'Baseline Protocol'">nidme:'Baseline Protocol'</a>
                             </td>
                     
                                 <td rowspan="3" style="text-align: center;">NIDM-Experiment Types<br/>                                 (PROV Entity)</td>
                         
-                                <td><a>nidm:'Baseline Protocol'</a></td>
+                                <td><a>nidme:'Baseline Protocol'</a></td>
                             </tr>
                 
                         <tr>
-                            <td><a title="nidm:'Demographics Acquisition Object'">nidm:'Demographics Acquisition Object'</a>
+                            <td><a title="nidme:'Demographics Acquisition Object'">nidme:'Demographics Acquisition Object'</a>
                             </td>
                     
-                                <td><a>nidm:'Demographics Acquisition Object'</a></td>
+                                <td><a>nidme:'Demographics Acquisition Object'</a></td>
                             </tr>
                 
                         <tr>
-                            <td><a title="nidm:'MRI Acquisition Object'">nidm:'MRI Acquisition Object'</a>
+                            <td><a title="nidme:'MRI Acquisition Object'">nidme:'MRI Acquisition Object'</a>
                             </td>
                     
-                                <td><a>nidm:'MRI Acquisition Object'</a></td>
+                                <td><a>nidme:'MRI Acquisition Object'</a></td>
                             </tr>
                 
                 </tbody>
                 </table>
             </div>
-            <!-- nidm:'Baseline Protocol' -->
-            <section id="section-nidm:'Baseline Protocol'"> 
-                <h1 label="nidm:'Baseline Protocol'">nidm:'Baseline Protocol'</h1>
+            <!-- nidme:'Baseline Protocol' -->
+            <section id="section-nidme:'Baseline Protocol'"> 
+                <h1 label="nidme:'Baseline Protocol'">nidme:'Baseline Protocol'</h1>
                 <div class="glossary-ref">
-                    A <dfn>nidm:'Baseline Protocol'</dfn>                    <sup><a title="nidm:'Baseline Protocol'">                    <span class="diamond">&#9826;</span></a></sup> is a baseline protocol is a plan that represents the study design for a given project. <a>nidm:'Baseline Protocol'</a> is a prov:Entity. 
+                    A <dfn>nidme:'Baseline Protocol'</dfn>                    <sup><a title="nidme:'Baseline Protocol'">                    <span class="diamond">&#9826;</span></a></sup> is a baseline protocol is a plan that represents the study design for a given project. <a>nidme:'Baseline Protocol'</a> is a prov:Entity. 
                 </div>
                 <p></p>
-                <div class="attributes" id="attributes-nidm:'Baseline Protocol'"> A <a>nidm:'Baseline Protocol'</a> has attributes:
+                <div class="attributes" id="attributes-nidme:'Baseline Protocol'"> A <a>nidme:'Baseline Protocol'</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:'Baseline Protocol'.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:'Baseline Protocol'.</li>
+                    <li><span class="attribute" id="nidme:'Baseline Protocol'.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidme:'Baseline Protocol'.</li>
                       
             </section>
-            <!-- nidm:'Demographics Acquisition Object' -->
-            <section id="section-nidm:'Demographics Acquisition Object'"> 
-                <h1 label="nidm:'Demographics Acquisition Object'">nidm:'Demographics Acquisition Object'</h1>
+            <!-- nidme:'Demographics Acquisition Object' -->
+            <section id="section-nidme:'Demographics Acquisition Object'"> 
+                <h1 label="nidme:'Demographics Acquisition Object'">nidme:'Demographics Acquisition Object'</h1>
                 <div class="glossary-ref">
-                    A <dfn>nidm:'Demographics Acquisition Object'</dfn>                    <sup><a title="nidm:'Demographics Acquisition Object'">                    <span class="diamond">&#9826;</span></a></sup> is a demographics acquisition object is an entity that represents the demographics information acquired from a person in the participant role. <a>nidm:'Demographics Acquisition Object'</a> is a prov:Entity. 
+                    A <dfn>nidme:'Demographics Acquisition Object'</dfn>                    <sup><a title="nidme:'Demographics Acquisition Object'">                    <span class="diamond">&#9826;</span></a></sup> is a demographics acquisition object is an entity that represents the demographics information acquired from a person in the participant role. <a>nidme:'Demographics Acquisition Object'</a> is a prov:Entity. 
                 </div>
                 <p></p>
-                <div class="attributes" id="attributes-nidm:'Demographics Acquisition Object'"> A <a>nidm:'Demographics Acquisition Object'</a> has attributes:
+                <div class="attributes" id="attributes-nidme:'Demographics Acquisition Object'"> A <a>nidme:'Demographics Acquisition Object'</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:'Demographics Acquisition Object'.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:'Demographics Acquisition Object'.</li>
+                    <li><span class="attribute" id="nidme:'Demographics Acquisition Object'.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidme:'Demographics Acquisition Object'.</li>
                       
             </section>
-            <!-- nidm:'MRI Acquisition Object' -->
-            <section id="section-nidm:'MRI Acquisition Object'"> 
-                <h1 label="nidm:'MRI Acquisition Object'">nidm:'MRI Acquisition Object'</h1>
+            <!-- nidme:'MRI Acquisition Object' -->
+            <section id="section-nidme:'MRI Acquisition Object'"> 
+                <h1 label="nidme:'MRI Acquisition Object'">nidme:'MRI Acquisition Object'</h1>
                 <div class="glossary-ref">
-                    A <dfn>nidm:'MRI Acquisition Object'</dfn>                    <sup><a title="nidm:'MRI Acquisition Object'">                    <span class="diamond">&#9826;</span></a></sup> is an MRI acquisition object represents a specific series or scan during an MRI study. <a>nidm:'MRI Acquisition Object'</a> is a prov:Entity. 
+                    A <dfn>nidme:'MRI Acquisition Object'</dfn>                    <sup><a title="nidme:'MRI Acquisition Object'">                    <span class="diamond">&#9826;</span></a></sup> is an MRI acquisition object represents a specific series or scan during an MRI study. <a>nidme:'MRI Acquisition Object'</a> is a prov:Entity. 
                 </div>
                 <p></p>
-                <div class="attributes" id="attributes-nidm:'MRI Acquisition Object'"> A <a>nidm:'MRI Acquisition Object'</a> has attributes:
+                <div class="attributes" id="attributes-nidme:'MRI Acquisition Object'"> A <a>nidme:'MRI Acquisition Object'</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:'MRI Acquisition Object'.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:'MRI Acquisition Object'.</li>
+                    <li><span class="attribute" id="nidme:'MRI Acquisition Object'.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidme:'MRI Acquisition Object'.</li>
                       
             </section>
             </section></section>

--- a/doc/content/specs/nidm-results_dev.html
+++ b/doc/content/specs/nidm-results_dev.html
@@ -339,10 +339,10 @@
                      
                         <li><span class="attribute" id="nidm:Map.nidm:hasMapHeader">
                         <dfn>nidm:hasMapHeader</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range nidm:MapHeader)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a>nidm:MapHeader</a>)</li> 
                         <li><span class="attribute" id="nidm:Map.nidm:inCoordinateSpace">
                         <dfn>nidm:inCoordinateSpace</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range nidm:CoordinateSpace)</li>
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range <a>nidm:CoordinateSpace</a>)</li>
             <!-- nidm:MapHeader -->
             <section id="section-nidm:MapHeader"> 
                 <h1 label="nidm:MapHeader">nidm:MapHeader</h1>
@@ -368,22 +368,22 @@
                      
                         <li><span class="attribute" id="nidm:CoordinateSpace.nidm:dimensionsInVoxels">
                         <dfn>nidm:dimensionsInVoxels</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> dimensions of some N-dimensional data. (range xsd:string)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> dimensions of some N-dimensional data. (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li> 
                         <li><span class="attribute" id="nidm:CoordinateSpace.nidm:inWorldCoordinateSystem">
                         <dfn>nidm:inWorldCoordinateSystem</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> type of coordinate system. (range nidm:CustomCoordinateSystem, nidm:MNICoordinateSystem, nidm:StandardizedCoordinateSystem, nidm:SubjectCoordinateSystem, nidm:TalairachCoordinateSystem, nidm:WorldCoordinateSystem)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> type of coordinate system. (range <a>nidm:CustomCoordinateSystem</a>, <a>nidm:MNICoordinateSystem</a>, <a>nidm:StandardizedCoordinateSystem</a>, <a>nidm:SubjectCoordinateSystem</a>, <a>nidm:TalairachCoordinateSystem</a> and <a>nidm:WorldCoordinateSystem</a>)</li> 
                         <li><span class="attribute" id="nidm:CoordinateSpace.nidm:numberOfDimensions">
                         <dfn>nidm:numberOfDimensions</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> number of dimensions of a data matrix. (range xsd:positiveInteger)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> number of dimensions of a data matrix. (range <a title="xsd:positiveInteger" href="http://www.w3.org/2001/XMLSchema#positiveInteger">xsd:positiveInteger</a>)</li> 
                         <li><span class="attribute" id="nidm:CoordinateSpace.nidm:voxelSize">
                         <dfn>nidm:voxelSize</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> 3D size of a voxel measured in voxelUnits. (range xsd:string)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> 3D size of a voxel measured in voxelUnits. (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li> 
                         <li><span class="attribute" id="nidm:CoordinateSpace.nidm:voxelToWorldMapping">
                         <dfn>nidm:voxelToWorldMapping</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> homogeneous transformation matrix to map from voxel coordinate system to world coordinate system. (range xsd:string)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> homogeneous transformation matrix to map from voxel coordinate system to world coordinate system. (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li> 
                         <li><span class="attribute" id="nidm:CoordinateSpace.nidm:voxelUnits">
                         <dfn>nidm:voxelUnits</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> units associated with each dimensions of some N-dimensional data. (range xsd:string)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> units associated with each dimensions of some N-dimensional data. (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>niiri:coordinate_space_id_1 a prov:Entity , nidm:CoordinateSpace ;
@@ -565,77 +565,17 @@
                      
                         <li><span class="attribute" id="nidm:ModelParametersEstimation.nidm:withEstimationMethod">
                         <dfn>nidm:withEstimationMethod</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range nidm:EstimationMethod, nidm:GeneralizedLeastSquares, nidm:OrdinaryLeastSquares, nidm:RobustIterativelyReweighedLeastSquares, nidm:WeightedLeastSquares)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a title="obo:STATO_0000119" href="http://purl.obolibrary.org/obo/STATO_0000119">obo:'model parameter estimation'</a>, <a title="obo:STATO_0000370" href="http://purl.obolibrary.org/obo/STATO_0000370">obo:'ordinary least squares estimation'</a>, <a title="obo:STATO_0000371" href="http://purl.obolibrary.org/obo/STATO_0000371">obo:'weighted least squares estimation'</a>, <a title="obo:STATO_0000372" href="http://purl.obolibrary.org/obo/STATO_0000372">obo:'generalized least squares estimation'</a>, <a title="obo:STATO_0000373" href="http://purl.obolibrary.org/obo/STATO_0000373">obo:'iteratively reweighted least squares estimation'</a>, <a title="obo:STATO_0000374" href="http://purl.obolibrary.org/obo/STATO_0000374">obo:'feasible generalized least squares estimation'</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>niiri:model_pe_id prov:used niiri:error_model_id ;
 	a prov:Activity , nidm:ModelParametersEstimation ;
 	rdfs:label "Model parameters estimation" ;
-	nidm:withEstimationMethod nidm:OrdinaryLeastSquares ;
+	nidm:withEstimationMethod obo:STATO_0000370 ; # obo:'ordinary least squares estimation'
 	prov:used niiri:design_matrix_id ;
     prov:used niiri:data_id ;
     prov:used niiri:error_model_id ;
-    prov:wasAssociatedWith niiri:software_id .</pre>
-            <!-- nidm:EstimationMethod -->
-            <section id="section-nidm:EstimationMethod"> 
-                <h1 label="nidm:EstimationMethod">nidm:EstimationMethod</h1>
-                <div class="glossary-ref">
-                    A <dfn>nidm:EstimationMethod</dfn>                    <sup><a title="nidm:EstimationMethod">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidm:EstimationMethod</a> is a prov:Entity. 
-                </div>
-                <p></p>
-                <div class="attributes" id="attributes-nidm:EstimationMethod"> A <a>nidm:EstimationMethod</a> has attributes:
-                <ul>
-                    <li><span class="attribute" id="nidm:EstimationMethod.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:EstimationMethod.</li>
-                      
-            </section>
-            <!-- nidm:GeneralizedLeastSquares -->
-            <section id="section-nidm:GeneralizedLeastSquares"> 
-                <h1 label="nidm:GeneralizedLeastSquares">nidm:GeneralizedLeastSquares</h1>
-                <div class="glossary-ref">
-                    A <dfn>nidm:GeneralizedLeastSquares</dfn>                    <sup><a title="nidm:GeneralizedLeastSquares">                    <span class="diamond">&#9826;</span></a></sup> is fIXME. <a>nidm:GeneralizedLeastSquares</a> is a prov:Entity. 
-                </div>
-                <p></p>
-                <div class="attributes" id="attributes-nidm:GeneralizedLeastSquares"> A <a>nidm:GeneralizedLeastSquares</a> has attributes:
-                <ul>
-                    <li><span class="attribute" id="nidm:GeneralizedLeastSquares.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:GeneralizedLeastSquares.</li>
-                      
-            </section>
-            <!-- nidm:OrdinaryLeastSquares -->
-            <section id="section-nidm:OrdinaryLeastSquares"> 
-                <h1 label="nidm:OrdinaryLeastSquares">nidm:OrdinaryLeastSquares</h1>
-                <div class="glossary-ref">
-                    A <dfn>nidm:OrdinaryLeastSquares</dfn>                    <sup><a title="nidm:OrdinaryLeastSquares">                    <span class="diamond">&#9826;</span></a></sup> is fIXME. <a>nidm:OrdinaryLeastSquares</a> is a prov:Entity. 
-                </div>
-                <p></p>
-                <div class="attributes" id="attributes-nidm:OrdinaryLeastSquares"> A <a>nidm:OrdinaryLeastSquares</a> has attributes:
-                <ul>
-                    <li><span class="attribute" id="nidm:OrdinaryLeastSquares.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:OrdinaryLeastSquares.</li>
-                      
-            </section>
-            <!-- nidm:RobustIterativelyReweighedLeastSquares -->
-            <section id="section-nidm:RobustIterativelyReweighedLeastSquares"> 
-                <h1 label="nidm:RobustIterativelyReweighedLeastSquares">nidm:RobustIterativelyReweighedLeastSquares</h1>
-                <div class="glossary-ref">
-                    A <dfn>nidm:RobustIterativelyReweighedLeastSquares</dfn>                    <sup><a title="nidm:RobustIterativelyReweighedLeastSquares">                    <span class="diamond">&#9826;</span></a></sup> is fIXME. <a>nidm:RobustIterativelyReweighedLeastSquares</a> is a prov:Entity. 
-                </div>
-                <p></p>
-                <div class="attributes" id="attributes-nidm:RobustIterativelyReweighedLeastSquares"> A <a>nidm:RobustIterativelyReweighedLeastSquares</a> has attributes:
-                <ul>
-                    <li><span class="attribute" id="nidm:RobustIterativelyReweighedLeastSquares.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:RobustIterativelyReweighedLeastSquares.</li>
-                      
-            </section>
-            <!-- nidm:WeightedLeastSquares -->
-            <section id="section-nidm:WeightedLeastSquares"> 
-                <h1 label="nidm:WeightedLeastSquares">nidm:WeightedLeastSquares</h1>
-                <div class="glossary-ref">
-                    A <dfn>nidm:WeightedLeastSquares</dfn>                    <sup><a title="nidm:WeightedLeastSquares">                    <span class="diamond">&#9826;</span></a></sup> is fIXME. <a>nidm:WeightedLeastSquares</a> is a prov:Entity. 
-                </div>
-                <p></p>
-                <div class="attributes" id="attributes-nidm:WeightedLeastSquares"> A <a>nidm:WeightedLeastSquares</a> has attributes:
-                <ul>
-                    <li><span class="attribute" id="nidm:WeightedLeastSquares.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:WeightedLeastSquares.</li>
-                      
-            </section>  
+    prov:wasAssociatedWith niiri:software_id .</pre>  
             </section>
             <!-- nidm:CustomMaskMap -->
             <section id="section-nidm:CustomMaskMap"> 
@@ -650,10 +590,10 @@
                      
                         <li><span class="attribute" id="nidm:CustomMaskMap.nidm:hasMapHeader">
                         <a>nidm:hasMapHeader</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range nidm:MapHeader)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a>nidm:MapHeader</a>)</li> 
                         <li><span class="attribute" id="nidm:CustomMaskMap.nidm:inCoordinateSpace">
                         <a>nidm:inCoordinateSpace</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range nidm:CoordinateSpace)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range <a>nidm:CoordinateSpace</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>niiri:mask_id_1 a prov:Entity , nidm:CustomMaskMap ;
@@ -677,10 +617,10 @@
                      
                         <li><span class="attribute" id="nidm:Data.nidm:grandMeanScaling">
                         <dfn>nidm:grandMeanScaling</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> binary flag defining whether the data was scaled. Specifically, "grand mean scaling" refers to multipliciation of every voxel in every scan by a common value.  Grand mean scaling is essential for first-level fMRI, to transform the arbitrary MRI units, but is generally not used with second level analyses. (range xsd:boolean)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> binary flag defining whether the data was scaled. Specifically, "grand mean scaling" refers to multipliciation of every voxel in every scan by a common value.  Grand mean scaling is essential for first-level fMRI, to transform the arbitrary MRI units, but is generally not used with second level analyses. (range <a title="xsd:boolean" href="http://www.w3.org/2001/XMLSchema#boolean">xsd:boolean</a>)</li> 
                         <li><span class="attribute" id="nidm:Data.nidm:targetIntensity">
                         <dfn>nidm:targetIntensity</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> value to which the grand mean of the Data was scaled (applies only if grandMeanScaling is true). (range xsd:float)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> value to which the grand mean of the Data was scaled (applies only if grandMeanScaling is true). (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>niiri:data_id a prov:Entity , nidm:Data , prov:Collection ;
@@ -721,19 +661,19 @@
                      
                         <li><span class="attribute" id="nidm:ErrorModel.nidm:dependenceSpatialModel">
                         <dfn>nidm:dependenceSpatialModel</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range nidm:SpatialModel, nidm:SpatiallyGlobalModel, nidm:SpatiallyLocalModel, nidm:SpatiallyRegularizedModel)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a>nidm:SpatialModel</a>, <a>nidm:SpatiallyGlobalModel</a>, <a>nidm:SpatiallyLocalModel</a> and <a>nidm:SpatiallyRegularizedModel</a>)</li> 
                         <li><span class="attribute" id="nidm:ErrorModel.nidm:errorVarianceHomogeneous">
                         <dfn>nidm:errorVarianceHomogeneous</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a boolean value reflecting how the variance of the error is modeled during parameter estimation; TRUE for constant variance over all observations in the model, FALSE for heterogeneous variance. (range xsd:boolean)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a boolean value reflecting how the variance of the error is modeled during parameter estimation; TRUE for constant variance over all observations in the model, FALSE for heterogeneous variance. (range <a title="xsd:boolean" href="http://www.w3.org/2001/XMLSchema#boolean">xsd:boolean</a>)</li> 
                         <li><span class="attribute" id="nidm:ErrorModel.nidm:hasErrorDependence">
                         <dfn>nidm:hasErrorDependence</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property that associates an ErrorDependence with an ErrorModel. (range nidm:ArbitrarilyCorrelatedError, nidm:CompoundSymmetricError, nidm:ErrorDependence, nidm:ExchangeableError, nidm:IndependentError, nidm:SeriallyCorrelatedError)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property that associates an ErrorDependence with an ErrorModel. (range <a>nidm:ArbitrarilyCorrelatedError</a>, <a>nidm:CompoundSymmetricError</a>, <a>nidm:ErrorDependence</a>, <a>nidm:ExchangeableError</a>, <a>nidm:IndependentError</a> and <a>nidm:SeriallyCorrelatedError</a>)</li> 
                         <li><span class="attribute" id="nidm:ErrorModel.nidm:hasErrorDistribution">
                         <dfn>nidm:hasErrorDistribution</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property that associates an ErrorDistribution with an ErrorModel. (range fsl:BinomialDistribution, fsl:NonParametricSymmetricDistribution, nidm:ErrorDistribution, nidm:GaussianDistribution, nidm:NonParametricDistribution, nidm:PoissonDistribution)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property that associates an ErrorDistribution with an ErrorModel. (range <a>fsl:BinomialDistribution</a>, <a>fsl:NonParametricSymmetricDistribution</a>, <a>nidm:ErrorDistribution</a>, <a>nidm:GaussianDistribution</a>, <a>nidm:NonParametricDistribution</a> and <a>nidm:PoissonDistribution</a>)</li> 
                         <li><span class="attribute" id="nidm:ErrorModel.nidm:varianceSpatialModel">
                         <dfn>nidm:varianceSpatialModel</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range nidm:SpatialModel, nidm:SpatiallyGlobalModel, nidm:SpatiallyLocalModel, nidm:SpatiallyRegularizedModel)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a>nidm:SpatialModel</a>, <a>nidm:SpatiallyGlobalModel</a>, <a>nidm:SpatiallyLocalModel</a> and <a>nidm:SpatiallyRegularizedModel</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>niiri:error_model_id a prov:Entity , nidm:ErrorModel ;
@@ -924,13 +864,13 @@
                      
                         <li><span class="attribute" id="nidm:GrandMeanMap.nidm:hasMapHeader">
                         <a>nidm:hasMapHeader</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range nidm:MapHeader)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a>nidm:MapHeader</a>)</li> 
                         <li><span class="attribute" id="nidm:GrandMeanMap.nidm:inCoordinateSpace">
                         <a>nidm:inCoordinateSpace</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range nidm:CoordinateSpace)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range <a>nidm:CoordinateSpace</a>)</li> 
                         <li><span class="attribute" id="nidm:GrandMeanMap.nidm:maskedMedian">
                         <dfn>nidm:maskedMedian</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> median value considering only in-mask voxels. Useful diagnostic when computed on grand mean image when grandMeanScaling is TRUE, as the median should be close to targetIntensity. (range xsd:float)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> median value considering only in-mask voxels. Useful diagnostic when computed on grand mean image when grandMeanScaling is TRUE, as the median should be close to targetIntensity. (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>niiri:grand_mean_map_id a prov:Entity , nidm:GrandMeanMap ;
@@ -956,10 +896,10 @@
                      
                         <li><span class="attribute" id="nidm:MaskMap.nidm:hasMapHeader">
                         <a>nidm:hasMapHeader</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range nidm:MapHeader)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a>nidm:MapHeader</a>)</li> 
                         <li><span class="attribute" id="nidm:MaskMap.nidm:inCoordinateSpace">
                         <a>nidm:inCoordinateSpace</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range nidm:CoordinateSpace)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range <a>nidm:CoordinateSpace</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>niiri:mask_id_2 a prov:Entity , nidm:MaskMap ;
@@ -984,10 +924,10 @@
                      
                         <li><span class="attribute" id="nidm:ParameterEstimateMap.nidm:hasMapHeader">
                         <a>nidm:hasMapHeader</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range nidm:MapHeader)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a>nidm:MapHeader</a>)</li> 
                         <li><span class="attribute" id="nidm:ParameterEstimateMap.nidm:inCoordinateSpace">
                         <a>nidm:inCoordinateSpace</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range nidm:CoordinateSpace)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range <a>nidm:CoordinateSpace</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>niiri:beta_map_id_1 a prov:Entity , nidm:ParameterEstimateMap ;
@@ -1012,10 +952,10 @@
                      
                         <li><span class="attribute" id="nidm:ResidualMeanSquaresMap.nidm:hasMapHeader">
                         <a>nidm:hasMapHeader</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range nidm:MapHeader)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a>nidm:MapHeader</a>)</li> 
                         <li><span class="attribute" id="nidm:ResidualMeanSquaresMap.nidm:inCoordinateSpace">
                         <a>nidm:inCoordinateSpace</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range nidm:CoordinateSpace)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range <a>nidm:CoordinateSpace</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>niiri:residual_mean_squares_map_id a prov:Entity , nidm:ResidualMeanSquaresMap ;
@@ -1114,13 +1054,13 @@
                      
                         <li><span class="attribute" id="nidm:ContrastMap.nidm:contrastName">
                         <dfn>nidm:contrastName</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> name of the contrast. (range xsd:string)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> name of the contrast. (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li> 
                         <li><span class="attribute" id="nidm:ContrastMap.nidm:hasMapHeader">
                         <a>nidm:hasMapHeader</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range nidm:MapHeader)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a>nidm:MapHeader</a>)</li> 
                         <li><span class="attribute" id="nidm:ContrastMap.nidm:inCoordinateSpace">
                         <a>nidm:inCoordinateSpace</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range nidm:CoordinateSpace)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range <a>nidm:CoordinateSpace</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>niiri:contrast_map_id a prov:Entity , nidm:ContrastMap ;
@@ -1147,10 +1087,10 @@
                      
                         <li><span class="attribute" id="nidm:ContrastStandardErrorMap.nidm:hasMapHeader">
                         <a>nidm:hasMapHeader</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range nidm:MapHeader)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a>nidm:MapHeader</a>)</li> 
                         <li><span class="attribute" id="nidm:ContrastStandardErrorMap.nidm:inCoordinateSpace">
                         <a>nidm:inCoordinateSpace</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range nidm:CoordinateSpace)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range <a>nidm:CoordinateSpace</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>niiri:contrast_standard_error_map_id a prov:Entity , nidm:ContrastStandardErrorMap ;
@@ -1175,10 +1115,10 @@
                      
                         <li><span class="attribute" id="nidm:ContrastWeights.nidm:contrastName">
                         <a>nidm:contrastName</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> name of the contrast. (range xsd:string)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> name of the contrast. (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li> 
                         <li><span class="attribute" id="nidm:ContrastWeights.nidm:statisticType">
                         <dfn>nidm:statisticType</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range nidm:FStatistic, nidm:Statistic, nidm:TStatistic, nidm:ZStatistic)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a>nidm:FStatistic</a>, <a>nidm:Statistic</a>, <a>nidm:TStatistic</a> and <a>nidm:ZStatistic</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>niiri:contrast_id a prov:Entity , nidm:ContrastWeights ;
@@ -1248,22 +1188,22 @@
                      
                         <li><span class="attribute" id="nidm:StatisticMap.nidm:contrastName">
                         <a>nidm:contrastName</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> name of the contrast. (range xsd:string)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> name of the contrast. (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li> 
                         <li><span class="attribute" id="nidm:StatisticMap.nidm:effectDegreesOfFreedom">
                         <dfn>nidm:effectDegreesOfFreedom</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> degrees of freedom of the effect. (range xsd:float)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> degrees of freedom of the effect. (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li> 
                         <li><span class="attribute" id="nidm:StatisticMap.nidm:errorDegreesOfFreedom">
                         <dfn>nidm:errorDegreesOfFreedom</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> degrees of freedom of the error. (range xsd:float)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> degrees of freedom of the error. (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li> 
                         <li><span class="attribute" id="nidm:StatisticMap.nidm:hasMapHeader">
                         <a>nidm:hasMapHeader</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range nidm:MapHeader)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a>nidm:MapHeader</a>)</li> 
                         <li><span class="attribute" id="nidm:StatisticMap.nidm:inCoordinateSpace">
                         <a>nidm:inCoordinateSpace</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range nidm:CoordinateSpace)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range <a>nidm:CoordinateSpace</a>)</li> 
                         <li><span class="attribute" id="nidm:StatisticMap.nidm:statisticType">
                         <a>nidm:statisticType</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range nidm:FStatistic, nidm:Statistic, nidm:TStatistic, nidm:ZStatistic)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a>nidm:FStatistic</a>, <a>nidm:Statistic</a>, <a>nidm:TStatistic</a> and <a>nidm:ZStatistic</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>niiri:statistic_map_id a prov:Entity , nidm:StatisticMap ;
@@ -1411,7 +1351,7 @@
                      
                         <li><span class="attribute" id="nidm:ConjunctionInference.nidm:hasAlternativeHypothesis">
                         <dfn>nidm:hasAlternativeHypothesis</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range nidm:OneTailedTest, nidm:TwoTailedTest)</li>
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a>nidm:OneTailedTest</a> and <a>nidm:TwoTailedTest</a>)</li>
             <!-- nidm:OneTailedTest -->
             <section id="section-nidm:OneTailedTest"> 
                 <h1 label="nidm:OneTailedTest">nidm:OneTailedTest</h1>
@@ -1450,7 +1390,7 @@
                      
                         <li><span class="attribute" id="nidm:Inference.nidm:hasAlternativeHypothesis">
                         <a>nidm:hasAlternativeHypothesis</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range nidm:OneTailedTest, nidm:TwoTailedTest)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a>nidm:OneTailedTest</a> and <a>nidm:TwoTailedTest</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>niiri:inference_id a prov:Activity , nidm:Inference ;
@@ -1472,22 +1412,22 @@
                      
                         <li><span class="attribute" id="nidm:Cluster.nidm:clusterLabelId">
                         <dfn>nidm:clusterLabelId</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> integer associated with a particular cluster as specified in the clusterLabelsMap. (range xsd:int)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> integer associated with a particular cluster as specified in the clusterLabelsMap. (range <a title="xsd:int" href="http://www.w3.org/2001/XMLSchema#int">xsd:int</a>)</li> 
                         <li><span class="attribute" id="nidm:Cluster.nidm:clusterSizeInVertices">
                         <dfn>nidm:clusterSizeInVertices</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> number of vertices that make up the cluster. (range xsd:positiveInteger)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> number of vertices that make up the cluster. (range <a title="xsd:positiveInteger" href="http://www.w3.org/2001/XMLSchema#positiveInteger">xsd:positiveInteger</a>)</li> 
                         <li><span class="attribute" id="nidm:Cluster.nidm:clusterSizeInVoxels">
                         <dfn>nidm:clusterSizeInVoxels</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> number of voxels that make up the cluster. (range xsd:positiveInteger)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> number of voxels that make up the cluster. (range <a title="xsd:positiveInteger" href="http://www.w3.org/2001/XMLSchema#positiveInteger">xsd:positiveInteger</a>)</li> 
                         <li><span class="attribute" id="nidm:Cluster.nidm:pValueFWER">
                         <dfn>nidm:pValueFWER</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> "A quantitative confidence value resulting from a multiple testing error correction method which adjusts the p-value used as input to control for Type I error in the context of multiple pairwise tests". (range xsd:float)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> "A quantitative confidence value resulting from a multiple testing error correction method which adjusts the p-value used as input to control for Type I error in the context of multiple pairwise tests". (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li> 
                         <li><span class="attribute" id="nidm:Cluster.nidm:pValueUncorrected">
                         <dfn>nidm:pValueUncorrected</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a p-value reported without correction for multiple testing.        . (range xsd:float)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a p-value reported without correction for multiple testing.        . (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li> 
                         <li><span class="attribute" id="nidm:Cluster.nidm:qValueFDR">
                         <dfn>nidm:qValueFDR</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a quantitative confidence value that measures the minimum false discovery rate that is incurred when calling that test significant. To compute q-values, it is necessary to know the p-value produced by a test and possibly set a false discovery rate level (same as OBI_0001442). (range xsd:float)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a quantitative confidence value that measures the minimum false discovery rate that is incurred when calling that test significant. To compute q-values, it is necessary to know the p-value produced by a test and possibly set a false discovery rate level (same as OBI_0001442). (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>niiri:cluster_0001 a prov:Entity , nidm:Cluster ;
@@ -1513,7 +1453,7 @@
                      
                         <li><span class="attribute" id="nidm:ClusterDefinitionCriteria.nidm:hasConnectivityCriterion">
                         <dfn>nidm:hasConnectivityCriterion</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property that associates a ConnectivityCriterion with a ClusterDefinitionCriteria. (range nidm:ConnectivityCriterion, nidm:PixelConnectivityCriterion, nidm:VoxelConnectivityCriterion)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property that associates a ConnectivityCriterion with a ClusterDefinitionCriteria. (range <a>nidm:ConnectivityCriterion</a>, <a>nidm:PixelConnectivityCriterion</a> and <a>nidm:VoxelConnectivityCriterion</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>niiri:cluster_definition_criteria_id a prov:Entity , nidm:ClusterDefinitionCriteria ;
@@ -1569,10 +1509,10 @@
                      
                         <li><span class="attribute" id="nidm:ClusterLabelsMap.nidm:hasMapHeader">
                         <a>nidm:hasMapHeader</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range nidm:MapHeader)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a>nidm:MapHeader</a>)</li> 
                         <li><span class="attribute" id="nidm:ClusterLabelsMap.nidm:inCoordinateSpace">
                         <a>nidm:inCoordinateSpace</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range nidm:CoordinateSpace)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range <a>nidm:CoordinateSpace</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>niiri:cluster_label_map_id a prov:Entity , nidm:ClusterLabelsMap ;
@@ -1593,13 +1533,13 @@
                      
                         <li><span class="attribute" id="nidm:Coordinate.nidm:coordinate1">
                         <dfn>nidm:coordinate1</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> coordinate along the first dimension in voxel units. (range xsd:float)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> coordinate along the first dimension in voxel units. (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li> 
                         <li><span class="attribute" id="nidm:Coordinate.nidm:coordinate2">
                         <dfn>nidm:coordinate2</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> coordinate along the second dimension in voxel units. (range xsd:float)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> coordinate along the second dimension in voxel units. (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li> 
                         <li><span class="attribute" id="nidm:Coordinate.nidm:coordinate3">
                         <dfn>nidm:coordinate3</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> coordinate along the third dimension in voxel units. (range xsd:float)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> coordinate along the third dimension in voxel units. (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>niiri:coordinate_0001 a prov:Entity , prov:Location , nidm:Coordinate ;
@@ -1621,10 +1561,10 @@
                      
                         <li><span class="attribute" id="nidm:DisplayMaskMap.nidm:hasMapHeader">
                         <a>nidm:hasMapHeader</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range nidm:MapHeader)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a>nidm:MapHeader</a>)</li> 
                         <li><span class="attribute" id="nidm:DisplayMaskMap.nidm:inCoordinateSpace">
                         <a>nidm:inCoordinateSpace</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range nidm:CoordinateSpace)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range <a>nidm:CoordinateSpace</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>niiri:display_map_id a prov:Entity , nidm:DisplayMaskMap ;
@@ -1639,7 +1579,7 @@
             <section id="section-nidm:ExcursionSetMap"> 
                 <h1 label="nidm:ExcursionSetMap">nidm:ExcursionSetMap</h1>
                 <div class="glossary-ref">
-                    A <dfn>nidm:ExcursionSetMap</dfn>                    <sup><a title="nidm:ExcursionSetMap">                    <span class="diamond">&#9826;</span></a></sup> is a map in which the set of elements not selected by the inference activity is set to zero or NaN. <a>nidm:ExcursionSetMap</a> is a prov:Entity. 
+                    A <dfn>nidm:ExcursionSetMap</dfn>                    <sup><a title="nidm:ExcursionSetMap">                    <span class="diamond">&#9826;</span></a></sup> is a map in which the set of elements not selected by the inference activity is set to zero or NaN. <a>nidm:ExcursionSetMap</a> is. 
                 </div>
                 <p></p>
                 <div class="attributes" id="attributes-nidm:ExcursionSetMap"> A <a>nidm:ExcursionSetMap</a> has attributes:
@@ -1648,19 +1588,19 @@
                      
                         <li><span class="attribute" id="nidm:ExcursionSetMap.nidm:hasClusterLabelsMap">
                         <dfn>nidm:hasClusterLabelsMap</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a map whose value at each location denotes cluster membership. Each cluster is denoted by a different integer. (range nidm:ClusterLabelsMap)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a map whose value at each location denotes cluster membership. Each cluster is denoted by a different integer. (range <a>nidm:ClusterLabelsMap</a>)</li> 
                         <li><span class="attribute" id="nidm:ExcursionSetMap.nidm:hasMapHeader">
                         <a>nidm:hasMapHeader</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range nidm:MapHeader)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a>nidm:MapHeader</a>)</li> 
                         <li><span class="attribute" id="nidm:ExcursionSetMap.nidm:inCoordinateSpace">
                         <a>nidm:inCoordinateSpace</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range nidm:CoordinateSpace)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range <a>nidm:CoordinateSpace</a>)</li> 
                         <li><span class="attribute" id="nidm:ExcursionSetMap.nidm:numberOfClusters">
                         <dfn>nidm:numberOfClusters</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range xsd:int)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a title="xsd:int" href="http://www.w3.org/2001/XMLSchema#int">xsd:int</a>)</li> 
                         <li><span class="attribute" id="nidm:ExcursionSetMap.nidm:pValue">
                         <dfn>nidm:pValue</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range xsd:float)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>niiri:excursion_set_map_id a prov:Entity , nidm:ExcursionSetMap ;
@@ -1690,22 +1630,22 @@
                      
                         <li><span class="attribute" id="nidm:ExtentThreshold.nidm:clusterSizeInVertices">
                         <a>nidm:clusterSizeInVertices</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> number of vertices that make up the cluster. (range xsd:positiveInteger)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> number of vertices that make up the cluster. (range <a title="xsd:positiveInteger" href="http://www.w3.org/2001/XMLSchema#positiveInteger">xsd:positiveInteger</a>)</li> 
                         <li><span class="attribute" id="nidm:ExtentThreshold.nidm:clusterSizeInVoxels">
                         <a>nidm:clusterSizeInVoxels</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> number of voxels that make up the cluster. (range xsd:positiveInteger)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> number of voxels that make up the cluster. (range <a title="xsd:positiveInteger" href="http://www.w3.org/2001/XMLSchema#positiveInteger">xsd:positiveInteger</a>)</li> 
                         <li><span class="attribute" id="nidm:ExtentThreshold.nidm:pValueFWER">
                         <a>nidm:pValueFWER</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> "A quantitative confidence value resulting from a multiple testing error correction method which adjusts the p-value used as input to control for Type I error in the context of multiple pairwise tests". (range xsd:float)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> "A quantitative confidence value resulting from a multiple testing error correction method which adjusts the p-value used as input to control for Type I error in the context of multiple pairwise tests". (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li> 
                         <li><span class="attribute" id="nidm:ExtentThreshold.nidm:pValueUncorrected">
                         <a>nidm:pValueUncorrected</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a p-value reported without correction for multiple testing.        . (range xsd:float)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a p-value reported without correction for multiple testing.        . (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li> 
                         <li><span class="attribute" id="nidm:ExtentThreshold.nidm:qValueFDR">
                         <a>nidm:qValueFDR</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a quantitative confidence value that measures the minimum false discovery rate that is incurred when calling that test significant. To compute q-values, it is necessary to know the p-value produced by a test and possibly set a false discovery rate level (same as OBI_0001442). (range xsd:float)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a quantitative confidence value that measures the minimum false discovery rate that is incurred when calling that test significant. To compute q-values, it is necessary to know the p-value produced by a test and possibly set a false discovery rate level (same as OBI_0001442). (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li> 
                         <li><span class="attribute" id="nidm:ExtentThreshold.nidm:userSpecifiedThresholdType">
                         <dfn>nidm:userSpecifiedThresholdType</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> type of method used to define a threshold (e.g. statistic value, uncorrected P-value or corrected P-value). (range xsd:string)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> type of method used to define a threshold (e.g. statistic value, uncorrected P-value or corrected P-value). (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>niiri:extent_threshold_id a prov:Entity , nidm:ExtentThreshold ;
@@ -1729,16 +1669,16 @@
                      
                         <li><span class="attribute" id="nidm:HeightThreshold.nidm:pValueFWER">
                         <a>nidm:pValueFWER</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> "A quantitative confidence value resulting from a multiple testing error correction method which adjusts the p-value used as input to control for Type I error in the context of multiple pairwise tests". (range xsd:float)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> "A quantitative confidence value resulting from a multiple testing error correction method which adjusts the p-value used as input to control for Type I error in the context of multiple pairwise tests". (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li> 
                         <li><span class="attribute" id="nidm:HeightThreshold.nidm:pValueUncorrected">
                         <a>nidm:pValueUncorrected</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a p-value reported without correction for multiple testing.        . (range xsd:float)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a p-value reported without correction for multiple testing.        . (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li> 
                         <li><span class="attribute" id="nidm:HeightThreshold.nidm:qValueFDR">
                         <a>nidm:qValueFDR</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a quantitative confidence value that measures the minimum false discovery rate that is incurred when calling that test significant. To compute q-values, it is necessary to know the p-value produced by a test and possibly set a false discovery rate level (same as OBI_0001442). (range xsd:float)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a quantitative confidence value that measures the minimum false discovery rate that is incurred when calling that test significant. To compute q-values, it is necessary to know the p-value produced by a test and possibly set a false discovery rate level (same as OBI_0001442). (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li> 
                         <li><span class="attribute" id="nidm:HeightThreshold.nidm:userSpecifiedThresholdType">
                         <a>nidm:userSpecifiedThresholdType</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> type of method used to define a threshold (e.g. statistic value, uncorrected P-value or corrected P-value). (range xsd:string)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> type of method used to define a threshold (e.g. statistic value, uncorrected P-value or corrected P-value). (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>niiri:height_threshold_id a prov:Entity , nidm:HeightThreshold ;
@@ -1761,10 +1701,10 @@
                      
                         <li><span class="attribute" id="nidm:InferenceMaskMap.nidm:hasMapHeader">
                         <a>nidm:hasMapHeader</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range nidm:MapHeader)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a>nidm:MapHeader</a>)</li> 
                         <li><span class="attribute" id="nidm:InferenceMaskMap.nidm:inCoordinateSpace">
                         <a>nidm:inCoordinateSpace</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range nidm:CoordinateSpace)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range <a>nidm:CoordinateSpace</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>niiri:sub_volume_id a prov:Entity , nidm:InferenceMaskMap ;
@@ -1788,16 +1728,16 @@
                      
                         <li><span class="attribute" id="nidm:Peak.nidm:equivalentZStatistic">
                         <dfn>nidm:equivalentZStatistic</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> statistic value transformed into Z units; the output of a process which takes a non-normal statistic and transforms it to an equivalent z score. (range xsd:float)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> statistic value transformed into Z units; the output of a process which takes a non-normal statistic and transforms it to an equivalent z score. (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li> 
                         <li><span class="attribute" id="nidm:Peak.nidm:pValueFWER">
                         <a>nidm:pValueFWER</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> "A quantitative confidence value resulting from a multiple testing error correction method which adjusts the p-value used as input to control for Type I error in the context of multiple pairwise tests". (range xsd:float)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> "A quantitative confidence value resulting from a multiple testing error correction method which adjusts the p-value used as input to control for Type I error in the context of multiple pairwise tests". (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li> 
                         <li><span class="attribute" id="nidm:Peak.nidm:pValueUncorrected">
                         <a>nidm:pValueUncorrected</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a p-value reported without correction for multiple testing.        . (range xsd:float)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a p-value reported without correction for multiple testing.        . (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li> 
                         <li><span class="attribute" id="nidm:Peak.nidm:qValueFDR">
                         <a>nidm:qValueFDR</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a quantitative confidence value that measures the minimum false discovery rate that is incurred when calling that test significant. To compute q-values, it is necessary to know the p-value produced by a test and possibly set a false discovery rate level (same as OBI_0001442). (range xsd:float)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a quantitative confidence value that measures the minimum false discovery rate that is incurred when calling that test significant. To compute q-values, it is necessary to know the p-value produced by a test and possibly set a false discovery rate level (same as OBI_0001442). (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>niiri:peak_0001 a prov:Entity , nidm:Peak ;
@@ -1823,10 +1763,10 @@
                      
                         <li><span class="attribute" id="nidm:PeakDefinitionCriteria.nidm:maxNumberOfPeaksPerCluster">
                         <dfn>nidm:maxNumberOfPeaksPerCluster</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> maximum number of peaks to be reported after inference within a cluster. (range xsd:int)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> maximum number of peaks to be reported after inference within a cluster. (range <a title="xsd:int" href="http://www.w3.org/2001/XMLSchema#int">xsd:int</a>)</li> 
                         <li><span class="attribute" id="nidm:PeakDefinitionCriteria.nidm:minDistanceBetweenPeaks">
                         <dfn>nidm:minDistanceBetweenPeaks</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> minimum distance between two peaks to be reported after inference. (range xsd:float)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> minimum distance between two peaks to be reported after inference. (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>niiri:peak_definition_criteria_id a prov:Entity , nidm:PeakDefinitionCriteria ;
@@ -1847,13 +1787,13 @@
                      
                         <li><span class="attribute" id="nidm:SearchSpaceMap.nidm:hasMapHeader">
                         <a>nidm:hasMapHeader</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range nidm:MapHeader)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a>nidm:MapHeader</a>)</li> 
                         <li><span class="attribute" id="nidm:SearchSpaceMap.nidm:inCoordinateSpace">
                         <a>nidm:inCoordinateSpace</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range nidm:CoordinateSpace)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range <a>nidm:CoordinateSpace</a>)</li> 
                         <li><span class="attribute" id="nidm:SearchSpaceMap.nidm:randomFieldStationarity">
                         <dfn>nidm:randomFieldStationarity</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> is the random field assumed to be stationary across the entire search volume?. (range xsd:boolean)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> is the random field assumed to be stationary across the entire search volume?. (range <a title="xsd:boolean" href="http://www.w3.org/2001/XMLSchema#boolean">xsd:boolean</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>niiri:search_space_id a prov:Entity , nidm:SearchSpaceMap ;
@@ -1927,7 +1867,7 @@
                      
                         <li><span class="attribute" id="nidm:SPM.nidm:softwareVersion">
                         <dfn>nidm:softwareVersion</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> name and number that specifies the software version. (range xsd:string)</li>  
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> name and number that specifies the software version. (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li>  
             </section>
             <!-- spm:ReselsPerVoxelMap -->
             <section id="section-spm:ReselsPerVoxelMap"> 
@@ -1942,10 +1882,10 @@
                      
                         <li><span class="attribute" id="spm:ReselsPerVoxelMap.nidm:hasMapHeader">
                         <a>nidm:hasMapHeader</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range nidm:MapHeader)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a>nidm:MapHeader</a>)</li> 
                         <li><span class="attribute" id="spm:ReselsPerVoxelMap.nidm:inCoordinateSpace">
                         <a>nidm:inCoordinateSpace</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range nidm:CoordinateSpace)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range <a>nidm:CoordinateSpace</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>niiri:resels_per_voxel_map_id a prov:Entity , spm:ReselsPerVoxelMap ;
@@ -2005,7 +1945,7 @@
                      
                         <li><span class="attribute" id="nidm:FSL.nidm:softwareVersion">
                         <a>nidm:softwareVersion</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> name and number that specifies the software version. (range xsd:string)</li>  
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> name and number that specifies the software version. (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li>  
             </section>
             <!-- fsl:CenterOfGravity -->
             <section id="section-fsl:CenterOfGravity"> 

--- a/nidm/imports/stato_import.ttl
+++ b/nidm/imports/stato_import.ttl
@@ -41,9 +41,9 @@ https://github.com/ISA-tools/stato/issues/18"""@en ;
                                                
                                                <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000125> .
 
-###  http://purl.obolibrary.org/obo/stato.owl#ordinary_least_squares_estimation
+###  http://purl.obolibrary.org/obo/stato.owl#STATO_0000370
 
-stato:ordinary_least_squares_estimation rdf:type :Class ;
+stato:STATO_0000370 rdf:type :Class ;
                                    
                                    rdfs:label "ordinary least squares estimation"@en ;
                                    

--- a/nidm/imports/stato_import.ttl
+++ b/nidm/imports/stato_import.ttl
@@ -1,5 +1,5 @@
 @prefix : <http://www.w3.org/2002/07/owl#> .
-@prefix stato: <http://purl.obolibrary.org/obo/> .
+@prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
@@ -17,7 +17,7 @@
 
 ###  http://purl.obolibrary.org/obo/STATO_0000119
 
-stato:STATO_0000119 rdf:type :Class ;
+obo:STATO_0000119 rdf:type :Class ;
                                                
                                                rdfs:label "model parameter estimation"@en ;
                                                
@@ -43,7 +43,7 @@ https://github.com/ISA-tools/stato/issues/18"""@en ;
 
 ###  http://purl.obolibrary.org/obo/stato.owl#STATO_0000370
 
-stato:STATO_0000370 rdf:type :Class ;
+obo:STATO_0000370 rdf:type :Class ;
                                    
                                    rdfs:label "ordinary least squares estimation"@en ;
                                    
@@ -73,7 +73,7 @@ stato:STATO_0000370 rdf:type :Class ;
 
 ###  http://purl.obolibrary.org/obo/STATO_0000371
 
-stato:STATO_0000371 rdf:type :Class ;
+obo:STATO_0000371 rdf:type :Class ;
                                                
                                                rdfs:label "weighted least squares estimation"@en ;
                                                
@@ -103,7 +103,7 @@ stato:STATO_0000371 rdf:type :Class ;
 
 ###  http://purl.obolibrary.org/obo/STATO_0000372
 
-stato:STATO_0000372 rdf:type :Class ;
+obo:STATO_0000372 rdf:type :Class ;
                                                
                                                rdfs:label "generalized least squares estimation"@en ;
                                                
@@ -130,7 +130,7 @@ stato:STATO_0000372 rdf:type :Class ;
 
 ###  http://purl.obolibrary.org/obo/STATO_0000373
 
-stato:STATO_0000373 rdf:type :Class ;
+obo:STATO_0000373 rdf:type :Class ;
                                                
                                                rdfs:label "iteratively reweighted least squares estimation"@en ;
                                                
@@ -159,7 +159,7 @@ stato:STATO_0000373 rdf:type :Class ;
 
 ###  http://purl.obolibrary.org/obo/STATO_0000374
 
-stato:STATO_0000374 rdf:type :Class ;
+obo:STATO_0000374 rdf:type :Class ;
                                                
                                                rdfs:label "feasible generalized least squares estimation"@en ;
                                                

--- a/nidm/imports/stato_import.ttl
+++ b/nidm/imports/stato_import.ttl
@@ -1,0 +1,183 @@
+@prefix : <http://www.w3.org/2002/07/owl#> .
+@prefix stato: <http://purl.obolibrary.org/obo/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<http://purl.org/nidash/nidm/stato_import.owl> rdf:type owl:Ontology .
+
+
+#################################################################
+#
+#    Annotation properties
+#
+#################################################################
+
+###  http://purl.obolibrary.org/obo/STATO_0000119
+
+stato:STATO_0000119 rdf:type :Class ;
+                                               
+                                               rdfs:label "model parameter estimation"@en ;
+                                               
+                                               rdfs:subClassOf <http://purl.obolibrary.org/obo/OBI_0200000> ,
+                                                               [ rdf:type :Restriction ;
+                                                                 :onProperty <http://purl.obolibrary.org/obo/OBI_0000299> ;
+                                                                 :someValuesFrom <http://purl.obolibrary.org/obo/STATO_0000144>
+                                                               ] ;
+                                               
+                                               <http://purl.obolibrary.org/obo/IAO_0000117> "Orlaith Burke"^^xsd:string ;
+                                               
+                                               <http://purl.obolibrary.org/obo/IAO_0000119> ""@en ;
+                                               
+                                               <http://purl.obolibrary.org/obo/IAO_0000117> "Alejandra Gonzalez-Beltran"@en ,
+                                                                                            "Philippe Rocca-Serra"@en ;
+                                               
+                                               <http://purl.obolibrary.org/obo/IAO_0000115> "model parameter estimation is a data transformation that finds parameter values (the model parameter estimates) most compatible with the data as judged by the model."@en ;
+                                               
+                                               <http://purl.obolibrary.org/obo/IAO_0000116> """textual definition modified following contributiong by Thomas Nichols:
+https://github.com/ISA-tools/stato/issues/18"""@en ;
+                                               
+                                               <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000125> .
+
+###  http://purl.obolibrary.org/obo/stato.owl#ordinary_least_squares_estimation
+
+stato:ordinary_least_squares_estimation rdf:type :Class ;
+                                   
+                                   rdfs:label "ordinary least squares estimation"@en ;
+                                   
+                                   rdfs:subClassOf <http://purl.obolibrary.org/obo/STATO_0000119> ,
+                                                   [ rdf:type :Restriction ;
+                                                     :onProperty <http://purl.obolibrary.org/obo/BFO_0000050> ;
+                                                     :someValuesFrom <http://purl.obolibrary.org/obo/STATO_0000108>
+                                                   ] ;
+                                   
+                                   <http://purl.obolibrary.org/obo/STATO_0000041> ""@en ;
+                                   
+                                   <http://purl.obolibrary.org/obo/IAO_0000117> "Alejandra Gonzalez-Beltran"@en ,
+                                                                                "Camille Maumet"@en ;
+                                   
+                                   <http://purl.obolibrary.org/obo/STATO_0000041> "https://stat.ethz.ch/R-manual/R-patched/library/stats/html/lm.html" ;
+                                   
+                                   <http://purl.obolibrary.org/obo/STATO_0000032> "OLS estimation" ;
+                                   
+                                   <http://purl.obolibrary.org/obo/IAO_0000117> "Philippe Rocca-Serra"@en ,
+                                                                                "Tom Nichols"@en ;
+                                   
+                                   <http://purl.obolibrary.org/obo/IAO_0000119> "http://en.wikipedia.org/wiki/Ordinary_least_squares and Tom Nichols"@en ;
+                                   
+                                   <http://purl.obolibrary.org/obo/IAO_0000115> "the ordinary least squares estimation is a model parameter estimation for a linear regression model when the errors are uncorrelated and equal in variance. Is the Best Linear Unbiased Estimation (BLUE) method under these assumptions, Uniformly Minimum-Variance Unbiased Estimator (UMVUE) with addition of a Gaussian assumption."@en ;
+                                   
+                                   <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000120> .
+
+###  http://purl.obolibrary.org/obo/STATO_0000371
+
+stato:STATO_0000371 rdf:type :Class ;
+                                               
+                                               rdfs:label "weighted least squares estimation"@en ;
+                                               
+                                               rdfs:subClassOf <http://purl.obolibrary.org/obo/STATO_0000119> ,
+                                                               [ rdf:type :Restriction ;
+                                                                 :onProperty <http://purl.obolibrary.org/obo/BFO_0000050> ;
+                                                                 :someValuesFrom <http://purl.obolibrary.org/obo/STATO_0000108>
+                                                               ] ;
+                                               
+                                               <http://purl.obolibrary.org/obo/STATO_0000032> "WLS estimation" ;
+                                               
+                                               <http://purl.obolibrary.org/obo/IAO_0000117> "Alejandra Gonzalez-Beltran"@en ,
+                                                                                            "Camille Maumet"@en ,
+                                                                                            "Orlaith Burke"@en ,
+                                                                                            "Philippe Rocca-Serra"@en ,
+                                                                                            "Tom Nichols"@en ;
+                                               
+                                               <http://purl.obolibrary.org/obo/IAO_0000119> "http://en.wikipedia.org/wiki/Least_squares#Weighted_least_squares and Tom Nichols"@en ;
+                                               
+                                               <http://purl.obolibrary.org/obo/STATO_0000041> "https://stat.ethz.ch/R-manual/R-patched/library/stats/html/lm.html"@en ;
+                                               
+                                               <http://purl.obolibrary.org/obo/IAO_0000115> "the weighted least squares estimation is a model parameter estimation for a linear regression model with errors that independent but have heterogeneous variance. Difficult to use use in practice, as weights must be set based on the variance which is usually unknown. If true variance is known, it is the Best Linear Unbiased Estimation (BLUE) method under these assumptions, Uniformly Minimum-Variance Unbiased Estimator (UMVUE) with addition of a Gaussian assumption."@en ;
+                                               
+                                               <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000120> .
+
+
+
+###  http://purl.obolibrary.org/obo/STATO_0000372
+
+stato:STATO_0000372 rdf:type :Class ;
+                                               
+                                               rdfs:label "generalized least squares estimation"@en ;
+                                               
+                                               rdfs:subClassOf <http://purl.obolibrary.org/obo/STATO_0000119> ,
+                                                               [ rdf:type :Restriction ;
+                                                                 :onProperty <http://purl.obolibrary.org/obo/BFO_0000050> ;
+                                                                 :someValuesFrom <http://purl.obolibrary.org/obo/STATO_0000108>
+                                                               ] ;
+                                               
+                                               <http://purl.obolibrary.org/obo/STATO_0000032> "GLS estimation" ;
+                                               
+                                               <http://purl.obolibrary.org/obo/IAO_0000117> "Philippe Rocca-Serra"@en ,
+                                                                                            "Tom Nichols"@en ;
+                                               
+                                               <http://purl.obolibrary.org/obo/IAO_0000119> "http://en.wikipedia.org/wiki/Generalized_least_squares and Tom Nichols"@en ;
+                                               
+                                               <http://purl.obolibrary.org/obo/STATO_0000041> "http://stat.ethz.ch/R-manual/R-devel/library/nlme/html/gls.html"@en ;
+                                               
+                                               <http://purl.obolibrary.org/obo/IAO_0000115> "the generalized least squares estimation is a model parameter estimation for a linear regression model with errors that are dependent and (possibly) have heterogeneous variance. Difficult to use use in practice, as covariance matrix of the errors must known to \"whiten\" data and model. If true covariance is known, it is the Best Linear Unbiased Estimation (BLUE) method under these assumptions, Uniformly Minimum-Variance Unbiased Estimator (UMVUE) with addition of a Gaussian assumption."@en ;
+                                               
+                                               <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000120> .
+
+
+
+###  http://purl.obolibrary.org/obo/STATO_0000373
+
+stato:STATO_0000373 rdf:type :Class ;
+                                               
+                                               rdfs:label "iteratively reweighted least squares estimation"@en ;
+                                               
+                                               rdfs:subClassOf <http://purl.obolibrary.org/obo/STATO_0000119> ,
+                                                               [ rdf:type :Restriction ;
+                                                                 :onProperty <http://purl.obolibrary.org/obo/BFO_0000050> ;
+                                                                 :someValuesFrom <http://purl.obolibrary.org/obo/STATO_0000108>
+                                                               ] ;
+                                               
+                                               <http://purl.obolibrary.org/obo/IAO_0000117> "Alejandra Gonzalez-Beltran" ,
+                                                                                            "Camille Maumet" ,
+                                                                                            "Orlaith Burke" ;
+                                               
+                                               <http://purl.obolibrary.org/obo/STATO_0000041> ""@en ;
+                                               
+                                               <http://purl.obolibrary.org/obo/IAO_0000117> "Philippe Rocca-Serra"@en ,
+                                                                                            "Tom Nichols"@en ;
+                                               
+                                               <http://purl.obolibrary.org/obo/IAO_0000119> "Tom Nichols"@en ;
+                                               
+                                               <http://purl.obolibrary.org/obo/IAO_0000115> "the iteratively reweighted least squares estimation is a model parameter estimation which is a practical implementation of Weighted Least Squares, where the heterogeneous variances of the errors are estimated from the residuals of the regression model, providing an estimate for the weights. Each successive estimate of the weights improves the estimation of the regression parameters, which in turn are used to compute residuals and update the weights"@en ;
+                                               
+                                               <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000120> .
+
+
+
+###  http://purl.obolibrary.org/obo/STATO_0000374
+
+stato:STATO_0000374 rdf:type :Class ;
+                                               
+                                               rdfs:label "feasible generalized least squares estimation"@en ;
+                                               
+                                               rdfs:subClassOf <http://purl.obolibrary.org/obo/STATO_0000372> ,
+                                                               [ rdf:type :Restriction ;
+                                                                 :onProperty <http://purl.obolibrary.org/obo/BFO_0000050> ;
+                                                                 :someValuesFrom <http://purl.obolibrary.org/obo/STATO_0000108>
+                                                               ] ;
+                                               
+                                               <http://purl.obolibrary.org/obo/IAO_0000115> "the feasible generalized least squares estimation is a model parameter estimation which is a practical implementation of Generalised Least Squares, where the covariance of the errors is estimated from the residuals of the regression model, providing the information needed to whiten the data and model. Each successive estimate of the whitening matrix improves the estimation of the regression parameters, which in turn are used to compute residuals and update the whitening matrix." ;
+                                               
+                                               <http://purl.obolibrary.org/obo/IAO_0000117> "Alejandra Gonzalez-Beltran"@en ,
+                                                                                            "Orlaith Burke"@en ;
+                                               
+                                               <http://purl.obolibrary.org/obo/IAO_0000119> "Tom Nichols" ;
+                                               
+                                               <http://purl.obolibrary.org/obo/IAO_0000117> "Camille Maumet" ,
+                                                                                            "Philippe Rocca-Serra"@en ,
+                                                                                            "Tom Nichols"@en ;
+                                               
+                                               <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000120> .                                   

--- a/nidm/nidm-experiment/scripts/create_expe_specification.py
+++ b/nidm/nidm-experiment/scripts/create_expe_specification.py
@@ -11,9 +11,11 @@ import os
 from rdflib.compare import *
 import sys
 import collections
+import glob
 
 RELPATH = os.path.dirname(os.path.abspath(__file__))
 NIDM_EXPE_PATH = os.path.dirname(RELPATH)
+NIDMPATH = os.path.join(NIDM_EXPE_PATH, os.pardir)
 
 # Append parent script directory to path
 sys.path.append(os.path.join( os.path.dirname(os.path.dirname(\
@@ -37,9 +39,12 @@ def main():
     # Retreive owl file for NIDM-Results
     if nidm_version == "dev":
         owl_file = os.path.join(TERMS_FOLDER, 'nidm-experiment.owl')
+        import_files = glob.glob(os.path.join(NIDMPATH, "imports", '*.ttl'))
     else:
         owl_file = os.path.join(RELEASED_TERMS_FOLDER, \
             'nidm-experiment_'+nidm_version+'.owl')
+        # For released version of the ontology imports are embedded
+        import_files = None
 
     # check the file exists
     assert os.path.exists(owl_file)
@@ -70,8 +75,9 @@ def main():
     derived_from = {       
     }
 
-    owlspec = OwlSpecification(owl_file, "NIDM-Experiment", subcomponents, \
-        used_by, generated_by, derived_from, prefix=str(NIDM_EXPERIMENT))
+    owlspec = OwlSpecification(owl_file, import_files, "NIDM-Experiment", 
+        subcomponents, used_by, generated_by, derived_from, 
+        prefix=str(NIDM_EXPERIMENT))
 
     if not nidm_version == "dev":
         owlspec.text = owlspec.text.replace("(under development)", nidm_original_version)

--- a/nidm/nidm-experiment/terms/nidm-experiment.owl
+++ b/nidm/nidm-experiment/terms/nidm-experiment.owl
@@ -10,7 +10,7 @@
 @prefix xsp: <http://www.owl-ontologies.com/2005/08/07/xsp.owl#> .
 @prefix daml: <http://www.daml.org/2001/03/daml+oil#> .
 @prefix meta: <http://purl.obolibrary.org/obo/iao/dev/ontology-metadata.owl#> .
-@prefix nidm: <http://purl.org/nidash/nidm/experiment#> .
+@prefix nidme: <http://purl.org/nidash/nidm/experiment#> .
 @prefix owl2: <http://www.w3.org/2006/12/owl2#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -166,14 +166,14 @@ dct:title rdf:type owl:DatatypeProperty .
 
 ###  http://purl.org/nidash/nidm/experiment#AcquisitionObject
 
-nidm:AcquisitionObject rdf:type owl:Class ;
+nidme:AcquisitionObject rdf:type owl:Class ;
                        
                        rdfs:label "Acquisition Object"^^xsd:string ;
                        
                        rdfs:subClassOf prov:Entity ,
                                        [ rdf:type owl:Restriction ;
                                          owl:onProperty prov:specializationOf ;
-                                         owl:onClass nidm:StudyObject ;
+                                         owl:onClass nidme:StudyObject ;
                                          owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger
                                        ] ;
                        
@@ -187,7 +187,7 @@ nidm:AcquisitionObject rdf:type owl:Class ;
 
 ###  http://purl.org/nidash/nidm/experiment#AnatomicalScan
 
-nidm:AnatomicalScan rdf:type owl:Class ;
+nidme:AnatomicalScan rdf:type owl:Class ;
                     
                     rdfs:subClassOf prov:Entity .
 
@@ -195,7 +195,7 @@ nidm:AnatomicalScan rdf:type owl:Class ;
 
 ###  http://purl.org/nidash/nidm/experiment#AnatomyImagingAcquisition
 
-nidm:AnatomyImagingAcquisition rdf:type owl:Class ;
+nidme:AnatomyImagingAcquisition rdf:type owl:Class ;
                                
                                rdfs:subClassOf prov:Activity .
 
@@ -203,7 +203,7 @@ nidm:AnatomyImagingAcquisition rdf:type owl:Class ;
 
 ###  http://purl.org/nidash/nidm/experiment#BaselineProtocol
 
-nidm:BaselineProtocol rdf:type owl:Class ;
+nidme:BaselineProtocol rdf:type owl:Class ;
                       
                       rdfs:label "Baseline Protocol"^^xsd:string ;
                       
@@ -219,7 +219,7 @@ nidm:BaselineProtocol rdf:type owl:Class ;
 
 ###  http://purl.org/nidash/nidm/experiment#BehaviorAndConsitionOnsets
 
-nidm:BehaviorAndConsitionOnsets rdf:type owl:Class ;
+nidme:BehaviorAndConsitionOnsets rdf:type owl:Class ;
                                 
                                 rdfs:subClassOf prov:Entity .
 
@@ -227,7 +227,7 @@ nidm:BehaviorAndConsitionOnsets rdf:type owl:Class ;
 
 ###  http://purl.org/nidash/nidm/experiment#Condition
 
-nidm:Condition rdf:type owl:Class ;
+nidme:Condition rdf:type owl:Class ;
                
                rdfs:subClassOf prov:Entity .
 
@@ -235,7 +235,7 @@ nidm:Condition rdf:type owl:Class ;
 
 ###  http://purl.org/nidash/nidm/experiment#Contrast
 
-nidm:Contrast rdf:type owl:Class ;
+nidme:Contrast rdf:type owl:Class ;
               
               rdfs:subClassOf prov:Entity .
 
@@ -243,7 +243,7 @@ nidm:Contrast rdf:type owl:Class ;
 
 ###  http://purl.org/nidash/nidm/experiment#DataCollection
 
-nidm:DataCollection rdf:type owl:Class ;
+nidme:DataCollection rdf:type owl:Class ;
                     
                     rdfs:subClassOf prov:Collection .
 
@@ -251,11 +251,11 @@ nidm:DataCollection rdf:type owl:Class ;
 
 ###  http://purl.org/nidash/nidm/experiment#DemographicsAcquisitionObject
 
-nidm:DemographicsAcquisitionObject rdf:type owl:Class ;
+nidme:DemographicsAcquisitionObject rdf:type owl:Class ;
                                    
                                    rdfs:label "Demographics Acquisition Object"^^xsd:string ;
                                    
-                                   rdfs:subClassOf nidm:AcquisitionObject ;
+                                   rdfs:subClassOf nidme:AcquisitionObject ;
                                    
                                    obo:IAO_0000115 "A demographics acquisition object is an entity that represents the demographics information acquired from a person in the participant role."^^xsd:string ;
                                    
@@ -267,7 +267,7 @@ nidm:DemographicsAcquisitionObject rdf:type owl:Class ;
 
 ###  http://purl.org/nidash/nidm/experiment#FunctionalScan
 
-nidm:FunctionalScan rdf:type owl:Class ;
+nidme:FunctionalScan rdf:type owl:Class ;
                     
                     rdfs:subClassOf prov:Entity .
 
@@ -275,7 +275,7 @@ nidm:FunctionalScan rdf:type owl:Class ;
 
 ###  http://purl.org/nidash/nidm/experiment#Group
 
-nidm:Group rdf:type owl:Class ;
+nidme:Group rdf:type owl:Class ;
            
            rdfs:subClassOf prov:Collection .
 
@@ -283,7 +283,7 @@ nidm:Group rdf:type owl:Class ;
 
 ###  http://purl.org/nidash/nidm/experiment#InvestigationCollection
 
-nidm:InvestigationCollection rdf:type owl:Class ;
+nidme:InvestigationCollection rdf:type owl:Class ;
                              
                              rdfs:subClassOf prov:Collection .
 
@@ -291,7 +291,7 @@ nidm:InvestigationCollection rdf:type owl:Class ;
 
 ###  http://purl.org/nidash/nidm/experiment#InvestigationProcess
 
-nidm:InvestigationProcess rdf:type owl:Class ;
+nidme:InvestigationProcess rdf:type owl:Class ;
                           
                           rdfs:subClassOf prov:Activity .
 
@@ -299,11 +299,11 @@ nidm:InvestigationProcess rdf:type owl:Class ;
 
 ###  http://purl.org/nidash/nidm/experiment#MRIAcquisitionObject
 
-nidm:MRIAcquisitionObject rdf:type owl:Class ;
+nidme:MRIAcquisitionObject rdf:type owl:Class ;
                           
                           rdfs:label "MRI Acquisition Object"^^xsd:string ;
                           
-                          rdfs:subClassOf nidm:AcquisitionObject ;
+                          rdfs:subClassOf nidme:AcquisitionObject ;
                           
                           obo:IAO_0000115 "An MRI acquisition object represents a specific series or scan during an MRI study."^^xsd:string ;
                           
@@ -315,7 +315,7 @@ nidm:MRIAcquisitionObject rdf:type owl:Class ;
 
 ###  http://purl.org/nidash/nidm/experiment#MRScanner
 
-nidm:MRScanner rdf:type owl:Class ;
+nidme:MRScanner rdf:type owl:Class ;
                
                rdfs:subClassOf prov:Agent .
 
@@ -323,7 +323,7 @@ nidm:MRScanner rdf:type owl:Class ;
 
 ###  http://purl.org/nidash/nidm/experiment#Model
 
-nidm:Model rdf:type owl:Class ;
+nidme:Model rdf:type owl:Class ;
            
            rdfs:subClassOf prov:Entity .
 
@@ -331,7 +331,7 @@ nidm:Model rdf:type owl:Class ;
 
 ###  http://purl.org/nidash/nidm/experiment#ModelSpecification
 
-nidm:ModelSpecification rdf:type owl:Class ;
+nidme:ModelSpecification rdf:type owl:Class ;
                         
                         rdfs:subClassOf prov:Activity .
 
@@ -339,7 +339,7 @@ nidm:ModelSpecification rdf:type owl:Class ;
 
 ###  http://purl.org/nidash/nidm/experiment#PresentationSoftware
 
-nidm:PresentationSoftware rdf:type owl:Class ;
+nidme:PresentationSoftware rdf:type owl:Class ;
                           
                           rdfs:subClassOf prov:SoftwareAgent .
 
@@ -347,7 +347,7 @@ nidm:PresentationSoftware rdf:type owl:Class ;
 
 ###  http://purl.org/nidash/nidm/experiment#PrincipalInvestigator
 
-nidm:PrincipalInvestigator rdf:type owl:Class ;
+nidme:PrincipalInvestigator rdf:type owl:Class ;
                            
                            rdfs:label "Principal Investigator"^^xsd:string ;
                            
@@ -363,14 +363,14 @@ nidm:PrincipalInvestigator rdf:type owl:Class ;
 
 ###  http://purl.org/nidash/nidm/experiment#ProjectObject
 
-nidm:ProjectObject rdf:type owl:Class ;
+nidme:ProjectObject rdf:type owl:Class ;
                    
                    rdfs:label "Project Object"^^xsd:string ;
                    
                    rdfs:subClassOf prov:Entity ,
                                    [ rdf:type owl:Restriction ;
                                      owl:onProperty dct:hasPart ;
-                                     owl:someValuesFrom nidm:StudyObject
+                                     owl:someValuesFrom nidme:StudyObject
                                    ] ;
                    
                    obo:IAO_0000115 "A project object is an entity that represents administrative information about one or more studies."^^xsd:string ;
@@ -383,7 +383,7 @@ nidm:ProjectObject rdf:type owl:Class ;
 
 ###  http://purl.org/nidash/nidm/experiment#ResearchAssistant
 
-nidm:ResearchAssistant rdf:type owl:Class ;
+nidme:ResearchAssistant rdf:type owl:Class ;
                        
                        rdfs:label "Research Assistant"^^xsd:string ;
                        
@@ -399,7 +399,7 @@ nidm:ResearchAssistant rdf:type owl:Class ;
 
 ###  http://purl.org/nidash/nidm/experiment#SessionAcquisition
 
-nidm:SessionAcquisition rdf:type owl:Class ;
+nidme:SessionAcquisition rdf:type owl:Class ;
                         
                         rdfs:subClassOf prov:Activity .
 
@@ -407,18 +407,18 @@ nidm:SessionAcquisition rdf:type owl:Class ;
 
 ###  http://purl.org/nidash/nidm/experiment#StudyObject
 
-nidm:StudyObject rdf:type owl:Class ;
+nidme:StudyObject rdf:type owl:Class ;
                  
                  rdfs:label "Study Object"^^xsd:string ;
                  
                  rdfs:subClassOf prov:Entity ,
                                  [ rdf:type owl:Restriction ;
                                    owl:onProperty dct:hasPart ;
-                                   owl:someValuesFrom nidm:AcquisitionObject
+                                   owl:someValuesFrom nidme:AcquisitionObject
                                  ] ,
                                  [ rdf:type owl:Restriction ;
                                    owl:onProperty prov:specializationOf ;
-                                   owl:onClass nidm:ProjectObject ;
+                                   owl:onClass nidme:ProjectObject ;
                                    owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger
                                  ] ;
                  
@@ -432,7 +432,7 @@ nidm:StudyObject rdf:type owl:Class ;
 
 ###  http://purl.org/nidash/nidm/experiment#StudyParticipant
 
-nidm:StudyParticipant rdf:type owl:Class ;
+nidme:StudyParticipant rdf:type owl:Class ;
                       
                       rdfs:label "Study Participant"^^xsd:string ;
                       
@@ -448,7 +448,7 @@ nidm:StudyParticipant rdf:type owl:Class ;
 
 ###  http://purl.org/nidash/nidm/experiment#Task
 
-nidm:Task rdf:type owl:Class ;
+nidme:Task rdf:type owl:Class ;
           
           rdfs:subClassOf prov:Collection .
 

--- a/nidm/nidm-results/fsl/README.md
+++ b/nidm/nidm-results/fsl/README.md
@@ -1,9 +1,9 @@
 
-Prov store: https://provenance.ecs.soton.ac.uk/store/documents/76679/
+Prov store: https://provenance.ecs.soton.ac.uk/store/documents/76699/
 	
-Alternative serialisations: [json](https://provenance.ecs.soton.ac.uk/store/documents/76679.json), [turtle](https://provenance.ecs.soton.ac.uk/store/documents/76679.ttl), 
-Graph: [svg](https://provenance.ecs.soton.ac.uk/store/documents/76679.svg), [PDF](https://provenance.ecs.soton.ac.uk/store/documents/76679.pdf), [png](https://provenance.ecs.soton.ac.uk/store/documents/76679.png)
+Alternative serialisations: [json](https://provenance.ecs.soton.ac.uk/store/documents/76699.json), [turtle](https://provenance.ecs.soton.ac.uk/store/documents/76699.ttl), 
+Graph: [svg](https://provenance.ecs.soton.ac.uk/store/documents/76699.svg), [PDF](https://provenance.ecs.soton.ac.uk/store/documents/76699.pdf), [png](https://provenance.ecs.soton.ac.uk/store/documents/76699.png)
 
-![Prov Graph](https://provenance.ecs.soton.ac.uk/store/documents/76679.png)
+![Prov Graph](https://provenance.ecs.soton.ac.uk/store/documents/76699.png)
 
 		

--- a/nidm/nidm-results/fsl/example001/README.md
+++ b/nidm/nidm-results/fsl/example001/README.md
@@ -1,9 +1,9 @@
 
-Prov store: https://provenance.ecs.soton.ac.uk/store/documents/76677/
+Prov store: https://provenance.ecs.soton.ac.uk/store/documents/76697/
 	
-Alternative serialisations: [json](https://provenance.ecs.soton.ac.uk/store/documents/76677.json), [turtle](https://provenance.ecs.soton.ac.uk/store/documents/76677.ttl), 
-Graph: [svg](https://provenance.ecs.soton.ac.uk/store/documents/76677.svg), [PDF](https://provenance.ecs.soton.ac.uk/store/documents/76677.pdf), [png](https://provenance.ecs.soton.ac.uk/store/documents/76677.png)
+Alternative serialisations: [json](https://provenance.ecs.soton.ac.uk/store/documents/76697.json), [turtle](https://provenance.ecs.soton.ac.uk/store/documents/76697.ttl), 
+Graph: [svg](https://provenance.ecs.soton.ac.uk/store/documents/76697.svg), [PDF](https://provenance.ecs.soton.ac.uk/store/documents/76697.pdf), [png](https://provenance.ecs.soton.ac.uk/store/documents/76697.png)
 
-![Prov Graph](https://provenance.ecs.soton.ac.uk/store/documents/76677.png)
+![Prov Graph](https://provenance.ecs.soton.ac.uk/store/documents/76697.png)
 
 		

--- a/nidm/nidm-results/fsl/example001/fsl_nidm.provn
+++ b/nidm/nidm-results/fsl/example001/fsl_nidm.provn
@@ -1,6 +1,7 @@
 document
 prefix crypto <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#>
 prefix neurolex <http://neurolex.org/wiki/>
+prefix obo <http://purl.obolibrary.org/obo/>
 prefix dct <http://purl.org/dc/terms/>
 prefix spm <http://www.incf.org/ns/nidash/spm#>
 prefix pre_0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
@@ -13,7 +14,7 @@ prefix xsd <http://www.w3.org/2001/XMLSchema>
 prefix bnode <http://openprovenance.org/provtoolbox/bnode/>
 prefix dctype <http://purl.org/dc/dcmitype/>
 prefix dc <http://purl.org/dc/elements/1.1/>
-activity(niiri:model_parameters_estimation_id,-,-,[prov:type = 'nidm:ModelParametersEstimation', prov:label = "Model Parameters Estimation", nidm:withEstimationMethod = 'nidm:GeneralizedLeastSquares'])
+activity(niiri:model_parameters_estimation_id,-,-,[prov:type = 'nidm:ModelParametersEstimation', prov:label = "Model Parameters Estimation", nidm:withEstimationMethod = 'obo:STATO_0000372'])
 activity(niiri:inference_id_1,-,-,[prov:type = 'nidm:Inference', prov:label = "Inference: Generation", nidm:hasAlternativeHypothesis = 'nidm:OneTailedTest'])
 activity(niiri:contrast_estimation_id_1,-,-,[prov:type = 'nidm:ContrastEstimation', prov:label = "Contrast estimation: Generation"])
 agent(niiri:software_id,[prov:type = 'nidm:FSL', prov:type = 'prov:SoftwareAgent', prov:label = "FSL", nidm:softwareVersion = "fsl-5_0_x" %% xsd:string, fsl:featVersion = "6.00" %% xsd:string])

--- a/nidm/nidm-results/fsl/example001/fsl_nidm.ttl
+++ b/nidm/nidm-results/fsl/example001/fsl_nidm.ttl
@@ -11,6 +11,9 @@
 @prefix niiri: <http://iri.nidash.org/> .
 @prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix obo: <http://purl.obolibrary.org/obo/> .
+
+
 
 niiri:cluster_definition_criteria_id_1 a prov:Entity , nidm:ClusterDefinitionCriteria ;
 	rdfs:label "Cluster Connectivity Criterion: 26" ;
@@ -508,7 +511,7 @@ niiri:inference_id_1 a prov:Activity , nidm:Inference ;
 niiri:model_parameters_estimation_id prov:used niiri:error_model_id ;
 	a prov:Activity , nidm:ModelParametersEstimation ;
 	rdfs:label "Model Parameters Estimation" ;
-	nidm:withEstimationMethod nidm:GeneralizedLeastSquares ;
+	nidm:withEstimationMethod obo:STATO_0000372 ; # obo:'generalized least squares estimation'
 	prov:used niiri:design_matrix_id ;
     prov:used niiri:data_id ;
     prov:used niiri:error_model_id ;

--- a/nidm/nidm-results/fsl/example002/fsl_nidm.ttl
+++ b/nidm/nidm-results/fsl/example002/fsl_nidm.ttl
@@ -11,6 +11,9 @@
 @prefix niiri: <http://iri.nidash.org/> .
 @prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix obo: <http://purl.obolibrary.org/obo/> .
+
+
 
 niiri:extent_threshold_id a prov:Entity , nidm:ExtentThreshold ;
 	rdfs:label "Extent Threshold: k>=0" ;

--- a/nidm/nidm-results/fsl/example003/fsl_nidm.ttl
+++ b/nidm/nidm-results/fsl/example003/fsl_nidm.ttl
@@ -11,6 +11,9 @@
 @prefix niiri: <http://iri.nidash.org/> .
 @prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix obo: <http://purl.obolibrary.org/obo/> .
+
+
 
 niiri:extent_threshold_id a prov:Entity , nidm:ExtentThreshold ;
 	rdfs:label "Extent Threshold: k>=0" ;

--- a/nidm/nidm-results/fsl/fsl_results.provn
+++ b/nidm/nidm-results/fsl/fsl_results.provn
@@ -1,6 +1,7 @@
 document
 prefix crypto <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#>
 prefix neurolex <http://neurolex.org/wiki/>
+prefix obo <http://purl.obolibrary.org/obo/>
 prefix dct <http://purl.org/dc/terms/>
 prefix spm <http://www.incf.org/ns/nidash/spm#>
 prefix pre_0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
@@ -13,7 +14,7 @@ prefix xsd <http://www.w3.org/2001/XMLSchema>
 prefix bnode <http://openprovenance.org/provtoolbox/bnode/>
 prefix dctype <http://purl.org/dc/dcmitype/>
 prefix dc <http://purl.org/dc/elements/1.1/>
-activity(niiri:model_pe_id,-,-,[prov:type = 'nidm:ModelParametersEstimation', prov:label = "Model parameters estimation", nidm:withEstimationMethod = 'nidm:OrdinaryLeastSquares'])
+activity(niiri:model_pe_id,-,-,[prov:type = 'nidm:ModelParametersEstimation', prov:label = "Model parameters estimation", nidm:withEstimationMethod = 'obo:STATO_0000370'])
 activity(niiri:inference_id,-,-,[prov:type = 'nidm:Inference', prov:label = "Inference", nidm:hasAlternativeHypothesis = 'nidm:OneTailedTest'])
 activity(niiri:contrast_estimation_id,-,-,[prov:type = 'nidm:ContrastEstimation', prov:label = "Contrast estimation"])
 agent(niiri:software_id,[prov:type = 'nidm:FSL', prov:type = 'prov:SoftwareAgent', prov:label = "FSL", nidm:softwareVersion = "fsl-5_0_x" %% xsd:string, fsl:featVersion = "6.00" %% xsd:string])

--- a/nidm/nidm-results/fsl/fsl_results.ttl
+++ b/nidm/nidm-results/fsl/fsl_results.ttl
@@ -11,6 +11,9 @@
 @prefix niiri: <http://iri.nidash.org/> .
 @prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix obo: <http://purl.obolibrary.org/obo/> .
+
+
 
 niiri:cluster_definition_criteria_id a prov:Entity , nidm:ClusterDefinitionCriteria ;
 	rdfs:label "Cluster Connectivity Criterion: 18" ;
@@ -353,7 +356,7 @@ niiri:inference_id a prov:Activity , nidm:Inference ;
 niiri:model_pe_id prov:used niiri:error_model_id ;
 	a prov:Activity , nidm:ModelParametersEstimation ;
 	rdfs:label "Model parameters estimation" ;
-	nidm:withEstimationMethod nidm:OrdinaryLeastSquares ;
+	nidm:withEstimationMethod obo:STATO_0000370 ; # obo:'ordinary least squares estimation'
 	prov:used niiri:design_matrix_id ;
     prov:used niiri:data_id ;
     prov:used niiri:error_model_id ;

--- a/nidm/nidm-results/scripts/create_example_from_templates.py
+++ b/nidm/nidm-results/scripts/create_example_from_templates.py
@@ -38,10 +38,13 @@ class ExampleFromTemplate(object):
             nidm_tpm = Template(fid.read())
             fid.close()
 
-            # try:
-            class_example = nidm_tpm.substitute(**substitutes)
-            # except KeyError:
-            #     print nidm_class
+            try:
+                class_example = nidm_tpm.substitute(**substitutes)
+            except KeyError as e:
+                print template_name
+                print nidm_class
+                print substitutes
+                raise e
 
             if self.one_file_per_class:
                 example_file = os.path.join(self.dir, nidm_class+".txt")

--- a/nidm/nidm-results/scripts/create_fsl_example.py
+++ b/nidm/nidm-results/scripts/create_fsl_example.py
@@ -14,7 +14,7 @@ RELPATH = os.path.dirname(os.path.abspath(__file__))
 NIDMRESULTSPATH = os.path.dirname(RELPATH)
 # Append parent script directory to path
 sys.path.append(os.path.join(NIDMRESULTSPATH, os.pardir, os.pardir, "scripts"))
-from Constants import STATO_OLS_STR
+from Constants import STATO_OLS_STR, STATO_OLS_LABEL
 
 def main():
 	nidm_classes = {
@@ -49,6 +49,7 @@ def main():
 			model_pe_id="niiri:model_pe_id",
 			label="Model parameters estimation",
 			est_method=STATO_OLS_STR,
+			est_method_comment=STATO_OLS_LABEL,
 			design_matrix_id="niiri:design_matrix_id",
 			data_matrix_id="niiri:data_id",
 			error_model_id="niiri:error_model_id",

--- a/nidm/nidm-results/scripts/create_fsl_example.py
+++ b/nidm/nidm-results/scripts/create_fsl_example.py
@@ -8,6 +8,14 @@ templates available in nidm/nidm-results/terms/templates
 import os
 from create_example_from_templates import ExampleFromTemplate
 
+import sys
+
+RELPATH = os.path.dirname(os.path.abspath(__file__))
+NIDMRESULTSPATH = os.path.dirname(RELPATH)
+# Append parent script directory to path
+sys.path.append(os.path.join(NIDMRESULTSPATH, os.pardir, os.pardir, "scripts"))
+from Constants import STATO_OLS_STR
+
 def main():
 	nidm_classes = {
 		"DesignMatrix": dict(
@@ -40,7 +48,7 @@ def main():
 		"ModelParametersEstimation": dict(
 			model_pe_id="niiri:model_pe_id",
 			label="Model parameters estimation",
-			est_method="nidm:OrdinaryLeastSquares",
+			est_method=STATO_OLS_STR,
 			design_matrix_id="niiri:design_matrix_id",
 			data_matrix_id="niiri:data_id",
 			error_model_id="niiri:error_model_id",

--- a/nidm/nidm-results/scripts/create_fsl_example_001.py
+++ b/nidm/nidm-results/scripts/create_fsl_example_001.py
@@ -14,7 +14,7 @@ RELPATH = os.path.dirname(os.path.abspath(__file__))
 NIDMRESULTSPATH = os.path.dirname(RELPATH)
 # Append parent script directory to path
 sys.path.append(os.path.join(NIDMRESULTSPATH, os.pardir, os.pardir, "scripts"))
-from Constants import STATO_GLS_STR
+from Constants import STATO_GLS_STR, STATO_GLS_LABEL
 
 def main():
 	nidm_classes = {
@@ -49,6 +49,7 @@ def main():
 			model_pe_id="niiri:model_parameters_estimation_id",
 			label="Model Parameters Estimation",
 			est_method=STATO_GLS_STR,
+			est_method_comment=STATO_GLS_LABEL,
 			design_matrix_id="niiri:design_matrix_id",
 			data_matrix_id="niiri:data_id",
 			error_model_id="niiri:error_model_id",

--- a/nidm/nidm-results/scripts/create_fsl_example_001.py
+++ b/nidm/nidm-results/scripts/create_fsl_example_001.py
@@ -8,6 +8,14 @@ templates available in nidm/nidm-results/terms/templates
 import os
 from create_example_from_templates import ExampleFromTemplate
 
+import sys
+
+RELPATH = os.path.dirname(os.path.abspath(__file__))
+NIDMRESULTSPATH = os.path.dirname(RELPATH)
+# Append parent script directory to path
+sys.path.append(os.path.join(NIDMRESULTSPATH, os.pardir, os.pardir, "scripts"))
+from Constants import STATO_GLS_STR
+
 def main():
 	nidm_classes = {
 		"DesignMatrix": dict(
@@ -40,7 +48,7 @@ def main():
 		"ModelParametersEstimation": dict(
 			model_pe_id="niiri:model_parameters_estimation_id",
 			label="Model Parameters Estimation",
-			est_method="nidm:GeneralizedLeastSquares",
+			est_method=STATO_GLS_STR,
 			design_matrix_id="niiri:design_matrix_id",
 			data_matrix_id="niiri:data_id",
 			error_model_id="niiri:error_model_id",

--- a/nidm/nidm-results/scripts/create_results_specification.py
+++ b/nidm/nidm-results/scripts/create_results_specification.py
@@ -10,9 +10,11 @@ import os
 from rdflib.compare import *
 import sys
 import collections
+import glob
 
 RELPATH = os.path.dirname(os.path.abspath(__file__))
 NIDMRESULTSPATH = os.path.dirname(RELPATH)
+NIDMPATH = os.path.join(NIDMRESULTSPATH, os.pardir)
 
 # Append parent script directory to path
 sys.path.append(os.path.join(NIDMRESULTSPATH, os.pardir, os.pardir, "scripts"))
@@ -35,9 +37,13 @@ def main():
     # Retreive owl file for NIDM-Results
     if nidm_version == "dev":
         owl_file = os.path.join(TERMS_FOLDER, 'nidm-results.owl')
+        import_files = glob.glob(os.path.join(NIDMPATH, "imports", '*.ttl'))
+
     else:
         owl_file = os.path.join(RELEASED_TERMS_FOLDER, \
             'nidm-results_'+nidm_version+'.owl')
+        # For released version of the ontology imports are embedded
+        import_files = None
 
     # check the file exists
     assert os.path.exists(owl_file)
@@ -107,8 +113,8 @@ def main():
              NIDM['Cluster'], NIDM['Peak'],
              NIDM['Coordinate']]
 
-    owlspec = OwlSpecification(owl_file, "NIDM-Results", components, used_by, 
-        generated_by, derived_from, prefix=str(NIDM))
+    owlspec = OwlSpecification(owl_file, import_files, "NIDM-Results", 
+        components, used_by, generated_by, derived_from, prefix=str(NIDM))
 
     owlspec._header_footer(component="nidm-results")
 

--- a/nidm/nidm-results/scripts/create_spm_example.py
+++ b/nidm/nidm-results/scripts/create_spm_example.py
@@ -14,7 +14,7 @@ RELPATH = os.path.dirname(os.path.abspath(__file__))
 NIDMRESULTSPATH = os.path.dirname(RELPATH)
 # Append parent script directory to path
 sys.path.append(os.path.join(NIDMRESULTSPATH, os.pardir, os.pardir, "scripts"))
-from Constants import STATO_OLS_STR
+from Constants import STATO_OLS_STR, STATO_OLS_LABEL
 
 def main():
 	nidm_classes = {
@@ -70,6 +70,7 @@ def main():
 			model_pe_id="niiri:model_pe_id",
 			label="Model parameters estimation",
 			est_method=STATO_OLS_STR,
+			est_method_comment=STATO_OLS_LABEL,
 			design_matrix_id="niiri:design_matrix_id",
 			data_matrix_id="niiri:data_id",
 			error_model_id="niiri:error_model_id",

--- a/nidm/nidm-results/scripts/create_spm_example.py
+++ b/nidm/nidm-results/scripts/create_spm_example.py
@@ -8,6 +8,14 @@ templates available in nidm/nidm-results/terms/templates
 import os
 from create_example_from_templates import ExampleFromTemplate
 
+import sys
+
+RELPATH = os.path.dirname(os.path.abspath(__file__))
+NIDMRESULTSPATH = os.path.dirname(RELPATH)
+# Append parent script directory to path
+sys.path.append(os.path.join(NIDMRESULTSPATH, os.pardir, os.pardir, "scripts"))
+from Constants import STATO_OLS_STR
+
 def main():
 	nidm_classes = {
 		"DesignMatrix": dict(
@@ -61,7 +69,7 @@ def main():
 		"ModelParametersEstimation": dict(
 			model_pe_id="niiri:model_pe_id",
 			label="Model parameters estimation",
-			est_method="nidm:OrdinaryLeastSquares",
+			est_method=STATO_OLS_STR,
 			design_matrix_id="niiri:design_matrix_id",
 			data_matrix_id="niiri:data_id",
 			error_model_id="niiri:error_model_id",

--- a/nidm/nidm-results/scripts/create_spm_example_001.py
+++ b/nidm/nidm-results/scripts/create_spm_example_001.py
@@ -8,6 +8,14 @@ class templates available in nidm/nidm-results/terms/templates
 import os
 from create_example_from_templates import ExampleFromTemplate
 
+import sys
+
+RELPATH = os.path.dirname(os.path.abspath(__file__))
+NIDMRESULTSPATH = os.path.dirname(RELPATH)
+# Append parent script directory to path
+sys.path.append(os.path.join(NIDMRESULTSPATH, os.pardir, os.pardir, "scripts"))
+from Constants import STATO_GLS_STR
+
 def main():
 	nidm_classes = {
 		"DesignMatrix": dict(
@@ -40,7 +48,7 @@ def main():
 		"ModelParametersEstimation": dict(
 			model_pe_id="niiri:model_pe_id",
 			label="Model parameters estimation",
-			est_method="nidm:GeneralizedLeastSquares",
+			est_method=STATO_GLS_STR,
 			design_matrix_id="niiri:design_matrix_id",
 			data_matrix_id="niiri:data_id",
 			error_model_id="niiri:error_model_id",

--- a/nidm/nidm-results/scripts/create_spm_example_001.py
+++ b/nidm/nidm-results/scripts/create_spm_example_001.py
@@ -14,7 +14,7 @@ RELPATH = os.path.dirname(os.path.abspath(__file__))
 NIDMRESULTSPATH = os.path.dirname(RELPATH)
 # Append parent script directory to path
 sys.path.append(os.path.join(NIDMRESULTSPATH, os.pardir, os.pardir, "scripts"))
-from Constants import STATO_GLS_STR
+from Constants import STATO_GLS_STR, STATO_GLS_LABEL
 
 def main():
 	nidm_classes = {
@@ -49,6 +49,7 @@ def main():
 			model_pe_id="niiri:model_pe_id",
 			label="Model parameters estimation",
 			est_method=STATO_GLS_STR,
+			est_method_comment=STATO_GLS_LABEL,
 			design_matrix_id="niiri:design_matrix_id",
 			data_matrix_id="niiri:data_id",
 			error_model_id="niiri:error_model_id",

--- a/nidm/nidm-results/scripts/create_spm_example_002.py
+++ b/nidm/nidm-results/scripts/create_spm_example_002.py
@@ -8,6 +8,14 @@ class templates available in nidm/nidm-results/terms/templates
 import os
 from create_example_from_templates import ExampleFromTemplate
 
+import sys
+
+RELPATH = os.path.dirname(os.path.abspath(__file__))
+NIDMRESULTSPATH = os.path.dirname(RELPATH)
+# Append parent script directory to path
+sys.path.append(os.path.join(NIDMRESULTSPATH, os.pardir, os.pardir, "scripts"))
+from Constants import STATO_OLS_STR
+
 def main():
 	nidm_classes = {
 		"DesignMatrix": dict(
@@ -40,7 +48,7 @@ def main():
 		"ModelParametersEstimation": dict(
 			model_pe_id="niiri:model_pe_id",
 			label="Model parameters estimation",
-			est_method="nidm:OrdinaryLeastSquares",
+			est_method=STATO_OLS_STR,
 			design_matrix_id="niiri:design_matrix_id",
 			data_matrix_id="niiri:data_id",
 			error_model_id="niiri:error_model_id",

--- a/nidm/nidm-results/scripts/create_spm_example_002.py
+++ b/nidm/nidm-results/scripts/create_spm_example_002.py
@@ -14,7 +14,7 @@ RELPATH = os.path.dirname(os.path.abspath(__file__))
 NIDMRESULTSPATH = os.path.dirname(RELPATH)
 # Append parent script directory to path
 sys.path.append(os.path.join(NIDMRESULTSPATH, os.pardir, os.pardir, "scripts"))
-from Constants import STATO_OLS_STR
+from Constants import STATO_OLS_STR, STATO_OLS_LABEL
 
 def main():
 	nidm_classes = {
@@ -49,6 +49,7 @@ def main():
 			model_pe_id="niiri:model_pe_id",
 			label="Model parameters estimation",
 			est_method=STATO_OLS_STR,
+			est_method_comment=STATO_OLS_LABEL,
 			design_matrix_id="niiri:design_matrix_id",
 			data_matrix_id="niiri:data_id",
 			error_model_id="niiri:error_model_id",

--- a/nidm/nidm-results/scripts/create_spm_example_003.py
+++ b/nidm/nidm-results/scripts/create_spm_example_003.py
@@ -8,6 +8,14 @@ class templates available in nidm/nidm-results/terms/templates
 import os
 from create_example_from_templates import ExampleFromTemplate
 
+import sys
+
+RELPATH = os.path.dirname(os.path.abspath(__file__))
+NIDMRESULTSPATH = os.path.dirname(RELPATH)
+# Append parent script directory to path
+sys.path.append(os.path.join(NIDMRESULTSPATH, os.pardir, os.pardir, "scripts"))
+from Constants import STATO_OLS_STR
+
 def main():
 	nidm_classes = {
 		"DesignMatrix": dict(
@@ -40,7 +48,7 @@ def main():
 		"ModelParametersEstimation": dict(
 			model_pe_id="niiri:model_pe_id",
 			label="Model parameters estimation",
-			est_method="nidm:OrdinaryLeastSquares",
+			est_method=STATO_OLS_STR,
 			design_matrix_id="niiri:design_matrix_id",
 			data_matrix_id="niiri:data_id",
 			error_model_id="niiri:error_model_id",

--- a/nidm/nidm-results/scripts/create_spm_example_003.py
+++ b/nidm/nidm-results/scripts/create_spm_example_003.py
@@ -14,7 +14,7 @@ RELPATH = os.path.dirname(os.path.abspath(__file__))
 NIDMRESULTSPATH = os.path.dirname(RELPATH)
 # Append parent script directory to path
 sys.path.append(os.path.join(NIDMRESULTSPATH, os.pardir, os.pardir, "scripts"))
-from Constants import STATO_OLS_STR
+from Constants import STATO_OLS_STR, STATO_OLS_LABEL
 
 def main():
 	nidm_classes = {
@@ -49,6 +49,7 @@ def main():
 			model_pe_id="niiri:model_pe_id",
 			label="Model parameters estimation",
 			est_method=STATO_OLS_STR,
+			est_method_comment=STATO_OLS_LABEL,
 			design_matrix_id="niiri:design_matrix_id",
 			data_matrix_id="niiri:data_id",
 			error_model_id="niiri:error_model_id",

--- a/nidm/nidm-results/scripts/create_term_examples.py
+++ b/nidm/nidm-results/scripts/create_term_examples.py
@@ -14,7 +14,7 @@ RELPATH = os.path.dirname(os.path.abspath(__file__))
 NIDMRESULTSPATH = os.path.dirname(RELPATH)
 # Append parent script directory to path
 sys.path.append(os.path.join(NIDMRESULTSPATH, os.pardir, os.pardir, "scripts"))
-from Constants import STATO_OLS_STR
+from Constants import STATO_OLS_STR, STATO_OLS_LABEL
 
 def main():
 	nidm_classes = {
@@ -49,6 +49,7 @@ def main():
 			model_pe_id="niiri:model_pe_id",
 			label="Model parameters estimation",
 			est_method=STATO_OLS_STR,
+			est_method_comment=STATO_OLS_LABEL,
 			software_id="niiri:software_id",
 			design_matrix_id="niiri:design_matrix_id",
 			data_matrix_id="niiri:data_id",

--- a/nidm/nidm-results/scripts/create_term_examples.py
+++ b/nidm/nidm-results/scripts/create_term_examples.py
@@ -8,6 +8,14 @@ by using the class templates available in nidm/nidm-results/terms/templates
 import os
 from create_example_from_templates import ExampleFromTemplate
 
+import sys
+
+RELPATH = os.path.dirname(os.path.abspath(__file__))
+NIDMRESULTSPATH = os.path.dirname(RELPATH)
+# Append parent script directory to path
+sys.path.append(os.path.join(NIDMRESULTSPATH, os.pardir, os.pardir, "scripts"))
+from Constants import STATO_OLS_STR
+
 def main():
 	nidm_classes = {
 		"DesignMatrix": dict(
@@ -40,7 +48,7 @@ def main():
 		"ModelParametersEstimation": dict(
 			model_pe_id="niiri:model_pe_id",
 			label="Model parameters estimation",
-			est_method="nidm:OrdinaryLeastSquares",
+			est_method=STATO_OLS_STR,
 			software_id="niiri:software_id",
 			design_matrix_id="niiri:design_matrix_id",
 			data_matrix_id="niiri:data_id",

--- a/nidm/nidm-results/spm/README.md
+++ b/nidm/nidm-results/spm/README.md
@@ -1,9 +1,9 @@
 
-Prov store: https://provenance.ecs.soton.ac.uk/store/documents/76675/
+Prov store: https://provenance.ecs.soton.ac.uk/store/documents/76695/
 	
-Alternative serialisations: [json](https://provenance.ecs.soton.ac.uk/store/documents/76675.json), [turtle](https://provenance.ecs.soton.ac.uk/store/documents/76675.ttl), 
-Graph: [svg](https://provenance.ecs.soton.ac.uk/store/documents/76675.svg), [PDF](https://provenance.ecs.soton.ac.uk/store/documents/76675.pdf), [png](https://provenance.ecs.soton.ac.uk/store/documents/76675.png)
+Alternative serialisations: [json](https://provenance.ecs.soton.ac.uk/store/documents/76695.json), [turtle](https://provenance.ecs.soton.ac.uk/store/documents/76695.ttl), 
+Graph: [svg](https://provenance.ecs.soton.ac.uk/store/documents/76695.svg), [PDF](https://provenance.ecs.soton.ac.uk/store/documents/76695.pdf), [png](https://provenance.ecs.soton.ac.uk/store/documents/76695.png)
 
-![Prov Graph](https://provenance.ecs.soton.ac.uk/store/documents/76675.png)
+![Prov Graph](https://provenance.ecs.soton.ac.uk/store/documents/76695.png)
 
 		

--- a/nidm/nidm-results/spm/example001/README.md
+++ b/nidm/nidm-results/spm/example001/README.md
@@ -1,9 +1,9 @@
 
-Prov store: https://provenance.ecs.soton.ac.uk/store/documents/76680/
+Prov store: https://provenance.ecs.soton.ac.uk/store/documents/76700/
 	
-Alternative serialisations: [json](https://provenance.ecs.soton.ac.uk/store/documents/76680.json), [turtle](https://provenance.ecs.soton.ac.uk/store/documents/76680.ttl), 
-Graph: [svg](https://provenance.ecs.soton.ac.uk/store/documents/76680.svg), [PDF](https://provenance.ecs.soton.ac.uk/store/documents/76680.pdf), [png](https://provenance.ecs.soton.ac.uk/store/documents/76680.png)
+Alternative serialisations: [json](https://provenance.ecs.soton.ac.uk/store/documents/76700.json), [turtle](https://provenance.ecs.soton.ac.uk/store/documents/76700.ttl), 
+Graph: [svg](https://provenance.ecs.soton.ac.uk/store/documents/76700.svg), [PDF](https://provenance.ecs.soton.ac.uk/store/documents/76700.pdf), [png](https://provenance.ecs.soton.ac.uk/store/documents/76700.png)
 
-![Prov Graph](https://provenance.ecs.soton.ac.uk/store/documents/76680.png)
+![Prov Graph](https://provenance.ecs.soton.ac.uk/store/documents/76700.png)
 
 		

--- a/nidm/nidm-results/spm/example001/example001_spm_results.provn
+++ b/nidm/nidm-results/spm/example001/example001_spm_results.provn
@@ -1,6 +1,7 @@
 document
 prefix crypto <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#>
 prefix neurolex <http://neurolex.org/wiki/>
+prefix obo <http://purl.obolibrary.org/obo/>
 prefix dct <http://purl.org/dc/terms/>
 prefix spm <http://www.incf.org/ns/nidash/spm#>
 prefix pre_0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
@@ -13,7 +14,7 @@ prefix xsd <http://www.w3.org/2001/XMLSchema>
 prefix bnode <http://openprovenance.org/provtoolbox/bnode/>
 prefix dctype <http://purl.org/dc/dcmitype/>
 prefix dc <http://purl.org/dc/elements/1.1/>
-activity(niiri:model_pe_id,-,-,[prov:type = 'nidm:ModelParametersEstimation', prov:label = "Model parameters estimation", nidm:withEstimationMethod = 'nidm:GeneralizedLeastSquares'])
+activity(niiri:model_pe_id,-,-,[prov:type = 'nidm:ModelParametersEstimation', prov:label = "Model parameters estimation", nidm:withEstimationMethod = 'obo:STATO_0000372'])
 activity(niiri:inference_id,-,-,[prov:type = 'nidm:Inference', prov:label = "Inference", nidm:hasAlternativeHypothesis = 'nidm:OneTailedTest'])
 activity(niiri:contrast_estimation_id,-,-,[prov:type = 'nidm:ContrastEstimation', prov:label = "Contrast estimation"])
 agent(niiri:software_id,[prov:type = 'nidm:SPM', prov:type = 'prov:SoftwareAgent', prov:label = "SPM", nidm:softwareVersion = "SPM12" %% xsd:string, spm:softwareRevision = "5853" %% xsd:string])

--- a/nidm/nidm-results/spm/example001/example001_spm_results.ttl
+++ b/nidm/nidm-results/spm/example001/example001_spm_results.ttl
@@ -11,6 +11,9 @@
 @prefix niiri: <http://iri.nidash.org/> .
 @prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix obo: <http://purl.obolibrary.org/obo/> .
+
+
 
 niiri:cluster_0001 a prov:Entity , nidm:Cluster ;
 	rdfs:label "Cluster: 0001" ;
@@ -308,7 +311,7 @@ niiri:mask_id_1 a prov:Entity , nidm:MaskMap ;
 niiri:model_pe_id prov:used niiri:error_model_id ;
 	a prov:Activity , nidm:ModelParametersEstimation ;
 	rdfs:label "Model parameters estimation" ;
-	nidm:withEstimationMethod nidm:GeneralizedLeastSquares ;
+	nidm:withEstimationMethod obo:STATO_0000372 ; # obo:'generalized least squares estimation'
 	prov:used niiri:design_matrix_id ;
     prov:used niiri:data_id ;
     prov:used niiri:error_model_id ;

--- a/nidm/nidm-results/spm/example002/README.md
+++ b/nidm/nidm-results/spm/example002/README.md
@@ -1,9 +1,9 @@
 
-Prov store: https://provenance.ecs.soton.ac.uk/store/documents/76678/
+Prov store: https://provenance.ecs.soton.ac.uk/store/documents/76698/
 	
-Alternative serialisations: [json](https://provenance.ecs.soton.ac.uk/store/documents/76678.json), [turtle](https://provenance.ecs.soton.ac.uk/store/documents/76678.ttl), 
-Graph: [svg](https://provenance.ecs.soton.ac.uk/store/documents/76678.svg), [PDF](https://provenance.ecs.soton.ac.uk/store/documents/76678.pdf), [png](https://provenance.ecs.soton.ac.uk/store/documents/76678.png)
+Alternative serialisations: [json](https://provenance.ecs.soton.ac.uk/store/documents/76698.json), [turtle](https://provenance.ecs.soton.ac.uk/store/documents/76698.ttl), 
+Graph: [svg](https://provenance.ecs.soton.ac.uk/store/documents/76698.svg), [PDF](https://provenance.ecs.soton.ac.uk/store/documents/76698.pdf), [png](https://provenance.ecs.soton.ac.uk/store/documents/76698.png)
 
-![Prov Graph](https://provenance.ecs.soton.ac.uk/store/documents/76678.png)
+![Prov Graph](https://provenance.ecs.soton.ac.uk/store/documents/76698.png)
 
 		

--- a/nidm/nidm-results/spm/example002/spm_results_2contrasts.provn
+++ b/nidm/nidm-results/spm/example002/spm_results_2contrasts.provn
@@ -1,6 +1,7 @@
 document
 prefix crypto <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#>
 prefix neurolex <http://neurolex.org/wiki/>
+prefix obo <http://purl.obolibrary.org/obo/>
 prefix dct <http://purl.org/dc/terms/>
 prefix spm <http://www.incf.org/ns/nidash/spm#>
 prefix pre_0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
@@ -13,7 +14,7 @@ prefix xsd <http://www.w3.org/2001/XMLSchema>
 prefix bnode <http://openprovenance.org/provtoolbox/bnode/>
 prefix dctype <http://purl.org/dc/dcmitype/>
 prefix dc <http://purl.org/dc/elements/1.1/>
-activity(niiri:model_pe_id,-,-,[prov:type = 'nidm:ModelParametersEstimation', prov:label = "Model parameters estimation", nidm:withEstimationMethod = 'nidm:OrdinaryLeastSquares'])
+activity(niiri:model_pe_id,-,-,[prov:type = 'nidm:ModelParametersEstimation', prov:label = "Model parameters estimation", nidm:withEstimationMethod = 'obo:STATO_0000370'])
 activity(niiri:inference_id_2,-,-,[prov:type = 'nidm:Inference', prov:label = "Inference 2", nidm:hasAlternativeHypothesis = 'nidm:OneTailedTest'])
 activity(niiri:inference_id_3,-,-,[prov:type = 'nidm:ConjunctionInference', prov:label = "Conjunction Inference 3", nidm:hasAlternativeHypothesis = 'nidm:OneTailedTest'])
 activity(niiri:inference_id,-,-,[prov:type = 'nidm:Inference', prov:label = "Inference 1", nidm:hasAlternativeHypothesis = 'nidm:OneTailedTest'])

--- a/nidm/nidm-results/spm/example002/spm_results_2contrasts.ttl
+++ b/nidm/nidm-results/spm/example002/spm_results_2contrasts.ttl
@@ -11,6 +11,9 @@
 @prefix niiri: <http://iri.nidash.org/> .
 @prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix obo: <http://purl.obolibrary.org/obo/> .
+
+
 
 niiri:cluster_definition_criteria_id a prov:Entity , nidm:ClusterDefinitionCriteria ;
 	rdfs:label "Cluster Connectivity Criterion: 18" ;
@@ -285,7 +288,7 @@ niiri:mask_id_1 a prov:Entity , nidm:MaskMap ;
 niiri:model_pe_id prov:used niiri:error_model_id ;
 	a prov:Activity , nidm:ModelParametersEstimation ;
 	rdfs:label "Model parameters estimation" ;
-	nidm:withEstimationMethod nidm:OrdinaryLeastSquares ;
+	nidm:withEstimationMethod obo:STATO_0000370 ; # obo:'ordinary least squares estimation'
 	prov:used niiri:design_matrix_id ;
     prov:used niiri:data_id ;
     prov:used niiri:error_model_id ;

--- a/nidm/nidm-results/spm/example003/README.md
+++ b/nidm/nidm-results/spm/example003/README.md
@@ -1,9 +1,9 @@
 
-Prov store: https://provenance.ecs.soton.ac.uk/store/documents/76676/
+Prov store: https://provenance.ecs.soton.ac.uk/store/documents/76696/
 	
-Alternative serialisations: [json](https://provenance.ecs.soton.ac.uk/store/documents/76676.json), [turtle](https://provenance.ecs.soton.ac.uk/store/documents/76676.ttl), 
-Graph: [svg](https://provenance.ecs.soton.ac.uk/store/documents/76676.svg), [PDF](https://provenance.ecs.soton.ac.uk/store/documents/76676.pdf), [png](https://provenance.ecs.soton.ac.uk/store/documents/76676.png)
+Alternative serialisations: [json](https://provenance.ecs.soton.ac.uk/store/documents/76696.json), [turtle](https://provenance.ecs.soton.ac.uk/store/documents/76696.ttl), 
+Graph: [svg](https://provenance.ecs.soton.ac.uk/store/documents/76696.svg), [PDF](https://provenance.ecs.soton.ac.uk/store/documents/76696.pdf), [png](https://provenance.ecs.soton.ac.uk/store/documents/76696.png)
 
-![Prov Graph](https://provenance.ecs.soton.ac.uk/store/documents/76676.png)
+![Prov Graph](https://provenance.ecs.soton.ac.uk/store/documents/76696.png)
 
 		

--- a/nidm/nidm-results/spm/example003/spm_results_conjunction.provn
+++ b/nidm/nidm-results/spm/example003/spm_results_conjunction.provn
@@ -1,6 +1,7 @@
 document
 prefix crypto <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#>
 prefix neurolex <http://neurolex.org/wiki/>
+prefix obo <http://purl.obolibrary.org/obo/>
 prefix dct <http://purl.org/dc/terms/>
 prefix spm <http://www.incf.org/ns/nidash/spm#>
 prefix pre_0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
@@ -13,7 +14,7 @@ prefix xsd <http://www.w3.org/2001/XMLSchema>
 prefix bnode <http://openprovenance.org/provtoolbox/bnode/>
 prefix dctype <http://purl.org/dc/dcmitype/>
 prefix dc <http://purl.org/dc/elements/1.1/>
-activity(niiri:model_pe_id,-,-,[prov:type = 'nidm:ModelParametersEstimation', prov:label = "Model parameters estimation", nidm:withEstimationMethod = 'nidm:OrdinaryLeastSquares'])
+activity(niiri:model_pe_id,-,-,[prov:type = 'nidm:ModelParametersEstimation', prov:label = "Model parameters estimation", nidm:withEstimationMethod = 'obo:STATO_0000370'])
 activity(niiri:contrast_estimation_id,-,-,[prov:type = 'nidm:ContrastEstimation', prov:label = "Contrast estimation 1"])
 activity(niiri:contrast_estimation_id_2,-,-,[prov:type = 'nidm:ContrastEstimation', prov:label = "Contrast estimation 2"])
 activity(niiri:inference_id,-,-,[prov:type = 'nidm:ConjunctionInference', prov:label = "Conjunction Inference", nidm:hasAlternativeHypothesis = 'nidm:OneTailedTest'])

--- a/nidm/nidm-results/spm/example003/spm_results_conjunction.ttl
+++ b/nidm/nidm-results/spm/example003/spm_results_conjunction.ttl
@@ -11,6 +11,9 @@
 @prefix niiri: <http://iri.nidash.org/> .
 @prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix obo: <http://purl.obolibrary.org/obo/> .
+
+
 
 niiri:cluster_definition_criteria_id a prov:Entity , nidm:ClusterDefinitionCriteria ;
 	rdfs:label "Cluster Connectivity Criterion: 18" ;
@@ -221,7 +224,7 @@ niiri:mask_id_1 a prov:Entity , nidm:MaskMap ;
 niiri:model_pe_id prov:used niiri:error_model_id ;
 	a prov:Activity , nidm:ModelParametersEstimation ;
 	rdfs:label "Model parameters estimation" ;
-	nidm:withEstimationMethod nidm:OrdinaryLeastSquares ;
+	nidm:withEstimationMethod obo:STATO_0000370 ; # obo:'ordinary least squares estimation'
 	prov:used niiri:design_matrix_id ;
     prov:used niiri:data_id ;
     prov:used niiri:error_model_id ;

--- a/nidm/nidm-results/spm/example004/spm_inference_activities.provn
+++ b/nidm/nidm-results/spm/example004/spm_inference_activities.provn
@@ -1,6 +1,7 @@
 document
 prefix crypto <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#>
 prefix neurolex <http://neurolex.org/wiki/>
+prefix obo <http://purl.obolibrary.org/obo/>
 prefix dct <http://purl.org/dc/terms/>
 prefix spm <http://www.incf.org/ns/nidash/spm#>
 prefix pre_0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#>

--- a/nidm/nidm-results/spm/example004/spm_inference_activities.ttl
+++ b/nidm/nidm-results/spm/example004/spm_inference_activities.ttl
@@ -11,6 +11,9 @@
 @prefix niiri: <http://iri.nidash.org/> .
 @prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix obo: <http://purl.obolibrary.org/obo/> .
+
+
 
 niiri:conjunction_id_1 a prov:Activity , nidm:ConjunctionInference ;
 	rdfs:label "Conjunction Inference" ;

--- a/nidm/nidm-results/spm/spm_results.provn
+++ b/nidm/nidm-results/spm/spm_results.provn
@@ -1,6 +1,7 @@
 document
 prefix crypto <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#>
 prefix neurolex <http://neurolex.org/wiki/>
+prefix obo <http://purl.obolibrary.org/obo/>
 prefix dct <http://purl.org/dc/terms/>
 prefix spm <http://www.incf.org/ns/nidash/spm#>
 prefix pre_0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
@@ -13,7 +14,7 @@ prefix xsd <http://www.w3.org/2001/XMLSchema>
 prefix bnode <http://openprovenance.org/provtoolbox/bnode/>
 prefix dctype <http://purl.org/dc/dcmitype/>
 prefix dc <http://purl.org/dc/elements/1.1/>
-activity(niiri:model_pe_id,-,-,[prov:type = 'nidm:ModelParametersEstimation', prov:label = "Model parameters estimation", nidm:withEstimationMethod = 'nidm:OrdinaryLeastSquares'])
+activity(niiri:model_pe_id,-,-,[prov:type = 'nidm:ModelParametersEstimation', prov:label = "Model parameters estimation", nidm:withEstimationMethod = 'obo:STATO_0000370'])
 activity(niiri:inference_id,-,-,[prov:type = 'nidm:Inference', prov:label = "Inference", nidm:hasAlternativeHypothesis = 'nidm:OneTailedTest'])
 activity(niiri:contrast_estimation_id,-,-,[prov:type = 'nidm:ContrastEstimation', prov:label = "Contrast estimation"])
 agent(niiri:software_id,[prov:type = 'nidm:SPM', prov:type = 'prov:SoftwareAgent', prov:label = "SPM", nidm:softwareVersion = "SPM12b" %% xsd:string, spm:softwareRevision = "5853" %% xsd:string])

--- a/nidm/nidm-results/spm/spm_results.ttl
+++ b/nidm/nidm-results/spm/spm_results.ttl
@@ -11,6 +11,9 @@
 @prefix niiri: <http://iri.nidash.org/> .
 @prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix obo: <http://purl.obolibrary.org/obo/> .
+
+
 
 niiri:cluster_0001 a prov:Entity , nidm:Cluster ;
 	rdfs:label "Cluster 0001" ;
@@ -354,7 +357,7 @@ niiri:model_pe_id prov:used niiri:mask_id_1 .
 niiri:model_pe_id prov:used niiri:error_model_id ;
 	a prov:Activity , nidm:ModelParametersEstimation ;
 	rdfs:label "Model parameters estimation" ;
-	nidm:withEstimationMethod nidm:OrdinaryLeastSquares ;
+	nidm:withEstimationMethod obo:STATO_0000370 ; # obo:'ordinary least squares estimation'
 	prov:used niiri:design_matrix_id ;
     prov:used niiri:data_id ;
     prov:used niiri:error_model_id ;

--- a/nidm/nidm-results/terms/catalog-v001.xml
+++ b/nidm/nidm-results/terms/catalog-v001.xml
@@ -2,6 +2,7 @@
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <uri id="Imports Wizard Entry" name="http://purl.org/nidash/nidm/nfo_import.owl" uri="../../imports/nfo_import.ttl"/>
     <uri id="Imports Wizard Entry" name="http://purl.org/nidash/nidm/dc_import.owl" uri="../../imports/dc_import.ttl"/>
+    <uri id="Imports Wizard Entry" name="http://purl.org/nidash/nidm/stato_import.owl" uri="../../imports/stato_import.ttl"/>
     <uri id="Imports Wizard Entry" name="http://www.w3.org/ns/prov-o-20130430" uri="http://www.w3.org/ns/prov-o-20130430"/>
     <uri id="Imports Wizard Entry" name="http://purl.obolibrary.org/nidm/iao_import.owl" uri="../../imports/iao_import.ttl"/>
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base=""/>

--- a/nidm/nidm-results/terms/examples/ModelParametersEstimation.txt
+++ b/nidm/nidm-results/terms/examples/ModelParametersEstimation.txt
@@ -1,7 +1,7 @@
 niiri:model_pe_id prov:used niiri:error_model_id ;
 	a prov:Activity , nidm:ModelParametersEstimation ;
 	rdfs:label "Model parameters estimation" ;
-	nidm:withEstimationMethod nidm:OrdinaryLeastSquares ;
+	nidm:withEstimationMethod obo:STATO_0000370 ; # obo:'ordinary least squares estimation'
 	prov:used niiri:design_matrix_id ;
     prov:used niiri:data_id ;
     prov:used niiri:error_model_id ;

--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -2,7 +2,6 @@
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix fsl: <http://www.incf.org/ns/nidash/fsl#> .
-@prefix iao: <http://purl.obolibrary.org/obo/> .
 @prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -75,11 +74,11 @@ nidm:dependenceSpatialModel rdf:type owl:ObjectProperty ;
 
 nidm:hasAlternativeHypothesis rdf:type owl:ObjectProperty ;
                               
-                              iao:IAO_0000116 "Discussed in https://github.com/incf-nidash/nidm/pull/81" ;
+                              obo:IAO_0000116 "Discussed in https://github.com/incf-nidash/nidm/pull/81" ;
                               
                               owl:sameAs "http://purl.obolibrary.org/obo/STATO_0000208" ;
                               
-                              iao:IAO_0000114 iao:IAO_0000122 ;
+                              obo:IAO_0000114 obo:IAO_0000122 ;
                               
                               rdfs:domain nidm:Inference ;
                               
@@ -94,11 +93,11 @@ nidm:hasAlternativeHypothesis rdf:type owl:ObjectProperty ;
 
 nidm:hasClusterLabelsMap rdf:type owl:ObjectProperty ;
                          
-                         iao:IAO_0000112 "file:///path/to/cluster_labels.img" ;
+                         obo:IAO_0000112 "file:///path/to/cluster_labels.img" ;
                          
                          rdfs:isDefinedBy "A map whose value at each location denotes cluster membership. Each cluster is denoted by a different integer." ;
                          
-                         iao:IAO_0000114 iao:IAO_0000120 ;
+                         obo:IAO_0000114 obo:IAO_0000120 ;
                          
                          rdfs:range nidm:ClusterLabelsMap ;
                          
@@ -112,9 +111,9 @@ nidm:hasConnectivityCriterion rdf:type owl:ObjectProperty ;
                               
                               rdfs:isDefinedBy "Property that associates a ConnectivityCriterion with a ClusterDefinitionCriteria." ;
                               
-                              iao:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/201." ;
+                              obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/201." ;
                               
-                              iao:IAO_0000114 iao:IAO_0000122 ;
+                              obo:IAO_0000114 obo:IAO_0000122 ;
                               
                               rdfs:domain nidm:ClusterDefinitionCriteria ;
                               
@@ -128,7 +127,7 @@ nidm:hasErrorDependence rdf:type owl:ObjectProperty ;
                         
                         rdfs:isDefinedBy "Property that associates an ErrorDependence with an ErrorModel." ;
                         
-                        iao:IAO_0000114 iao:IAO_0000122 ;
+                        obo:IAO_0000114 obo:IAO_0000122 ;
                         
                         rdfs:range nidm:ErrorDependence ;
                         
@@ -142,7 +141,7 @@ nidm:hasErrorDistribution rdf:type owl:ObjectProperty ;
                           
                           rdfs:isDefinedBy "Property that associates an ErrorDistribution with an ErrorModel." ;
                           
-                          iao:IAO_0000114 iao:IAO_0000122 ;
+                          obo:IAO_0000114 obo:IAO_0000122 ;
                           
                           rdfs:range nidm:ErrorDistribution ;
                           
@@ -154,7 +153,7 @@ nidm:hasErrorDistribution rdf:type owl:ObjectProperty ;
 
 nidm:hasMapHeader rdf:type owl:ObjectProperty ;
                   
-                  iao:IAO_0000114 iao:IAO_0000124 ;
+                  obo:IAO_0000114 obo:IAO_0000124 ;
                   
                   rdfs:domain nidm:Map ;
                   
@@ -166,11 +165,11 @@ nidm:hasMapHeader rdf:type owl:ObjectProperty ;
 
 nidm:inCoordinateSpace rdf:type owl:ObjectProperty ;
                        
-                       iao:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/171 by NN JT CM SG KH TN." ;
+                       obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/171 by NN JT CM SG KH TN." ;
                        
                        rdfs:isDefinedBy "Property of a DataArray to associate a CoordinateSpace with a physical file." ;
                        
-                       iao:IAO_0000114 iao:IAO_0000122 ;
+                       obo:IAO_0000114 obo:IAO_0000122 ;
                        
                        rdfs:range nidm:CoordinateSpace ;
                        
@@ -184,9 +183,9 @@ nidm:inWorldCoordinateSystem rdf:type owl:ObjectProperty ;
                              
                              rdfs:isDefinedBy "Type of coordinate system." ;
                              
-                             iao:IAO_0000112 "nidm:MNICoordinateSystem" ;
+                             obo:IAO_0000112 "nidm:MNICoordinateSystem" ;
                              
-                             iao:IAO_0000114 iao:IAO_0000120 ;
+                             obo:IAO_0000114 obo:IAO_0000120 ;
                              
                              rdfs:domain nidm:CoordinateSpace ;
                              
@@ -198,7 +197,7 @@ nidm:inWorldCoordinateSystem rdf:type owl:ObjectProperty ;
 
 nidm:objectModel rdf:type owl:ObjectProperty ;
                  
-                 iao:IAO_0000114 iao:IAO_0000124 ;
+                 obo:IAO_0000114 obo:IAO_0000124 ;
                  
                  rdfs:range nidm:NIDMObjectModel ;
                  
@@ -210,7 +209,7 @@ nidm:objectModel rdf:type owl:ObjectProperty ;
 
 nidm:statisticType rdf:type owl:ObjectProperty ;
                    
-                   iao:IAO_0000114 iao:IAO_0000124 ;
+                   obo:IAO_0000114 obo:IAO_0000124 ;
                    
                    rdfs:domain nidm:ContrastWeights ;
                    
@@ -238,7 +237,7 @@ nidm:withEstimationMethod rdf:type owl:ObjectProperty ;
                           
                           rdfs:isDefinedBy "FIXME" ;
                           
-                          rdfs:range iao:STATO_0000119 ;
+                          rdfs:range obo:STATO_0000119 ;
                           
                           rdfs:domain nidm:ModelParametersEstimation .
 
@@ -250,11 +249,11 @@ spm:hasMaximumIntensityProjection rdf:type owl:ObjectProperty ;
                                   
                                   rdfs:isDefinedBy "Maximum intensity projection of a map." ;
                                   
-                                  iao:IAO_0000116 "Range: Path to an image (e.g.png)." ;
+                                  obo:IAO_0000116 "Range: Path to an image (e.g.png)." ;
                                   
-                                  iao:IAO_0000112 "file:///path/to/MIP.png" ;
+                                  obo:IAO_0000112 "file:///path/to/MIP.png" ;
                                   
-                                  iao:IAO_0000114 iao:IAO_0000120 ;
+                                  obo:IAO_0000114 obo:IAO_0000120 ;
                                   
                                   rdfs:range dctype:Image ;
                                   
@@ -299,11 +298,11 @@ dct:format rdf:type owl:DatatypeProperty ;
 
 fsl:coordinate1InVoxels rdf:type owl:DatatypeProperty ;
                         
-                        iao:IAO_0000112 "-60" ;
+                        obo:IAO_0000112 "-60" ;
                         
                         rdfs:isDefinedBy "Coordinate along the first dimension in voxels." ;
                         
-                        iao:IAO_0000114 iao:IAO_0000120 ;
+                        obo:IAO_0000114 obo:IAO_0000120 ;
                         
                         rdfs:domain nidm:Coordinate ;
                         
@@ -317,9 +316,9 @@ fsl:coordinate2InVoxels rdf:type owl:DatatypeProperty ;
                         
                         rdfs:isDefinedBy "Coordinate along the second dimension in voxels." ;
                         
-                        iao:IAO_0000112 "-28" ;
+                        obo:IAO_0000112 "-28" ;
                         
-                        iao:IAO_0000114 iao:IAO_0000120 ;
+                        obo:IAO_0000114 obo:IAO_0000120 ;
                         
                         rdfs:domain nidm:Coordinate ;
                         
@@ -333,9 +332,9 @@ fsl:coordinate3InVoxels rdf:type owl:DatatypeProperty ;
                         
                         rdfs:isDefinedBy "Coordinate along the third dimension in voxels" ;
                         
-                        iao:IAO_0000112 "13" ;
+                        obo:IAO_0000112 "13" ;
                         
-                        iao:IAO_0000114 iao:IAO_0000120 ;
+                        obo:IAO_0000114 obo:IAO_0000120 ;
                         
                         rdfs:domain nidm:Coordinate ;
                         
@@ -349,7 +348,7 @@ fsl:dlh rdf:type owl:DatatypeProperty ;
         
         rdfs:comment "To be renamed" ;
         
-        iao:IAO_0000114 iao:IAO_0000124 ;
+        obo:IAO_0000114 obo:IAO_0000124 ;
         
         rdfs:domain nidm:SearchSpaceMap ;
         
@@ -361,7 +360,7 @@ fsl:dlh rdf:type owl:DatatypeProperty ;
 
 fsl:featVersion rdf:type owl:DatatypeProperty ;
                 
-                iao:IAO_0000114 iao:IAO_0000124 ;
+                obo:IAO_0000114 obo:IAO_0000124 ;
                 
                 rdfs:domain nidm:FSL ;
                 
@@ -373,7 +372,7 @@ fsl:featVersion rdf:type owl:DatatypeProperty ;
 
 fsl:reselSizeInVoxels rdf:type owl:DatatypeProperty ;
                       
-                      iao:IAO_0000114 iao:IAO_0000124 ;
+                      obo:IAO_0000114 obo:IAO_0000124 ;
                       
                       rdfs:domain nidm:SearchSpaceMap ;
                       
@@ -389,7 +388,7 @@ fsl:searchVolumeInVoxels rdf:type owl:DatatypeProperty ;
                          
                          rdfs:comment "Check if this can be merged with spm:searchVolumeInVoxels" ;
                          
-                         iao:IAO_0000114 iao:IAO_0000124 ;
+                         obo:IAO_0000114 obo:IAO_0000124 ;
                          
                          rdfs:domain nidm:SearchSpaceMap ;
                          
@@ -403,11 +402,11 @@ fsl:searchVolumeInVoxels rdf:type owl:DatatypeProperty ;
 
 nidm:clusterLabelId rdf:type owl:DatatypeProperty ;
                     
-                    iao:IAO_0000112 "5" ;
+                    obo:IAO_0000112 "5" ;
                     
                     rdfs:isDefinedBy "Integer associated with a particular cluster as specified in the clusterLabelsMap." ;
                     
-                    iao:IAO_0000114 iao:IAO_0000125 ;
+                    obo:IAO_0000114 obo:IAO_0000125 ;
                     
                     rdfs:domain nidm:Cluster ;
                     
@@ -419,11 +418,11 @@ nidm:clusterLabelId rdf:type owl:DatatypeProperty ;
 
 nidm:clusterSizeInVertices rdf:type owl:DatatypeProperty ;
                            
-                           iao:IAO_0000112 "10" ;
+                           obo:IAO_0000112 "10" ;
                            
                            rdfs:isDefinedBy "Number of vertices that make up the cluster." ;
                            
-                           iao:IAO_0000114 iao:IAO_0000120 ;
+                           obo:IAO_0000114 obo:IAO_0000120 ;
                            
                            rdfs:domain nidm:Cluster ,
                                        nidm:ExtentThreshold ;
@@ -436,11 +435,11 @@ nidm:clusterSizeInVertices rdf:type owl:DatatypeProperty ;
 
 nidm:clusterSizeInVoxels rdf:type owl:DatatypeProperty ;
                          
-                         iao:IAO_0000112 "18" ;
+                         obo:IAO_0000112 "18" ;
                          
                          rdfs:isDefinedBy "Number of voxels that make up the cluster." ;
                          
-                         iao:IAO_0000114 iao:IAO_0000125 ;
+                         obo:IAO_0000114 obo:IAO_0000125 ;
                          
                          rdfs:domain nidm:Cluster ,
                                      nidm:ExtentThreshold ;
@@ -453,11 +452,11 @@ nidm:clusterSizeInVoxels rdf:type owl:DatatypeProperty ;
 
 nidm:contrastName rdf:type owl:DatatypeProperty ;
                   
-                  iao:IAO_0000112 "\"Listening > Rest\"" ;
+                  obo:IAO_0000112 "\"Listening > Rest\"" ;
                   
                   rdfs:isDefinedBy "Name of the contrast." ;
                   
-                  iao:IAO_0000114 iao:IAO_0000120 ;
+                  obo:IAO_0000114 obo:IAO_0000120 ;
                   
                   rdfs:domain nidm:ContrastMap ,
                               nidm:ContrastWeights ,
@@ -471,13 +470,13 @@ nidm:contrastName rdf:type owl:DatatypeProperty ;
 
 nidm:coordinate1 rdf:type owl:DatatypeProperty ;
                  
-                 iao:IAO_0000116 "Under discussion at: https://github.com/incf-nidash/nidm/issues/145" ;
+                 obo:IAO_0000116 "Under discussion at: https://github.com/incf-nidash/nidm/issues/145" ;
                  
                  rdfs:isDefinedBy "Coordinate along the first dimension in voxel units." ;
                  
-                 iao:IAO_0000112 "-60" ;
+                 obo:IAO_0000112 "-60" ;
                  
-                 iao:IAO_0000114 iao:IAO_0000120 ;
+                 obo:IAO_0000114 obo:IAO_0000120 ;
                  
                  rdfs:domain nidm:Coordinate ;
                  
@@ -489,11 +488,11 @@ nidm:coordinate1 rdf:type owl:DatatypeProperty ;
 
 nidm:coordinate2 rdf:type owl:DatatypeProperty ;
                  
-                 iao:IAO_0000112 "-28" ;
+                 obo:IAO_0000112 "-28" ;
                  
                  rdfs:isDefinedBy "Coordinate along the second dimension in voxel units." ;
                  
-                 iao:IAO_0000114 iao:IAO_0000120 ;
+                 obo:IAO_0000114 obo:IAO_0000120 ;
                  
                  rdfs:domain nidm:Coordinate ;
                  
@@ -505,11 +504,11 @@ nidm:coordinate2 rdf:type owl:DatatypeProperty ;
 
 nidm:coordinate3 rdf:type owl:DatatypeProperty ;
                  
-                 iao:IAO_0000112 "13" ;
+                 obo:IAO_0000112 "13" ;
                  
                  rdfs:isDefinedBy "Coordinate along the third dimension in voxel units." ;
                  
-                 iao:IAO_0000114 iao:IAO_0000120 ;
+                 obo:IAO_0000114 obo:IAO_0000120 ;
                  
                  rdfs:domain nidm:Coordinate ;
                  
@@ -521,15 +520,15 @@ nidm:coordinate3 rdf:type owl:DatatypeProperty ;
 
 nidm:dimensionsInVoxels rdf:type owl:DatatypeProperty ;
                         
-                        iao:IAO_0000116 "Range: Vector of integers." ;
+                        obo:IAO_0000116 "Range: Vector of integers." ;
                         
-                        iao:IAO_0000112 "[64 64 20]" ;
+                        obo:IAO_0000112 "[64 64 20]" ;
                         
                         rdfs:isDefinedBy "Dimensions of some N-dimensional data." ;
                         
-                        iao:IAO_0000116 "Under discussion at: https://github.com/incf-nidash/nidm/issues/146" ;
+                        obo:IAO_0000116 "Under discussion at: https://github.com/incf-nidash/nidm/issues/146" ;
                         
-                        iao:IAO_0000114 iao:IAO_0000120 ;
+                        obo:IAO_0000114 obo:IAO_0000120 ;
                         
                         rdfs:domain nidm:CoordinateSpace ;
                         
@@ -541,11 +540,11 @@ nidm:dimensionsInVoxels rdf:type owl:DatatypeProperty ;
 
 nidm:effectDegreesOfFreedom rdf:type owl:DatatypeProperty ;
                             
-                            iao:IAO_0000112 "1" ;
+                            obo:IAO_0000112 "1" ;
                             
                             rdfs:isDefinedBy "Degrees of freedom of the effect." ;
                             
-                            iao:IAO_0000114 iao:IAO_0000120 ;
+                            obo:IAO_0000114 obo:IAO_0000120 ;
                             
                             rdfs:domain nidm:StatisticMap ;
                             
@@ -564,9 +563,9 @@ nidm:equivalentZStatistic rdf:type owl:DatatypeProperty ;
                           
                           rdfs:isDefinedBy "Statistic value transformed into Z units; the output of a process which takes a non-normal statistic and transforms it to an equivalent z score." ;
                           
-                          iao:IAO_0000112 "3.5" ;
+                          obo:IAO_0000112 "3.5" ;
                           
-                          iao:IAO_0000114 iao:IAO_0000120 ;
+                          obo:IAO_0000114 obo:IAO_0000120 ;
                           
                           rdfs:domain nidm:Peak ;
                           
@@ -580,9 +579,9 @@ nidm:errorDegreesOfFreedom rdf:type owl:DatatypeProperty ;
                            
                            rdfs:isDefinedBy "Degrees of freedom of the error." ;
                            
-                           iao:IAO_0000112 "72.999999" ;
+                           obo:IAO_0000112 "72.999999" ;
                            
-                           iao:IAO_0000114 iao:IAO_0000120 ;
+                           obo:IAO_0000114 obo:IAO_0000120 ;
                            
                            rdfs:domain nidm:StatisticMap ;
                            
@@ -601,7 +600,7 @@ nidm:errorVarianceHomogeneous rdf:type owl:DatatypeProperty ;
                               
                               rdfs:isDefinedBy "A boolean value reflecting how the variance of the error is modeled during parameter estimation; TRUE for constant variance over all observations in the model, FALSE for heterogeneous variance." ;
                               
-                              iao:IAO_0000114 iao:IAO_0000122 ;
+                              obo:IAO_0000114 obo:IAO_0000122 ;
                               
                               rdfs:domain nidm:ErrorModel ;
                               
@@ -613,7 +612,7 @@ nidm:errorVarianceHomogeneous rdf:type owl:DatatypeProperty ;
 
 nidm:globalNullDegree rdf:type owl:DatatypeProperty ;
                       
-                      iao:IAO_0000114 iao:IAO_0000124 ;
+                      obo:IAO_0000114 obo:IAO_0000124 ;
                       
                       rdfs:domain spm:KConjunctionInference ;
                       
@@ -625,11 +624,11 @@ nidm:globalNullDegree rdf:type owl:DatatypeProperty ;
 
 nidm:grandMeanScaling rdf:type owl:DatatypeProperty ;
                       
-                      iao:IAO_0000112 "TRUE" ;
+                      obo:IAO_0000112 "TRUE" ;
                       
                       rdfs:isDefinedBy "Binary flag defining whether the data was scaled. Specifically, \"grand mean scaling\" refers to multipliciation of every voxel in every scan by a common value.  Grand mean scaling is essential for first-level fMRI, to transform the arbitrary MRI units, but is generally not used with second level analyses." ;
                       
-                      iao:IAO_0000114 iao:IAO_0000125 ;
+                      obo:IAO_0000114 obo:IAO_0000125 ;
                       
                       rdfs:domain nidm:Data ;
                       
@@ -643,9 +642,9 @@ nidm:inWorldCoordinateSystem rdf:type owl:DatatypeProperty ;
                              
                              rdfs:isDefinedBy "Type of coordinate system." ;
                              
-                             iao:IAO_0000112 "nidm:MNICoordinateSystem" ;
+                             obo:IAO_0000112 "nidm:MNICoordinateSystem" ;
                              
-                             iao:IAO_0000114 iao:IAO_0000120 .
+                             obo:IAO_0000114 obo:IAO_0000120 .
 
 
 
@@ -655,13 +654,13 @@ nidm:maskedMedian rdf:type owl:DatatypeProperty ;
                   
                   rdfs:isDefinedBy "Median value considering only in-mask voxels. Useful diagnostic when computed on grand mean image when grandMeanScaling is TRUE, as the median should be close to targetIntensity." ;
                   
-                  iao:IAO_0000112 "155.23" ;
+                  obo:IAO_0000112 "155.23" ;
                   
                   rdfs:seeAlso "http://purl.obolibrary.org/obo/OBI_0200119" ;
                   
-                  iao:IAO_0000117 "TN, Naming discussed at: https://github.com/incf-nidash/nidm/issues/70" ;
+                  obo:IAO_0000117 "TN, Naming discussed at: https://github.com/incf-nidash/nidm/issues/70" ;
                   
-                  iao:IAO_0000114 iao:IAO_0000125 ;
+                  obo:IAO_0000114 obo:IAO_0000125 ;
                   
                   rdfs:domain nidm:GrandMeanMap ;
                   
@@ -675,9 +674,9 @@ nidm:maxNumberOfPeaksPerCluster rdf:type owl:DatatypeProperty ;
                                 
                                 rdfs:isDefinedBy "Maximum number of peaks to be reported after inference within a cluster." ;
                                 
-                                iao:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/200." ;
+                                obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/200." ;
                                 
-                                iao:IAO_0000114 iao:IAO_0000122 ;
+                                obo:IAO_0000114 obo:IAO_0000122 ;
                                 
                                 rdfs:domain nidm:PeakDefinitionCriteria ;
                                 
@@ -689,11 +688,11 @@ nidm:maxNumberOfPeaksPerCluster rdf:type owl:DatatypeProperty ;
 
 nidm:minDistanceBetweenPeaks rdf:type owl:DatatypeProperty ;
                              
-                             iao:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/200." ;
+                             obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/200." ;
                              
                              rdfs:isDefinedBy "Minimum distance between two peaks to be reported after inference." ;
                              
-                             iao:IAO_0000114 iao:IAO_0000122 ;
+                             obo:IAO_0000114 obo:IAO_0000122 ;
                              
                              rdfs:domain nidm:PeakDefinitionCriteria ;
                              
@@ -705,15 +704,15 @@ nidm:minDistanceBetweenPeaks rdf:type owl:DatatypeProperty ;
 
 nidm:noiseFWHM rdf:type owl:DatatypeProperty ;
                
-               iao:IAO_0000117 "Under discussion at https://github.com/incf-nidash/nidm/issues/173" ;
+               obo:IAO_0000117 "Under discussion at https://github.com/incf-nidash/nidm/issues/173" ;
                
-               iao:IAO_0000112 "2.35" ;
+               obo:IAO_0000112 "2.35" ;
                
                rdfs:isDefinedBy "Estimated Full Width at Half Maximum of the noise distribution." ;
                
                rdfs:seeAlso "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#Full_Width_at_Half_Maximum" ;
                
-               iao:IAO_0000114 iao:IAO_0000120 .
+               obo:IAO_0000114 obo:IAO_0000120 .
 
 
 
@@ -721,7 +720,7 @@ nidm:noiseFWHM rdf:type owl:DatatypeProperty ;
 
 nidm:numberOfClusters rdf:type owl:DatatypeProperty ;
                       
-                      iao:IAO_0000114 iao:IAO_0000124 ;
+                      obo:IAO_0000114 obo:IAO_0000124 ;
                       
                       rdfs:domain nidm:ExcursionSetMap ;
                       
@@ -737,9 +736,9 @@ nidm:numberOfDimensions rdf:type owl:DatatypeProperty ;
                         
                         rdfs:isDefinedBy "Number of dimensions of a data matrix." ;
                         
-                        iao:IAO_0000112 "3" ;
+                        obo:IAO_0000112 "3" ;
                         
-                        iao:IAO_0000114 iao:IAO_0000120 ;
+                        obo:IAO_0000114 obo:IAO_0000120 ;
                         
                         rdfs:domain nidm:CoordinateSpace ;
                         
@@ -757,9 +756,9 @@ nidm:pValue rdf:type owl:DatatypeProperty ;
 http://purl.obolibrary.org/obo/OBI_0000175
 http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#P-Value""" ;
             
-            iao:IAO_0000112 "8.95E-14" ;
+            obo:IAO_0000112 "8.95E-14" ;
             
-            iao:IAO_0000114 iao:IAO_0000122 ;
+            obo:IAO_0000114 obo:IAO_0000122 ;
             
             rdfs:domain nidm:ExcursionSetMap ;
             
@@ -778,7 +777,7 @@ http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#P-Value""" ;
 
 nidm:pValueFWER rdf:type owl:DatatypeProperty ;
                 
-                iao:IAO_0000112 "0.05" ;
+                obo:IAO_0000112 "0.05" ;
                 
                 owl:sameAs "This definition is from OBI. Please update this note if the definition is modified." ;
                 
@@ -786,7 +785,7 @@ nidm:pValueFWER rdf:type owl:DatatypeProperty ;
                 
                 rdfs:isDefinedBy "\"A quantitative confidence value resulting from a multiple testing error correction method which adjusts the p-value used as input to control for Type I error in the context of multiple pairwise tests\"" ;
                 
-                iao:IAO_0000114 iao:IAO_0000423 ;
+                obo:IAO_0000114 obo:IAO_0000423 ;
                 
                 rdfs:domain nidm:Cluster ,
                             nidm:ExtentThreshold ,
@@ -808,13 +807,13 @@ nidm:pValueFWER rdf:type owl:DatatypeProperty ;
 
 nidm:pValueUncorrected rdf:type owl:DatatypeProperty ;
                        
-                       iao:IAO_0000112 "0.0542" ;
+                       obo:IAO_0000112 "0.0542" ;
                        
                        rdfs:isDefinedBy "A p-value reported without correction for multiple testing.        " ;
                        
                        rdfs:seeAlso "http://purl.obolibrary.org/obo/IAO_0000121" ;
                        
-                       iao:IAO_0000114 iao:IAO_0000423 ;
+                       obo:IAO_0000114 obo:IAO_0000423 ;
                        
                        rdfs:domain nidm:Cluster ,
                                    nidm:ExtentThreshold ,
@@ -840,9 +839,9 @@ nidm:qValueFDR rdf:type owl:DatatypeProperty ;
                
                owl:sameAs "http://purl.obolibrary.org/obo/OBI_0001442" ;
                
-               iao:IAO_0000112 "0.000154" ;
+               obo:IAO_0000112 "0.000154" ;
                
-               iao:IAO_0000114 iao:IAO_0000122 ;
+               obo:IAO_0000114 obo:IAO_0000122 ;
                
                rdfs:domain nidm:Cluster ,
                            nidm:ExtentThreshold ,
@@ -864,11 +863,11 @@ nidm:qValueFDR rdf:type owl:DatatypeProperty ;
 
 nidm:randomFieldStationarity rdf:type owl:DatatypeProperty ;
                              
-                             iao:IAO_0000117 "Under discussion at https://github.com/incf-nidash/nidm/issues/130" ;
+                             obo:IAO_0000117 "Under discussion at https://github.com/incf-nidash/nidm/issues/130" ;
                              
                              rdfs:isDefinedBy "Is the random field assumed to be stationary across the entire search volume?" ;
                              
-                             iao:IAO_0000114 iao:IAO_0000120 ;
+                             obo:IAO_0000114 obo:IAO_0000120 ;
                              
                              rdfs:domain nidm:SearchSpaceMap ;
                              
@@ -880,11 +879,11 @@ nidm:randomFieldStationarity rdf:type owl:DatatypeProperty ;
 
 nidm:softwareVersion rdf:type owl:DatatypeProperty ;
                      
-                     iao:IAO_0000112 "SPM99, SPM2, SPM5, SPM8, SPM12b, FSL5.0.0" ;
+                     obo:IAO_0000112 "SPM99, SPM2, SPM5, SPM8, SPM12b, FSL5.0.0" ;
                      
                      rdfs:isDefinedBy "Name and number that specifies the software version." ;
                      
-                     iao:IAO_0000114 iao:IAO_0000125 ;
+                     obo:IAO_0000114 obo:IAO_0000125 ;
                      
                      rdfs:range xsd:string ;
                      
@@ -898,9 +897,9 @@ nidm:targetIntensity rdf:type owl:DatatypeProperty ;
                      
                      rdfs:isDefinedBy "Value to which the grand mean of the Data was scaled (applies only if grandMeanScaling is true)." ;
                      
-                     iao:IAO_0000112 "100" ;
+                     obo:IAO_0000112 "100" ;
                      
-                     iao:IAO_0000114 iao:IAO_0000125 ;
+                     obo:IAO_0000114 obo:IAO_0000125 ;
                      
                      rdfs:domain nidm:Data ;
                      
@@ -919,13 +918,13 @@ nidm:userSpecifiedThresholdType rdf:type owl:DatatypeProperty ;
                                 
                                 rdfs:isDefinedBy "Type of method used to define a threshold (e.g. statistic value, uncorrected P-value or corrected P-value)." ;
                                 
-                                iao:IAO_0000112 "nidm:pValueFWER" ;
+                                obo:IAO_0000112 "nidm:pValueFWER" ;
                                 
-                                iao:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/150" ;
+                                obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/150" ;
                                 
-                                iao:IAO_0000116 "Range is currently string but should be limited to {'nidm:pValueFWER' not found'nidm:pValueFDR' not found'nidm:pValueUncorrected';'nidm:statistic'}?" ;
+                                obo:IAO_0000116 "Range is currently string but should be limited to {'nidm:pValueFWER' not found'nidm:pValueFDR' not found'nidm:pValueUncorrected';'nidm:statistic'}?" ;
                                 
-                                iao:IAO_0000114 iao:IAO_0000428 ;
+                                obo:IAO_0000114 obo:IAO_0000428 ;
                                 
                                 rdfs:domain nidm:ExtentThreshold ,
                                             nidm:HeightThreshold ;
@@ -938,7 +937,7 @@ nidm:userSpecifiedThresholdType rdf:type owl:DatatypeProperty ;
 
 nidm:version rdf:type owl:DatatypeProperty ;
              
-             iao:IAO_0000114 iao:IAO_0000124 ;
+             obo:IAO_0000114 obo:IAO_0000124 ;
              
              rdfs:range xsd:string ;
              
@@ -952,14 +951,14 @@ nidm:voxelSize rdf:type owl:DatatypeProperty ;
                
                rdfs:isDefinedBy "3D size of a voxel measured in voxelUnits." ;
                
-               iao:IAO_0000112 "[2 2 4]" ;
+               obo:IAO_0000112 "[2 2 4]" ;
                
                rdfs:seeAlso """http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C95003 
 """ ;
                
-               iao:IAO_0000116 "Range: Vector of floats." ;
+               obo:IAO_0000116 "Range: Vector of floats." ;
                
-               iao:IAO_0000114 iao:IAO_0000120 ;
+               obo:IAO_0000114 obo:IAO_0000120 ;
                
                rdfs:domain nidm:CoordinateSpace ;
                
@@ -971,15 +970,15 @@ nidm:voxelSize rdf:type owl:DatatypeProperty ;
 
 nidm:voxelToWorldMapping rdf:type owl:DatatypeProperty ;
                          
-                         iao:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/148" ;
+                         obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/148" ;
                          
-                         iao:IAO_0000112 "[3 0 0 0;0 3 0 0;0 0 3 0; 0 0 0 1] " ;
+                         obo:IAO_0000112 "[3 0 0 0;0 3 0 0;0 0 3 0; 0 0 0 1] " ;
                          
                          rdfs:isDefinedBy "Homogeneous transformation matrix to map from voxel coordinate system to world coordinate system." ;
                          
-                         iao:IAO_0000116 "Range: Matrix of float." ;
+                         obo:IAO_0000116 "Range: Matrix of float." ;
                          
-                         iao:IAO_0000114 iao:IAO_0000122 ;
+                         obo:IAO_0000114 obo:IAO_0000122 ;
                          
                          rdfs:domain nidm:CoordinateSpace ;
                          
@@ -991,15 +990,15 @@ nidm:voxelToWorldMapping rdf:type owl:DatatypeProperty ;
 
 nidm:voxelUnits rdf:type owl:DatatypeProperty ;
                 
-                iao:IAO_0000116 "Range: Vector of strings." ;
+                obo:IAO_0000116 "Range: Vector of strings." ;
                 
                 rdfs:isDefinedBy "Units associated with each dimensions of some N-dimensional data." ;
                 
-                iao:IAO_0000117 "Under discussion at https://github.com/incf-nidash/nidm/issues/147" ;
+                obo:IAO_0000117 "Under discussion at https://github.com/incf-nidash/nidm/issues/147" ;
                 
-                iao:IAO_0000112 "{'mm' 'mm' 's'}" ;
+                obo:IAO_0000112 "{'mm' 'mm' 's'}" ;
                 
-                iao:IAO_0000114 iao:IAO_0000120 ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
                 
                 rdfs:domain nidm:CoordinateSpace ;
                 
@@ -1011,13 +1010,13 @@ nidm:voxelUnits rdf:type owl:DatatypeProperty ;
 
 spm:clusterSizeInResels rdf:type owl:DatatypeProperty ;
                         
-                        iao:IAO_0000117 "Under discussion at: https://github.com/incf-nidash/nidm/issues/127" ;
+                        obo:IAO_0000117 "Under discussion at: https://github.com/incf-nidash/nidm/issues/127" ;
                         
                         rdfs:isDefinedBy "Size of cluster measured in resels." ;
                         
-                        iao:IAO_0000112 "13" ;
+                        obo:IAO_0000112 "13" ;
                         
-                        iao:IAO_0000114 iao:IAO_0000122 ;
+                        obo:IAO_0000114 obo:IAO_0000122 ;
                         
                         rdfs:domain nidm:Cluster ,
                                     nidm:ExtentThreshold ;
@@ -1037,9 +1036,9 @@ spm:expectedNumberOfClusters rdf:type owl:DatatypeProperty ;
                              
                              rdfs:isDefinedBy "Expected number of clusters in an excursion set." ;
                              
-                             iao:IAO_0000112 "9.51" ;
+                             obo:IAO_0000112 "9.51" ;
                              
-                             iao:IAO_0000114 iao:IAO_0000125 ;
+                             obo:IAO_0000114 obo:IAO_0000125 ;
                              
                              rdfs:domain nidm:SearchSpaceMap ;
                              
@@ -1058,9 +1057,9 @@ spm:expectedNumberOfVerticesPerCluster rdf:type owl:DatatypeProperty ;
                                        
                                        rdfs:isDefinedBy "Expected number of vertices in a cluster." ;
                                        
-                                       iao:IAO_0000112 "60.632" ;
+                                       obo:IAO_0000112 "60.632" ;
                                        
-                                       iao:IAO_0000114 iao:IAO_0000120 ;
+                                       obo:IAO_0000114 obo:IAO_0000120 ;
                                        
                                        rdfs:domain nidm:SearchSpaceMap ;
                                        
@@ -1079,9 +1078,9 @@ spm:expectedNumberOfVoxelsPerCluster rdf:type owl:DatatypeProperty ;
                                      
                                      rdfs:isDefinedBy "Expected number of voxels in a cluster." ;
                                      
-                                     iao:IAO_0000112 "60.632" ;
+                                     obo:IAO_0000112 "60.632" ;
                                      
-                                     iao:IAO_0000114 iao:IAO_0000120 ;
+                                     obo:IAO_0000114 obo:IAO_0000120 ;
                                      
                                      rdfs:domain nidm:SearchSpaceMap ;
                                      
@@ -1100,9 +1099,9 @@ spm:heightCriticalThresholdFDR05 rdf:type owl:DatatypeProperty ;
                                  
                                  rdfs:isDefinedBy "Peak statistic threshold corrected for false discovery rate at a level of alpha = 0.05. " ;
                                  
-                                 iao:IAO_0000112 "5.896" ;
+                                 obo:IAO_0000112 "5.896" ;
                                  
-                                 iao:IAO_0000114 iao:IAO_0000122 ;
+                                 obo:IAO_0000114 obo:IAO_0000122 ;
                                  
                                  rdfs:domain nidm:SearchSpaceMap ;
                                  
@@ -1116,9 +1115,9 @@ spm:heightCriticalThresholdFWE05 rdf:type owl:DatatypeProperty ;
                                  
                                  rdfs:isDefinedBy "Peak statistic threshold corrected for family-wise error at a level of alpha = 0.05. " ;
                                  
-                                 iao:IAO_0000112 "4.913" ;
+                                 obo:IAO_0000112 "4.913" ;
                                  
-                                 iao:IAO_0000114 iao:IAO_0000122 ;
+                                 obo:IAO_0000114 obo:IAO_0000122 ;
                                  
                                  rdfs:domain nidm:SearchSpaceMap ;
                                  
@@ -1132,11 +1131,11 @@ spm:noiseFWHMInUnits rdf:type owl:DatatypeProperty ;
                      
                      rdfs:isDefinedBy "Estimated Full Width at Half Maximum of the noise distribution in world units." ;
                      
-                     iao:IAO_0000116 "Range: Vector of positive floats." ;
+                     obo:IAO_0000116 "Range: Vector of positive floats." ;
                      
-                     iao:IAO_0000112 "[8.87, 8.89, 7.83]" ;
+                     obo:IAO_0000112 "[8.87, 8.89, 7.83]" ;
                      
-                     iao:IAO_0000114 iao:IAO_0000120 ;
+                     obo:IAO_0000114 obo:IAO_0000120 ;
                      
                      rdfs:domain nidm:SearchSpaceMap ;
                      
@@ -1150,13 +1149,13 @@ spm:noiseFWHMInUnits rdf:type owl:DatatypeProperty ;
 
 spm:noiseFWHMInVertices rdf:type owl:DatatypeProperty ;
                         
-                        iao:IAO_0000112 "[2.95, 2.96, 2.61]" ;
+                        obo:IAO_0000112 "[2.95, 2.96, 2.61]" ;
                         
-                        iao:IAO_0000116 "Range: Vector of positive floats." ;
+                        obo:IAO_0000116 "Range: Vector of positive floats." ;
                         
                         rdfs:isDefinedBy "Estimated Full Width at Half Maximum of the noise distribution in world vertices." ;
                         
-                        iao:IAO_0000114 iao:IAO_0000120 ;
+                        obo:IAO_0000114 obo:IAO_0000120 ;
                         
                         rdfs:domain nidm:MaskMap ;
                         
@@ -1170,13 +1169,13 @@ spm:noiseFWHMInVoxels rdf:type owl:DatatypeProperty ;
                       
                       rdfs:isDefinedBy "Estimated Full Width at Half Maximum of the noise distribution in voxels." ;
                       
-                      iao:IAO_0000116 "Range: Vector of positive floats." ;
+                      obo:IAO_0000116 "Range: Vector of positive floats." ;
                       
-                      iao:IAO_0000112 "[3.7 3.7 3.1]" ;
+                      obo:IAO_0000112 "[3.7 3.7 3.1]" ;
                       
                       rdfs:seeAlso "Synonyms of or close match with nidm:NoiseFWHM" ;
                       
-                      iao:IAO_0000114 iao:IAO_0000120 ;
+                      obo:IAO_0000114 obo:IAO_0000120 ;
                       
                       rdfs:domain nidm:SearchSpaceMap ;
                       
@@ -1192,9 +1191,9 @@ spm:reselSize rdf:type owl:DatatypeProperty ;
               
               rdfs:isDefinedBy "Size of one resel in voxels or vertices." ;
               
-              iao:IAO_0000112 "22.325" ;
+              obo:IAO_0000112 "22.325" ;
               
-              iao:IAO_0000114 iao:IAO_0000120 ;
+              obo:IAO_0000114 obo:IAO_0000120 ;
               
               rdfs:domain nidm:SearchSpaceMap ;
               
@@ -1211,7 +1210,7 @@ spm:reselSize rdf:type owl:DatatypeProperty ;
 
 spm:searchVolumeInResels rdf:type owl:DatatypeProperty ;
                          
-                         iao:IAO_0000112 "151.3" ;
+                         obo:IAO_0000112 "151.3" ;
                          
                          rdfs:isDefinedBy "Total number of resels within the search volume." ;
                          
@@ -1232,16 +1231,16 @@ spm:searchVolumeInResels rdf:type owl:DatatypeProperty ;
 
 spm:searchVolumeInUnits rdf:type owl:DatatypeProperty ;
                         
-                        iao:IAO_0000116 """Context: volumeInVoxels nidm_0025. Range: Positivefloat not found. BIRNLex or 
+                        obo:IAO_0000116 """Context: volumeInVoxels nidm_0025. Range: Positivefloat not found. BIRNLex or 
 NIDM Concept ID: spm_84. """ ;
                         
-                        iao:IAO_0000117 "Discussed at https://github.com/incf-nidash/nidm/pull/131" ;
+                        obo:IAO_0000117 "Discussed at https://github.com/incf-nidash/nidm/pull/131" ;
                         
                         rdfs:isDefinedBy "The volume of the searched region in units determined by the current coordinate space units (e.g., mm^3 for axis units of mm in a three dimensional image, sec.Hz for a time by frequency two dimensional image)." ;
                         
-                        iao:IAO_0000112 "1771011" ;
+                        obo:IAO_0000112 "1771011" ;
                         
-                        iao:IAO_0000114 iao:IAO_0000122 ;
+                        obo:IAO_0000114 obo:IAO_0000122 ;
                         
                         rdfs:domain nidm:SearchSpaceMap ;
                         
@@ -1260,9 +1259,9 @@ spm:searchVolumeInVertices rdf:type owl:DatatypeProperty ;
                            
                            rdfs:isDefinedBy "Total number of vertices within the search volume." ;
                            
-                           iao:IAO_0000112 "151.3" ;
+                           obo:IAO_0000112 "151.3" ;
                            
-                           iao:IAO_0000114 iao:IAO_0000120 ;
+                           obo:IAO_0000114 obo:IAO_0000120 ;
                            
                            rdfs:domain nidm:SearchSpaceMap ;
                            
@@ -1281,13 +1280,13 @@ spm:searchVolumeInVoxels rdf:type owl:DatatypeProperty ;
                          
                          rdfs:seeAlso "Synonyms of nidm:volumeInVoxels" ;
                          
-                         iao:IAO_0000116 "Check if this can be merged with fsl:searchVolumeInVoxels" ;
+                         obo:IAO_0000116 "Check if this can be merged with fsl:searchVolumeInVoxels" ;
                          
                          rdfs:isDefinedBy "Total number of voxels within the search volume." ;
                          
-                         iao:IAO_0000112 "68656" ;
+                         obo:IAO_0000112 "68656" ;
                          
-                         iao:IAO_0000114 iao:IAO_0000124 ;
+                         obo:IAO_0000114 obo:IAO_0000124 ;
                          
                          rdfs:domain nidm:SearchSpaceMap ;
                          
@@ -1299,15 +1298,15 @@ spm:searchVolumeInVoxels rdf:type owl:DatatypeProperty ;
 
 spm:searchVolumeReselsGeometry rdf:type owl:DatatypeProperty ;
                                
-                               iao:IAO_0000112 "[6 68.8 589.1 1475.5]" ;
+                               obo:IAO_0000112 "[6 68.8 589.1 1475.5]" ;
                                
                                rdfs:seeAlso "http://www.ncbi.nlm.nih.gov/pubmed/20408186" ;
                                
                                rdfs:isDefinedBy "Description of geometry of search volume.  As per Worsley et al. [ http://www.ncbi.nlm.nih.gov/pubmed/20408186 ], the first element is the Euler Characteristic of the search volume, the second element is twice the average caliper diameter, the third element is half the surface area, and the fourth element is the volume.  With the exception of the first element (which is a unitless integer) all quantities are in units of Resels." ;
                                
-                               iao:IAO_0000116 "Range: Vector of 1 positive integer and 3 positive floats." ;
+                               obo:IAO_0000116 "Range: Vector of 1 positive integer and 3 positive floats." ;
                                
-                               iao:IAO_0000114 iao:IAO_0000125 ;
+                               obo:IAO_0000114 obo:IAO_0000125 ;
                                
                                rdfs:domain nidm:SearchSpaceMap ;
                                
@@ -1321,11 +1320,11 @@ spm:searchVolumeReselsGeometry rdf:type owl:DatatypeProperty ;
 
 spm:smallestSignifClusterSizeInVerticesFDR05 rdf:type owl:DatatypeProperty ;
                                              
-                                             iao:IAO_0000112 "5" ;
+                                             obo:IAO_0000112 "5" ;
                                              
                                              rdfs:isDefinedBy "Smallest cluster size in vertices that are significant at a false discovery rate corrected alpha value of 0.05.  " ;
                                              
-                                             iao:IAO_0000114 iao:IAO_0000125 ;
+                                             obo:IAO_0000114 obo:IAO_0000125 ;
                                              
                                              rdfs:domain nidm:SearchSpaceMap ;
                                              
@@ -1340,9 +1339,9 @@ spm:smallestSignifClusterSizeInVerticesFWE05 rdf:type owl:DatatypeProperty ;
                                              rdfs:isDefinedBy """Smallest cluster size in vertices significant at family-wise error rate corrected alpha value of 0.05. 
 """ ;
                                              
-                                             iao:IAO_0000112 "2" ;
+                                             obo:IAO_0000112 "2" ;
                                              
-                                             iao:IAO_0000114 iao:IAO_0000125 ;
+                                             obo:IAO_0000114 obo:IAO_0000125 ;
                                              
                                              rdfs:domain nidm:SearchSpaceMap ;
                                              
@@ -1354,11 +1353,11 @@ spm:smallestSignifClusterSizeInVerticesFWE05 rdf:type owl:DatatypeProperty ;
 
 spm:smallestSignifClusterSizeInVoxelsFDR05 rdf:type owl:DatatypeProperty ;
                                            
-                                           iao:IAO_0000112 "3" ;
+                                           obo:IAO_0000112 "3" ;
                                            
                                            rdfs:isDefinedBy "Smallest cluster size in voxels significant at false discovery rate corrected alpha value of 0.05.  " ;
                                            
-                                           iao:IAO_0000114 iao:IAO_0000125 ;
+                                           obo:IAO_0000114 obo:IAO_0000125 ;
                                            
                                            rdfs:domain nidm:SearchSpaceMap ;
                                            
@@ -1373,9 +1372,9 @@ spm:smallestSignifClusterSizeInVoxelsFWE05 rdf:type owl:DatatypeProperty ;
                                            rdfs:isDefinedBy """Smallest cluster size in voxels significant at family-wise error corrected alpha value of 0.05. 
 """ ;
                                            
-                                           iao:IAO_0000112 "1" ;
+                                           obo:IAO_0000112 "1" ;
                                            
-                                           iao:IAO_0000114 iao:IAO_0000125 ;
+                                           obo:IAO_0000114 obo:IAO_0000125 ;
                                            
                                            rdfs:domain nidm:SearchSpaceMap ;
                                            
@@ -1387,11 +1386,11 @@ spm:smallestSignifClusterSizeInVoxelsFWE05 rdf:type owl:DatatypeProperty ;
 
 spm:softwareRevision rdf:type owl:DatatypeProperty ;
                      
-                     iao:IAO_0000112 "5417" ;
+                     obo:IAO_0000112 "5417" ;
                      
                      rdfs:isDefinedBy "revision number of a piece of software." ;
                      
-                     iao:IAO_0000114 iao:IAO_0000120 ;
+                     obo:IAO_0000114 obo:IAO_0000120 ;
                      
                      rdfs:range xsd:string ;
                      
@@ -1444,7 +1443,7 @@ fsl:BinomialDistribution rdf:type owl:Class ;
                          
                          rdfs:isDefinedBy "The binomial distribution is a discrete probability distribution which describes the probability of k successes in n draws with replacement from a finite population of size N. The binomial distribution is frequently used to model the number of successes in a sample of size n drawn with replacement from a population of size N. The binomial distribution gives the discrete probability distribution of obtaining exactly n successes out of N Bernoulli trials (where the result of each Bernoulli trial is true with probability p and false with probability q=1-p ) notation: B(n,p) The mean is N*p The variance is N*p*q. (Definition from STATO)." ;
                          
-                         iao:IAO_0000114 iao:IAO_0000122 .
+                         obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -1456,11 +1455,11 @@ fsl:CenterOfGravity rdf:type owl:Class ;
                     
                     rdfs:isDefinedBy "Centre Of Gravity for the cluster, equivalent to the concept of Centre Of Gravity for a object with distributed mass, where intensity substitutes for mass in this case (definition from http://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Cluster)" ;
                     
-                    iao:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/FSL_CenterOfGravity.txt" ;
+                    obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/FSL_CenterOfGravity.txt" ;
                     
                     rdfs:seeAlso "http://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Cluster" ;
                     
-                    iao:IAO_0000114 iao:IAO_0000120 .
+                    obo:IAO_0000114 obo:IAO_0000120 .
 
 
 
@@ -1470,9 +1469,9 @@ fsl:ClusterMaximumStatistic rdf:type owl:Class ;
                             
                             rdfs:subClassOf prov:Entity ;
                             
-                            iao:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/FSL_ClusterMaximumStatistic.txt" ;
+                            obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/FSL_ClusterMaximumStatistic.txt" ;
                             
-                            iao:IAO_0000114 iao:IAO_0000124 .
+                            obo:IAO_0000114 obo:IAO_0000124 .
 
 
 
@@ -1482,7 +1481,7 @@ fsl:ContrastVarianceMap rdf:type owl:Class ;
                         
                         rdfs:subClassOf nidm:Map ;
                         
-                        iao:IAO_0000114 iao:IAO_0000124 .
+                        obo:IAO_0000114 obo:IAO_0000124 .
 
 
 
@@ -1494,7 +1493,7 @@ fsl:NonParametricSymmetricDistribution rdf:type owl:Class ;
                                        
                                        rdfs:isDefinedBy "Probability distribution estimated empirically on the data assuming only symmetry of the probability distribution." ;
                                        
-                                       iao:IAO_0000114 iao:IAO_0000122 .
+                                       obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -1504,9 +1503,9 @@ nidm:ArbitrarilyCorrelatedError rdf:type owl:Class ;
                                 
                                 rdfs:subClassOf nidm:ErrorDependence ;
                                 
-                                iao:IAO_0000117 "TN; Under discussion at https://github.com/ISA-tools/stato/issues/28" ;
+                                obo:IAO_0000117 "TN; Under discussion at https://github.com/ISA-tools/stato/issues/28" ;
                                 
-                                iao:IAO_0000114 iao:IAO_0000423 .
+                                obo:IAO_0000114 obo:IAO_0000423 .
 
 
 
@@ -1516,11 +1515,11 @@ nidm:Cluster rdf:type owl:Class ;
              
              rdfs:subClassOf prov:Entity ;
              
-             iao:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/Cluster.txt" ;
+             obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/Cluster.txt" ;
              
              rdfs:isDefinedBy "Statistic defined at the cluster-level in an excusion set. In SPM it is defined as the cluster size. FIXME (now Cluster instead of ClusterStatistic)" ;
              
-             iao:IAO_0000114 iao:IAO_0000120 .
+             obo:IAO_0000114 obo:IAO_0000120 .
 
 
 
@@ -1532,9 +1531,9 @@ nidm:ClusterDefinitionCriteria rdf:type owl:Class ;
                                
                                rdfs:isDefinedBy "Set of criterion specified a priori to define the clusters reported after inference (e.g. pixel or voxel connectivity criterion)." ;
                                
-                               iao:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ClusterDefinitionCriteria.txt" ;
+                               obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ClusterDefinitionCriteria.txt" ;
                                
-                               iao:IAO_0000114 iao:IAO_0000122 .
+                               obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -1544,9 +1543,9 @@ nidm:ClusterLabelsMap rdf:type owl:Class ;
                       
                       rdfs:subClassOf nidm:Map ;
                       
-                      iao:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ClusterLabelsMap.txt"^^xsd:anyURI ;
+                      obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ClusterLabelsMap.txt"^^xsd:anyURI ;
                       
-                      iao:IAO_0000114 iao:IAO_0000124 .
+                      obo:IAO_0000114 obo:IAO_0000124 .
 
 
 
@@ -1556,9 +1555,9 @@ nidm:CompoundSymmetricError rdf:type owl:Class ;
                             
                             rdfs:subClassOf nidm:ErrorDependence ;
                             
-                            iao:IAO_0000117 "TN; Under discussion at https://github.com/ISA-tools/stato/issues/28" ;
+                            obo:IAO_0000117 "TN; Under discussion at https://github.com/ISA-tools/stato/issues/28" ;
                             
-                            iao:IAO_0000114 iao:IAO_0000423 .
+                            obo:IAO_0000114 obo:IAO_0000423 .
 
 
 
@@ -1568,11 +1567,11 @@ nidm:ConjunctionInference rdf:type owl:Class ;
                           
                           rdfs:subClassOf nidm:Inference ;
                           
-                          iao:IAO_0000116 "Term discussed in https://github.com/incf-nidash/nidm/pull/134." ;
+                          obo:IAO_0000116 "Term discussed in https://github.com/incf-nidash/nidm/pull/134." ;
                           
                           rdfs:isDefinedBy "Statistically testing for the joint significance of multiple effects, with emphasis on rejecting all (instead of one or more) of the respective null hypotheses." ;
                           
-                          iao:IAO_0000114 iao:IAO_0000122 .
+                          obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -1582,13 +1581,13 @@ nidm:ConnectivityCriterion rdf:type owl:Class ;
                            
                            rdfs:subClassOf prov:Entity ;
                            
-                           iao:IAO_0000117 "TN, KH, CM" ;
+                           obo:IAO_0000117 "TN, KH, CM" ;
                            
                            rdfs:isDefinedBy "The criterion used to characterize two voxels, pixels or vertices as 'connected'." ;
                            
-                           iao:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/201." ;
+                           obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/201." ;
                            
-                           iao:IAO_0000114 iao:IAO_0000122 .
+                           obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -1600,13 +1599,13 @@ nidm:ContrastEstimation rdf:type owl:Class ;
                         
                         rdfs:subClassOf prov:Activity ;
                         
-                        iao:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ContrastEstimation.txt"^^xsd:anyURI ;
+                        obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ContrastEstimation.txt"^^xsd:anyURI ;
                         
-                        iao:IAO_0000116 "Under discussion at: https://github.com/ISA-tools/stato/issues/23" ;
+                        obo:IAO_0000116 "Under discussion at: https://github.com/ISA-tools/stato/issues/23" ;
                         
                         rdfs:isDefinedBy "The process of estimating a contrast from the estimated parameters of statistical model." ;
                         
-                        iao:IAO_0000114 iao:IAO_0000423 .
+                        obo:IAO_0000114 obo:IAO_0000423 .
 
 
 
@@ -1616,11 +1615,11 @@ nidm:ContrastMap rdf:type owl:Class ;
                  
                  rdfs:subClassOf nidm:Map ;
                  
-                 iao:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ContrastMap.txt"^^xsd:anyURI ;
+                 obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ContrastMap.txt"^^xsd:anyURI ;
                  
                  rdfs:isDefinedBy "A map whose value at each location is statistical contrast estimate." ;
                  
-                 iao:IAO_0000114 iao:IAO_0000125 .
+                 obo:IAO_0000114 obo:IAO_0000125 .
 
 
 
@@ -1630,11 +1629,11 @@ nidm:ContrastStandardErrorMap rdf:type owl:Class ;
                               
                               rdfs:subClassOf nidm:Map ;
                               
-                              iao:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ContrastStandardErrorMap.txt"^^xsd:anyURI ;
+                              obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ContrastStandardErrorMap.txt"^^xsd:anyURI ;
                               
                               rdfs:isDefinedBy "A map whose value at each location is the standard error of a given contrast." ;
                               
-                              iao:IAO_0000114 iao:IAO_0000125 .
+                              obo:IAO_0000114 obo:IAO_0000125 .
 
 
 
@@ -1644,15 +1643,15 @@ nidm:ContrastWeights rdf:type owl:Class ;
                      
                      rdfs:subClassOf prov:Entity ;
                      
-                     iao:IAO_0000116 "Range: Vector of integers not found." ;
+                     obo:IAO_0000116 "Range: Vector of integers not found." ;
                      
-                     iao:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ContrastWeights.txt" ;
+                     obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ContrastWeights.txt" ;
                      
-                     iao:IAO_0000116 "Under discussion at: https://github.com/ISA-tools/stato/issues/23" ;
+                     obo:IAO_0000116 "Under discussion at: https://github.com/ISA-tools/stato/issues/23" ;
                      
                      rdfs:isDefinedBy "Vector defining the linear combination associated with a particular contrast. " ;
                      
-                     iao:IAO_0000114 iao:IAO_0000423 .
+                     obo:IAO_0000114 obo:IAO_0000423 .
 
 
 
@@ -1664,11 +1663,11 @@ nidm:Coordinate rdf:type owl:Class ;
                 
                 owl:sameAs "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C44465"^^xsd:anyURI ;
                 
-                iao:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/Coordinate.txt"^^xsd:anyURI ;
+                obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/Coordinate.txt"^^xsd:anyURI ;
                 
-                iao:IAO_0000116 "Discussed in https://github.com/incf-nidash/nidm/pull/144 and https://github.com/incf-nidash/nidm/pull/172." ;
+                obo:IAO_0000116 "Discussed in https://github.com/incf-nidash/nidm/pull/144 and https://github.com/incf-nidash/nidm/pull/172." ;
                 
-                iao:IAO_0000114 iao:IAO_0000122 .
+                obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -1678,14 +1677,14 @@ nidm:CoordinateSpace rdf:type owl:Class ;
                      
                      rdfs:subClassOf prov:Entity ;
                      
-                     iao:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/CoordinateSpace.txt"^^xsd:anyURI ;
+                     obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/CoordinateSpace.txt"^^xsd:anyURI ;
                      
                      rdfs:isDefinedBy "An entity with spatial attributes (e.g., dimensions, units, and voxel-to-world mapping) that provides context to a SpatialImage (e.g., a StatisticMap)." ;
                      
-                     iao:IAO_0000116 """BIRNLex or 
+                     obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_21. """ ;
                      
-                     iao:IAO_0000114 iao:IAO_0000120 .
+                     obo:IAO_0000114 obo:IAO_0000120 .
 
 
 
@@ -1697,7 +1696,7 @@ nidm:CustomCoordinateSystem rdf:type owl:Class ;
                             
                             rdfs:comment "FIXME. This definition needs to be re-worked and reviewed." ;
                             
-                            iao:IAO_0000114 iao:IAO_0000120 .
+                            obo:IAO_0000114 obo:IAO_0000120 .
 
 
 
@@ -1707,11 +1706,11 @@ nidm:CustomMaskMap rdf:type owl:Class ;
                    
                    rdfs:subClassOf nidm:Map ;
                    
-                   iao:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/CustomMaskMap.txt" ;
+                   obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/CustomMaskMap.txt" ;
                    
                    rdfs:isDefinedBy "mask defined by the user to restrain the space in which model fitting is performed." ;
                    
-                   iao:IAO_0000114 iao:IAO_0000120 .
+                   obo:IAO_0000114 obo:IAO_0000120 .
 
 
 
@@ -1721,15 +1720,15 @@ nidm:Data rdf:type owl:Class ;
           
           rdfs:subClassOf prov:Entity ;
           
-          iao:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/Data.txt"^^xsd:anyURI ;
+          obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/Data.txt"^^xsd:anyURI ;
           
           owl:sameAs "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C25474" ;
           
           rdfs:isDefinedBy "\"A collection or single item of factual information, derived from measurement or research, from which conclusions may be drawn.\"" ;
           
-          iao:IAO_0000116 "This definition is from NCIT. Please update this note if the definition is modified." ;
+          obo:IAO_0000116 "This definition is from NCIT. Please update this note if the definition is modified." ;
           
-          iao:IAO_0000114 iao:IAO_0000125 .
+          obo:IAO_0000114 obo:IAO_0000125 .
 
 
 
@@ -1754,15 +1753,15 @@ nidm:DesignMatrix rdf:type owl:Class ;
                                     owl:onDataRange xsd:string
                                   ] ;
                   
-                  iao:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/DesignMatrix.txt"^^xsd:anyURI ;
+                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/DesignMatrix.txt"^^xsd:anyURI ;
                   
-                  iao:IAO_0000117 "TN" ;
+                  obo:IAO_0000117 "TN" ;
                   
                   rdfs:seeAlso "stato:design matrix" ;
                   
                   rdfs:isDefinedBy "A matrix of values defining the explanatory variables used in a regression model.  Each column corresponds to one explanatory variable, each row corresponds to one observation." ;
                   
-                  iao:IAO_0000114 iao:IAO_0000125 .
+                  obo:IAO_0000114 obo:IAO_0000125 .
 
 
 
@@ -1772,13 +1771,13 @@ nidm:DisplayMaskMap rdf:type owl:Class ;
                     
                     rdfs:subClassOf nidm:Map ;
                     
-                    iao:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/DisplayMaskMap.txt"^^xsd:anyURI ;
+                    obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/DisplayMaskMap.txt"^^xsd:anyURI ;
                     
                     rdfs:comment "Mask defined by the user to restrain the space in which inference results are reported. This mask does not affect the search volume used for multiple-testing correction; e.g. it does not alter voxel-wise corrected p-values." ;
                     
-                    iao:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/157" ;
+                    obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/157" ;
                     
-                    iao:IAO_0000114 iao:IAO_0000122 .
+                    obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -1790,7 +1789,7 @@ nidm:ErrorDependence rdf:type owl:Class ;
                      
                      rdfs:isDefinedBy "Dependence structure of the error, used as part of model estimation." ;
                      
-                     iao:IAO_0000114 iao:IAO_0000122 .
+                     obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -1800,9 +1799,9 @@ nidm:ErrorDistribution rdf:type owl:Class ;
                        
                        rdfs:subClassOf prov:Entity ;
                        
-                       iao:IAO_0000115 "Probability distribution used to model the error." ;
+                       obo:IAO_0000115 "Probability distribution used to model the error." ;
                        
-                       iao:IAO_0000114 iao:IAO_0000122 .
+                       obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -1812,11 +1811,11 @@ nidm:ErrorModel rdf:type owl:Class ;
                 
                 rdfs:subClassOf prov:Entity ;
                 
-                iao:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ErrorModel.txt"^^xsd:anyURI ;
+                obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ErrorModel.txt"^^xsd:anyURI ;
                 
                 rdfs:isDefinedBy "Model used to describe the random variation of the error term as part of parameter estimation, including specification of the error probability distribution, its variance and dependence both spatially and across observations." ;
                 
-                iao:IAO_0000114 iao:IAO_0000122 .
+                obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -1826,11 +1825,11 @@ nidm:ExchangeableError rdf:type owl:Class ;
                        
                        rdfs:subClassOf nidm:ErrorDependence ;
                        
-                       iao:IAO_0000117 "TN; Under discussion at https://github.com/ISA-tools/stato/issues/28" ;
+                       obo:IAO_0000117 "TN; Under discussion at https://github.com/ISA-tools/stato/issues/28" ;
                        
                        rdfs:comment "Under gaussianity assumption this is equivalent to compound symmetry but not in general." ;
                        
-                       iao:IAO_0000114 iao:IAO_0000423 .
+                       obo:IAO_0000114 obo:IAO_0000423 .
 
 
 
@@ -1845,14 +1844,13 @@ nidm:ExcursionSetMap rdf:type owl:Class ;
                                        owl:minQualifiedCardinality "0"^^xsd:nonNegativeInteger
                                      ] ;
                      
-                     iao:IAO_0000116 "Discussed in the Neuroimaging terms spreadsheet and in https://github.com/incf-nidash/nidm/issues/256." ;
+                     obo:IAO_0000116 "Discussed in the Neuroimaging terms spreadsheet and in https://github.com/incf-nidash/nidm/issues/256." ;
                      
                      rdfs:isDefinedBy "A map in which the set of elements not selected by the inference activity is set to zero or NaN" ;
                      
-                     iao:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ExcursionSetMap.txt" ;
+                     obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ExcursionSetMap.txt" ;
                      
-                     iao:IAO_0000114 iao:IAO_0000122 .
-
+                     obo:IAO_0000114 obo:IAO_0000122 .
 
 
 ###  http://www.incf.org/ns/nidash/nidm#ExtentThreshold
@@ -1861,12 +1859,12 @@ nidm:ExtentThreshold rdf:type owl:Class ;
                      
                      rdfs:subClassOf prov:Entity ;
                      
-                     iao:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ExtentThreshold.txt"^^xsd:anyURI ;
+                     obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ExtentThreshold.txt"^^xsd:anyURI ;
                      
                      rdfs:isDefinedBy """A numerical value that establishes a bound on a range of cluster-sizes. / [from extentThresh:]        Minimum cluster size used when thresholding a statistic image        5voxels
 """ ;
                      
-                     iao:IAO_0000114 iao:IAO_0000120 .
+                     obo:IAO_0000114 obo:IAO_0000120 .
 
 
 
@@ -1880,7 +1878,7 @@ nidm:FSL rdf:type owl:Class ;
          
          rdfs:isDefinedBy "FMRIB Software Library software package for the analysis of neuroimaging data from the FMRIB." ;
          
-         iao:IAO_0000114 iao:IAO_0000125 .
+         obo:IAO_0000114 obo:IAO_0000125 .
 
 
 
@@ -1890,7 +1888,7 @@ nidm:FSLResults rdf:type owl:Class ;
                 
                 rdfs:subClassOf nidm:NIDMObjectModel ;
                 
-                iao:IAO_0000114 iao:IAO_0000124 .
+                obo:IAO_0000114 obo:IAO_0000124 .
 
 
 
@@ -1902,7 +1900,7 @@ nidm:FStatistic rdf:type owl:Class ;
                 
                 owl:sameAs "http://purl.obolibrary.org/obo/STATO_0000282"^^xsd:anyURI ;
                 
-                iao:IAO_0000114 iao:IAO_0000122 .
+                obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -1916,7 +1914,7 @@ nidm:GaussianDistribution rdf:type owl:Class ;
                           
                           rdfs:isDefinedBy "A normal distribution is a continuous probability distribution described by a probability distribution function described here: http://mathworld.wolfram.com/NormalDistribution.html (Definition from STATO)." ;
                           
-                          iao:IAO_0000114 iao:IAO_0000122 .
+                          obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -1926,9 +1924,9 @@ nidm:GrandMeanMap rdf:type owl:Class ;
                   
                   rdfs:subClassOf nidm:Map ;
                   
-                  iao:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/GrandMeanMap.txt"^^xsd:anyURI ;
+                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/GrandMeanMap.txt"^^xsd:anyURI ;
                   
-                  iao:IAO_0000114 iao:IAO_0000124 .
+                  obo:IAO_0000114 obo:IAO_0000124 .
 
 
 
@@ -1938,12 +1936,12 @@ nidm:HeightThreshold rdf:type owl:Class ;
                      
                      rdfs:subClassOf prov:Entity ;
                      
-                     iao:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/HeightThreshold.txt"^^xsd:anyURI ;
+                     obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/HeightThreshold.txt"^^xsd:anyURI ;
                      
                      rdfs:isDefinedBy """A numerical value that establishes a bound on a range of voxelwise or vertex-wise defined statistic.
 """ ;
                      
-                     iao:IAO_0000114 iao:IAO_0000125 .
+                     obo:IAO_0000114 obo:IAO_0000125 .
 
 
 
@@ -1953,9 +1951,9 @@ nidm:IndependentError rdf:type owl:Class ;
                       
                       rdfs:subClassOf nidm:ErrorDependence ;
                       
-                      iao:IAO_0000117 "TN; Under discussion at https://github.com/ISA-tools/stato/issues/28" ;
+                      obo:IAO_0000117 "TN; Under discussion at https://github.com/ISA-tools/stato/issues/28" ;
                       
-                      iao:IAO_0000114 iao:IAO_0000423 .
+                      obo:IAO_0000114 obo:IAO_0000423 .
 
 
 
@@ -1965,13 +1963,13 @@ nidm:Inference rdf:type owl:Class ;
                
                rdfs:subClassOf prov:Activity ;
                
-               iao:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/Inference.txt"^^xsd:anyURI ;
+               obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/Inference.txt"^^xsd:anyURI ;
                
                owl:sameAs "http://purl.obolibrary.org/obo/STATO_0000299" ;
                
                rdfs:isDefinedBy "Statistical inference is a process of drawing conclusions following data analysis using statistical methods (statistical tests) and evaluating whether to reject or accept null hypothesis. (definition from STATO)." ;
                
-               iao:IAO_0000114 iao:IAO_0000122 .
+               obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -1983,9 +1981,9 @@ nidm:InferenceMaskMap rdf:type owl:Class ;
                       
                       rdfs:isDefinedBy "mask defined by the user to restrain the space in which inference is performed." ;
                       
-                      iao:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/InferenceMaskMap.txt" ;
+                      obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/InferenceMaskMap.txt" ;
                       
-                      iao:IAO_0000116 """BIRNLex or 
+                      obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_101. """ .
 
 
@@ -2000,7 +1998,7 @@ nidm:MNICoordinateSystem rdf:type owl:Class ;
                          
                          rdfs:isDefinedBy "Coordinate system defined with reference to the MNI atlas." ;
                          
-                         iao:IAO_0000114 iao:IAO_0000120 .
+                         obo:IAO_0000114 obo:IAO_0000120 .
 
 
 
@@ -2020,11 +2018,11 @@ nidm:Map rdf:type owl:Class ;
                            owl:onDataRange xsd:string
                          ] ;
          
-         iao:IAO_0000116 "Discussed in https://github.com/incf-nidash/nidm/pull/149" ;
+         obo:IAO_0000116 "Discussed in https://github.com/incf-nidash/nidm/pull/149" ;
          
          rdfs:isDefinedBy "Ordered set of values corresponding to the discrete sampling of some process (e.g. brain MRI data measured on a regular 3D lattice; or brain cortical surface data measured irregularly over the cortex)." ;
          
-         iao:IAO_0000114 iao:IAO_0000122 .
+         obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -2044,7 +2042,7 @@ nidm:MapHeader rdf:type owl:Class ;
                                  owl:onDataRange xsd:string
                                ] ;
                
-               iao:IAO_0000114 iao:IAO_0000124 .
+               obo:IAO_0000114 obo:IAO_0000124 .
 
 
 
@@ -2056,11 +2054,11 @@ nidm:MaskMap rdf:type owl:Class ;
              
              rdfs:isDefinedBy "map or surface on which the associated results are displayed. " ;
              
-             iao:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/155" ;
+             obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/155" ;
              
-             iao:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/MaskMap.txt" ;
+             obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/MaskMap.txt" ;
              
-             iao:IAO_0000114 iao:IAO_0000120 .
+             obo:IAO_0000114 obo:IAO_0000120 .
 
 
 
@@ -2070,13 +2068,13 @@ nidm:ModelParametersEstimation rdf:type owl:Class ;
                                
                                rdfs:subClassOf prov:Activity ;
                                
-                               iao:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ModelParametersEstimation.txt"^^xsd:anyURI ;
+                               obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ModelParametersEstimation.txt"^^xsd:anyURI ;
                                
-                               iao:IAO_0000116 "Discussed at: https://github.com/incf-nidash/nidm/issues/141" ;
+                               obo:IAO_0000116 "Discussed at: https://github.com/incf-nidash/nidm/issues/141" ;
                                
                                rdfs:isDefinedBy "the process of performing a stato:\"Model Parameter Estimation\" at each element of a map" ;
                                
-                               iao:IAO_0000114 iao:IAO_0000122 .
+                               obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -2086,7 +2084,7 @@ nidm:NIDMObjectModel rdf:type owl:Class ;
                      
                      rdfs:subClassOf prov:Entity ;
                      
-                     iao:IAO_0000114 iao:IAO_0000124 .
+                     obo:IAO_0000114 obo:IAO_0000124 .
 
 
 
@@ -2098,7 +2096,7 @@ nidm:NonParametricDistribution rdf:type owl:Class ;
                                
                                rdfs:isDefinedBy "Probability distribution estimated empirically on the data without assumptions on the shape of the probability distribution." ;
                                
-                               iao:IAO_0000114 iao:IAO_0000122 .
+                               obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -2110,9 +2108,9 @@ nidm:OneTailedTest rdf:type owl:Class ;
                    
                    owl:sameAs "http://purl.obolibrary.org/obo/STATO_0000286"^^xsd:anyURI ;
                    
-                   iao:IAO_0000116 "Re-use \"one tailed test\" from STATO." ;
+                   obo:IAO_0000116 "Re-use \"one tailed test\" from STATO." ;
                    
-                   iao:IAO_0000114 iao:IAO_0000122 .
+                   obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -2122,13 +2120,13 @@ nidm:ParameterEstimateMap rdf:type owl:Class ;
                           
                           rdfs:subClassOf nidm:Map ;
                           
-                          iao:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ParameterEstimateMap.txt"^^xsd:anyURI ;
+                          obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ParameterEstimateMap.txt"^^xsd:anyURI ;
                           
-                          iao:IAO_0000116 "Under discussion at: https://github.com/incf-nidash/nidm/issues/141 (see also https://github.com/ISA-tools/stato/issues/18)" ;
+                          obo:IAO_0000116 "Under discussion at: https://github.com/incf-nidash/nidm/issues/141 (see also https://github.com/ISA-tools/stato/issues/18)" ;
                           
                           rdfs:isDefinedBy "A map whose value at each location is the estimate of a model parameter." ;
                           
-                          iao:IAO_0000114 iao:IAO_0000120 .
+                          obo:IAO_0000114 obo:IAO_0000120 .
 
 
 
@@ -2140,9 +2138,9 @@ nidm:Peak rdf:type owl:Class ;
           
           rdfs:isDefinedBy "Statistic defined at the peak-level in an excursion set. FIXME (now Peak instead of PeakStatistic)" ;
           
-          iao:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/Peak.txt" ;
+          obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/Peak.txt" ;
           
-          iao:IAO_0000114 iao:IAO_0000120 .
+          obo:IAO_0000114 obo:IAO_0000120 .
 
 
 
@@ -2152,13 +2150,13 @@ nidm:PeakDefinitionCriteria rdf:type owl:Class ;
                             
                             rdfs:subClassOf prov:Entity ;
                             
-                            iao:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/PeakDefinitionCriteria.txt"^^xsd:anyURI ;
+                            obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/PeakDefinitionCriteria.txt"^^xsd:anyURI ;
                             
                             rdfs:isDefinedBy "Set of criterion specified a priori to define the peaks reported after inference (e.g. maximum number of peaks within a cluster, minimum distance between peaks)." ;
                             
-                            iao:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/200." ;
+                            obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/200." ;
                             
-                            iao:IAO_0000114 iao:IAO_0000122 .
+                            obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -2168,11 +2166,11 @@ nidm:PixelConnectivityCriterion rdf:type owl:Class ;
                                 
                                 rdfs:subClassOf nidm:ConnectivityCriterion ;
                                 
-                                iao:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/201." ;
+                                obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/201." ;
                                 
                                 rdfs:isDefinedBy "The criterion used to characterize two pixels as 'connected'. In two dimensions voxels that are connected can share an edge (4-connected) or, edge or corner (8-connected)." ;
                                 
-                                iao:IAO_0000114 iao:IAO_0000122 .
+                                obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -2186,7 +2184,7 @@ nidm:PoissonDistribution rdf:type owl:Class ;
                          
                          rdfs:isDefinedBy "Poisson distribution is a probability distribution used to model the number of events occurring within a given time interval. It is defined by a real number (λ) and an integer k representing the number of events and a function. The expected value of a Poisson-distributed random variable is equal to λ and so is its variance. (Definition from STATO)." ;
                          
-                         iao:IAO_0000114 iao:IAO_0000122 .
+                         obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -2196,18 +2194,18 @@ nidm:ResidualMeanSquaresMap rdf:type owl:Class ;
                             
                             rdfs:subClassOf nidm:Map ;
                             
-                            iao:IAO_0000117 "KH" ;
+                            obo:IAO_0000117 "KH" ;
                             
-                            iao:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ResidualMeanSquaresMap.txt" ;
+                            obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ResidualMeanSquaresMap.txt" ;
                             
                             rdfs:isDefinedBy "A map whose value at each location is the residual of the mean squares fit to the data." ;
                             
                             rdfs:seeAlso "This is a map of \"residuals\" as defined at http://bioportal.bioontology.org/ontologies/STATO/?p=classes&conceptid=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FSTATO_0000234 " ;
                             
-                            iao:IAO_0000116 """BIRNLex or 
+                            obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_52. """ ;
                             
-                            iao:IAO_0000114 iao:IAO_0000125 .
+                            obo:IAO_0000114 obo:IAO_0000125 .
 
 
 
@@ -2221,7 +2219,7 @@ nidm:SPM rdf:type owl:Class ;
          
          rdfs:seeAlso "http://www.fil.ion.ucl.ac.uk/spm/" ;
          
-         iao:IAO_0000114 iao:IAO_0000125 .
+         obo:IAO_0000114 obo:IAO_0000125 .
 
 
 
@@ -2231,7 +2229,7 @@ nidm:SPMResults rdf:type owl:Class ;
                 
                 rdfs:subClassOf nidm:NIDMObjectModel ;
                 
-                iao:IAO_0000114 iao:IAO_0000124 .
+                obo:IAO_0000114 obo:IAO_0000124 .
 
 
 
@@ -2245,9 +2243,9 @@ nidm:SearchSpaceMap rdf:type owl:Class ;
                     
                     rdfs:isDefinedBy "mask in which the inference was performed." ;
                     
-                    iao:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/SearchSpaceMap.txt" ;
+                    obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/SearchSpaceMap.txt" ;
                     
-                    iao:IAO_0000114 iao:IAO_0000120 .
+                    obo:IAO_0000114 obo:IAO_0000120 .
 
 
 
@@ -2257,9 +2255,9 @@ nidm:SeriallyCorrelatedError rdf:type owl:Class ;
                              
                              rdfs:subClassOf nidm:ErrorDependence ;
                              
-                             iao:IAO_0000117 "TN; Under discussion at https://github.com/ISA-tools/stato/issues/28" ;
+                             obo:IAO_0000117 "TN; Under discussion at https://github.com/ISA-tools/stato/issues/28" ;
                              
-                             iao:IAO_0000114 iao:IAO_0000423 .
+                             obo:IAO_0000114 obo:IAO_0000423 .
 
 
 
@@ -2314,7 +2312,7 @@ nidm:StandardizedCoordinateSystem rdf:type owl:Class ;
                                   
                                   rdfs:isDefinedBy "Parent of all reference spaces except \"Subject\"." ;
                                   
-                                  iao:IAO_0000114 iao:IAO_0000120 .
+                                  obo:IAO_0000114 obo:IAO_0000120 .
 
 
 
@@ -2326,7 +2324,7 @@ nidm:Statistic rdf:type owl:Class ;
                
                owl:sameAs "http://purl.obolibrary.org/obo/STATO_0000039"^^xsd:anyURI ;
                
-               iao:IAO_0000114 iao:IAO_0000122 .
+               obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -2336,11 +2334,11 @@ nidm:StatisticMap rdf:type owl:Class ;
                   
                   rdfs:subClassOf nidm:Map ;
                   
-                  iao:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/StatisticMap.txt"^^xsd:anyURI ;
+                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/StatisticMap.txt"^^xsd:anyURI ;
                   
                   rdfs:isDefinedBy "A map whose value at each location is a statistic. " ;
                   
-                  iao:IAO_0000114 iao:IAO_0000120 .
+                  obo:IAO_0000114 obo:IAO_0000120 .
 
 
 
@@ -2354,7 +2352,7 @@ nidm:SubjectCoordinateSystem rdf:type owl:Class ;
                              
                              rdfs:isDefinedBy "Coordinate system defined by the subject brain (no spatial normalisation applied)." ;
                              
-                             iao:IAO_0000114 iao:IAO_0000120 .
+                             obo:IAO_0000114 obo:IAO_0000120 .
 
 
 
@@ -2366,7 +2364,7 @@ nidm:TStatistic rdf:type owl:Class ;
                 
                 owl:sameAs "http://purl.obolibrary.org/obo/STATO_0000176"^^xsd:anyURI ;
                 
-                iao:IAO_0000114 iao:IAO_0000122 .
+                obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -2380,7 +2378,7 @@ nidm:TalairachCoordinateSystem rdf:type owl:Class ;
                                
                                rdfs:seeAlso "http://www.talairach.org/" ;
                                
-                               iao:IAO_0000114 iao:IAO_0000120 .
+                               obo:IAO_0000114 obo:IAO_0000120 .
 
 
 
@@ -2394,7 +2392,7 @@ nidm:TwoTailedTest rdf:type owl:Class ;
                    
                    owl:sameAs "http://purl.obolibrary.org/obo/STATO_0000287"^^xsd:anyURI ;
                    
-                   iao:IAO_0000114 iao:IAO_0000122 .
+                   obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -2404,11 +2402,11 @@ nidm:VoxelConnectivityCriterion rdf:type owl:Class ;
                                 
                                 rdfs:subClassOf nidm:ConnectivityCriterion ;
                                 
-                                iao:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/201." ;
+                                obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/201." ;
                                 
                                 rdfs:isDefinedBy "The criterion used to characterize two voxels as 'connected'. In three dimensions voxels that are connected can share a voxel face (6-connected), face or edge (18-connectec), or face, edge, or corner (26-connected)." ;
                                 
-                                iao:IAO_0000114 iao:IAO_0000122 .
+                                obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -2418,7 +2416,7 @@ nidm:WorldCoordinateSystem rdf:type owl:Class ;
                            
                            rdfs:subClassOf prov:Entity ;
                            
-                           iao:IAO_0000114 iao:IAO_0000124 .
+                           obo:IAO_0000114 obo:IAO_0000124 .
 
 
 
@@ -2428,7 +2426,7 @@ nidm:ZStatistic rdf:type owl:Class ;
                 
                 rdfs:subClassOf nidm:Statistic ;
                 
-                iao:IAO_0000114 iao:IAO_0000124 .
+                obo:IAO_0000114 obo:IAO_0000124 .
 
 
 
@@ -2440,7 +2438,7 @@ spm:KConjunctionInference rdf:type owl:Class ;
                           
                           rdfs:isDefinedBy "Inference testing for the joint significance of a subset of the effects." ;
                           
-                          iao:IAO_0000114 iao:IAO_0000120 .
+                          obo:IAO_0000114 obo:IAO_0000120 .
 
 
 
@@ -2450,11 +2448,11 @@ spm:ReselsPerVoxelMap rdf:type owl:Class ;
                       
                       rdfs:subClassOf nidm:Map ;
                       
-                      iao:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/SPM_ReselsPerVoxelMap.txt"^^xsd:anyURI ;
+                      obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/SPM_ReselsPerVoxelMap.txt"^^xsd:anyURI ;
                       
                       rdfs:isDefinedBy "A map whose value at each location is the number of resels per voxel. " ;
                       
-                      iao:IAO_0000114 iao:IAO_0000120 .
+                      obo:IAO_0000114 obo:IAO_0000120 .
 
 
 
@@ -2480,7 +2478,7 @@ nidm:Colin27CoordinateSystem rdf:type nidm:StandardizedCoordinateSystem ,
                              
                              rdfs:comment "FIXME. This definition needs to be re-worked and reviewed." ;
                              
-                             iao:IAO_0000114 iao:IAO_0000120 .
+                             obo:IAO_0000114 obo:IAO_0000120 .
 
 
 
@@ -2493,7 +2491,7 @@ nidm:Icbm452AirCoordinateSystem rdf:type nidm:MNICoordinateSystem ,
                                 
                                 rdfs:isDefinedBy "Coordinate system defined by the \"average of 452 T1-weighted MRIs of normal young adult brains\" with \"linear transforms of the subjects into the atlas space using a 12-parameter affine transformation\"" ;
                                 
-                                iao:IAO_0000114 iao:IAO_0000120 .
+                                obo:IAO_0000114 obo:IAO_0000120 .
 
 
 
@@ -2506,7 +2504,7 @@ nidm:Icbm452Warp5CoordinateSystem rdf:type nidm:MNICoordinateSystem ,
                                   
                                   rdfs:isDefinedBy "Coordinate system defined by the \"average of 452 T1-weighted MRIs of normal young adult brains\" \"based on a 5th order polynomial transformation into the atlas space\"" ;
                                   
-                                  iao:IAO_0000114 iao:IAO_0000120 .
+                                  obo:IAO_0000114 obo:IAO_0000120 .
 
 
 
@@ -2521,7 +2519,7 @@ nidm:IcbmMni152LinearCoordinateSystem rdf:type nidm:MNICoordinateSystem ,
                                       
                                       rdfs:isDefinedBy "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, linearly transformed to Talairach space\"." ;
                                       
-                                      iao:IAO_0000114 iao:IAO_0000120 .
+                                      obo:IAO_0000114 obo:IAO_0000120 .
 
 
 
@@ -2534,7 +2532,7 @@ nidm:IcbmMni152NonLinear2009aAsymmetricCoordinateSystem rdf:type nidm:MNICoordin
                                                         
                                                         rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009" ;
                                                         
-                                                        iao:IAO_0000114 iao:IAO_0000120 .
+                                                        obo:IAO_0000114 obo:IAO_0000120 .
 
 
 
@@ -2547,7 +2545,7 @@ nidm:IcbmMni152NonLinear2009aSymmetricCoordinateSystem rdf:type nidm:MNICoordina
                                                        
                                                        rdfs:isDefinedBy "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." ;
                                                        
-                                                       iao:IAO_0000114 iao:IAO_0000120 .
+                                                       obo:IAO_0000114 obo:IAO_0000120 .
 
 
 
@@ -2560,7 +2558,7 @@ nidm:IcbmMni152NonLinear2009bAsymmetricCoordinateSystem rdf:type nidm:MNICoordin
                                                         
                                                         rdfs:isDefinedBy "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." ;
                                                         
-                                                        iao:IAO_0000114 iao:IAO_0000120 .
+                                                        obo:IAO_0000114 obo:IAO_0000120 .
 
 
 
@@ -2573,7 +2571,7 @@ nidm:IcbmMni152NonLinear2009bSymmetricCoordinateSystem rdf:type nidm:MNICoordina
                                                        
                                                        rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009" ;
                                                        
-                                                       iao:IAO_0000114 iao:IAO_0000120 .
+                                                       obo:IAO_0000114 obo:IAO_0000120 .
 
 
 
@@ -2588,7 +2586,7 @@ nidm:IcbmMni152NonLinear2009cAsymmetricCoordinateSystem rdf:type nidm:MNICoordin
                                                         
                                                         rdfs:isDefinedBy "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." ;
                                                         
-                                                        iao:IAO_0000114 iao:IAO_0000120 .
+                                                        obo:IAO_0000114 obo:IAO_0000120 .
 
 
 
@@ -2601,7 +2599,7 @@ nidm:IcbmMni152NonLinear2009cSymmetricCoordinateSystem rdf:type nidm:MNICoordina
                                                        
                                                        rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009" ;
                                                        
-                                                       iao:IAO_0000114 iao:IAO_0000120 .
+                                                       obo:IAO_0000114 obo:IAO_0000120 .
 
 
 
@@ -2616,7 +2614,7 @@ nidm:IcbmMni152NonLinear6thGenerationCoordinateSystem rdf:type nidm:MNICoordinat
                                                       
                                                       rdfs:comment "Used in FSL (cf. http://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Atlases)" ;
                                                       
-                                                      iao:IAO_0000114 iao:IAO_0000120 .
+                                                      obo:IAO_0000114 obo:IAO_0000120 .
 
 
 
@@ -2631,7 +2629,7 @@ nidm:Ixi549CoordinateSystem rdf:type nidm:MNICoordinateSystem ,
                             
                             rdfs:comment "Used in SPM12b (cf. spm12b/spm_templates.man)" ;
                             
-                            iao:IAO_0000114 iao:IAO_0000120 .
+                            obo:IAO_0000114 obo:IAO_0000120 .
 
 
 
@@ -2644,7 +2642,7 @@ nidm:Mni305CoordinateSystem rdf:type nidm:MNICoordinateSystem ,
                             
                             rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/MNI305" ;
                             
-                            iao:IAO_0000114 iao:IAO_0000120 .
+                            obo:IAO_0000114 obo:IAO_0000120 .
 
 
 
@@ -2689,11 +2687,11 @@ nidm:connected8In2D rdf:type owl:NamedIndividual .
 nidm:pixel4connected rdf:type nidm:PixelConnectivityCriterion ,
                               owl:NamedIndividual ;
                      
-                     iao:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/201." ;
+                     obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/201." ;
                      
                      rdfs:isDefinedBy "A pair of pixels are 4-Connected if they share an edge." ;
                      
-                     iao:IAO_0000114 iao:IAO_0000122 .
+                     obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -2704,9 +2702,9 @@ nidm:pixel8connected rdf:type nidm:PixelConnectivityCriterion ,
                      
                      rdfs:isDefinedBy "A pair of pixels are 8-Connected if they share an edge or corner." ;
                      
-                     iao:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/201." ;
+                     obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/201." ;
                      
-                     iao:IAO_0000114 iao:IAO_0000122 .
+                     obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -2715,11 +2713,11 @@ nidm:pixel8connected rdf:type nidm:PixelConnectivityCriterion ,
 nidm:voxel18connected rdf:type nidm:VoxelConnectivityCriterion ,
                                owl:NamedIndividual ;
                       
-                      iao:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/201." ;
+                      obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/201." ;
                       
                       rdfs:isDefinedBy "A pair of voxels are 18-Connected if they share a face or edge." ;
                       
-                      iao:IAO_0000114 iao:IAO_0000122 .
+                      obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -2730,9 +2728,9 @@ nidm:voxel26connected rdf:type nidm:VoxelConnectivityCriterion ,
                       
                       rdfs:isDefinedBy "A pair of voxels are 26-Connected if they share a face, edge or corner." ;
                       
-                      iao:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/201." ;
+                      obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/201." ;
                       
-                      iao:IAO_0000114 iao:IAO_0000122 .
+                      obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -2743,9 +2741,9 @@ nidm:voxel6connected rdf:type nidm:VoxelConnectivityCriterion ,
                      
                      rdfs:isDefinedBy "A pair of voxels are 6-Connected if they share a face." ;
                      
-                     iao:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/201." ;
+                     obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/201." ;
                      
-                     iao:IAO_0000114 iao:IAO_0000122 .
+                     obo:IAO_0000114 obo:IAO_0000122 .
 
 
 

--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -13,6 +13,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#> .
 @prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix obo: <http://purl.obolibrary.org/obo/> .
 @base <http://www.w3.org/2002/07/owl#> .
 
 [ rdf:type owl:Ontology ;
@@ -1402,7 +1403,7 @@ spm:softwareRevision rdf:type owl:DatatypeProperty ;
 
 nfo:fileName rdf:type owl:DatatypeProperty ;
              
-             iao:IAO_0000112 "con_0001.img" ;
+             obo:IAO_0000112 "con_0001.img" ;
              
              rdfs:range xsd:string .
 

--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -20,6 +20,7 @@
   owl:imports <http://purl.obolibrary.org/nidm/iao_import.owl> ,
               <http://purl.org/nidash/nidm/dc_import.owl> ,
               <http://purl.org/nidash/nidm/nfo_import.owl> ,
+              <http://purl.org/nidash/nidm/stato_import.owl> ,
               <http://www.w3.org/ns/prov-o-20130430>
 ] .
 
@@ -237,7 +238,7 @@ nidm:withEstimationMethod rdf:type owl:ObjectProperty ;
                           
                           rdfs:isDefinedBy "FIXME" ;
                           
-                          rdfs:range nidm:EstimationMethod ;
+                          rdfs:range iao:STATO_0000119 ;
                           
                           rdfs:domain nidm:ModelParametersEstimation .
 
@@ -1819,14 +1820,6 @@ nidm:ErrorModel rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#EstimationMethod
-
-nidm:EstimationMethod rdf:type owl:Class ;
-                      
-                      rdfs:subClassOf prov:Entity .
-
-
-
 ###  http://www.incf.org/ns/nidash/nidm#ExchangeableError
 
 nidm:ExchangeableError rdf:type owl:Class ;
@@ -1924,18 +1917,6 @@ nidm:GaussianDistribution rdf:type owl:Class ;
                           rdfs:isDefinedBy "A normal distribution is a continuous probability distribution described by a probability distribution function described here: http://mathworld.wolfram.com/NormalDistribution.html (Definition from STATO)." ;
                           
                           iao:IAO_0000114 iao:IAO_0000122 .
-
-
-
-###  http://www.incf.org/ns/nidash/nidm#GeneralizedLeastSquares
-
-nidm:GeneralizedLeastSquares rdf:type owl:Class ;
-                             
-                             rdfs:subClassOf nidm:EstimationMethod ;
-                             
-                             rdfs:isDefinedBy "FIXME" ;
-                             
-                             rdfs:comment "GLS (both heteroscedasticity and dependence accounted for) OLS is a special case of WLS & GLS; WLS is a special case of GLS." .
 
 
 
@@ -2135,18 +2116,6 @@ nidm:OneTailedTest rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#OrdinaryLeastSquares
-
-nidm:OrdinaryLeastSquares rdf:type owl:Class ;
-                          
-                          rdfs:subClassOf nidm:EstimationMethod ;
-                          
-                          rdfs:comment "OLS (no heteroscedasticity or dependence accounted for)" ;
-                          
-                          rdfs:isDefinedBy "FIXME" .
-
-
-
 ###  http://www.incf.org/ns/nidash/nidm#ParameterEstimateMap
 
 nidm:ParameterEstimateMap rdf:type owl:Class ;
@@ -2239,18 +2208,6 @@ nidm:ResidualMeanSquaresMap rdf:type owl:Class ;
 NIDM Concept ID: nidm_52. """ ;
                             
                             iao:IAO_0000114 iao:IAO_0000125 .
-
-
-
-###  http://www.incf.org/ns/nidash/nidm#RobustIterativelyReweighedLeastSquares
-
-nidm:RobustIterativelyReweighedLeastSquares rdf:type owl:Class ;
-                                            
-                                            rdfs:subClassOf nidm:EstimationMethod ;
-                                            
-                                            rdfs:isDefinedBy "FIXME" ;
-                                            
-                                            rdfs:comment "used for automatically down-weighting outliers, using some given influence function (e.g. Huber; see [1] for a neuroimaging application)." .
 
 
 
@@ -2452,18 +2409,6 @@ nidm:VoxelConnectivityCriterion rdf:type owl:Class ;
                                 rdfs:isDefinedBy "The criterion used to characterize two voxels as 'connected'. In three dimensions voxels that are connected can share a voxel face (6-connected), face or edge (18-connectec), or face, edge, or corner (26-connected)." ;
                                 
                                 iao:IAO_0000114 iao:IAO_0000122 .
-
-
-
-###  http://www.incf.org/ns/nidash/nidm#WeightedLeastSquares
-
-nidm:WeightedLeastSquares rdf:type owl:Class ;
-                          
-                          rdfs:subClassOf nidm:EstimationMethod ;
-                          
-                          rdfs:isDefinedBy "FIXME" ;
-                          
-                          rdfs:comment "WLS (heteroscedasticity accounted for, but no dependence)" .
 
 
 

--- a/nidm/nidm-results/terms/templates/ModelParametersEstimation.txt
+++ b/nidm/nidm-results/terms/templates/ModelParametersEstimation.txt
@@ -1,7 +1,7 @@
 $model_pe_id prov:used niiri:error_model_id ;
 	a prov:Activity , nidm:ModelParametersEstimation ;
 	rdfs:label "$label" ;
-	nidm:withEstimationMethod $est_method ;
+	nidm:withEstimationMethod $est_method ; # $est_method_comment
 	prov:used $design_matrix_id ;
     prov:used $data_matrix_id ;
     prov:used $error_model_id ;

--- a/nidm/nidm-results/terms/templates/Namespaces.txt
+++ b/nidm/nidm-results/terms/templates/Namespaces.txt
@@ -11,3 +11,4 @@
 @prefix niiri: <http://iri.nidash.org/> .
 @prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix stato: <http://purl.obolibrary.org/obo/> .

--- a/nidm/nidm-results/terms/templates/Namespaces.txt
+++ b/nidm/nidm-results/terms/templates/Namespaces.txt
@@ -11,4 +11,5 @@
 @prefix niiri: <http://iri.nidash.org/> .
 @prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix stato: <http://purl.obolibrary.org/obo/> .
+@prefix obo: <http://purl.obolibrary.org/obo/> .
+

--- a/nidm/nidm-results/test/CheckConsistency.py
+++ b/nidm/nidm-results/test/CheckConsistency.py
@@ -146,7 +146,7 @@ def get_attributes_from_owl(my_owl_graph):
             
     return list((attributes, ranges, restrictions))
 
-def get_owl_graph(owl_file):
+def get_owl_graph(owl_file, import_files=None):
     # Read owl (turtle) file
     owl_graph = Graph()
     # This is a workaround to avoid issue with "#" in base prefix as 
@@ -156,6 +156,22 @@ def get_owl_graph(owl_file):
     owl_txt = open(owl_file, 'r').read().replace("http://www.w3.org/2002/07/owl#", 
                     "http://www.w3.org/2002/07/owl")
     owl_graph.parse(data=owl_txt, format='turtle')
+
+    if import_files is not None:
+        for import_file in import_files:
+            # Read owl (turtle) file
+            import_graph = Graph()
+            import_txt = open(import_file, 'r').read()
+
+            # This is a workaround to avoid issue with "#" in base prefix as 
+            # described in https://github.com/RDFLib/rdflib/issues/379,
+            # When the fix is introduced in rdflib these 2 lines will be replaced by:
+            # self.owl.parse(owl_file, format='turtle')
+            import_txt = import_txt.replace("http://www.w3.org/2002/07/owl#", 
+                            "http://www.w3.org/2002/07/owl")
+            import_graph.parse(data=import_txt, format='turtle')
+
+            owl_graph = owl_graph + import_graph
 
     return owl_graph
 

--- a/nidm/nidm-results/test/TestExamplesMatchVocabulary.py
+++ b/nidm/nidm-results/test/TestExamplesMatchVocabulary.py
@@ -10,6 +10,7 @@ import os
 from rdflib.graph import Graph
 from TestCommons import *
 from CheckConsistency import *
+import glob
 
 RELPATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -22,16 +23,10 @@ class TestExamples(unittest.TestCase):
         # check the file exists
         assert os.path.exists(owl_file)
         # Read owl (turtle) file
-        self.owl = Graph()
+        import_files = glob.glob(os.path.join(os.path.dirname(owl_file), os.pardir, os.pardir, "imports", '*.ttl'))
+        self.owl = get_owl_graph(owl_file, import_files)
 
-        # This is a workaround to avoid issue with "#" in base prefix as 
-        # described in https://github.com/RDFLib/rdflib/issues/379,
-        # When the fix is introduced in rdflib these 2 lines will be replaced by:
-        # self.owl.parse(owl_file, format='turtle')
-        owl_txt = open(owl_file, 'r').read().replace("http://www.w3.org/2002/07/owl#", 
-                        "http://www.w3.org/2002/07/owl")
-        self.owl.parse(data=owl_txt, format='turtle')
-        
+       
         # Retreive all classes defined in the owl file
         self.sub_types = get_class_names_in_owl(self.owl) #set(); #{'entity': set(), 'activity': set(), 'agent' : set()}
         # For each class find out attribute list as defined by domain in attributes

--- a/scripts/Constants.py
+++ b/scripts/Constants.py
@@ -25,7 +25,8 @@ DCT = Namespace('http://purl.org/dc/terms/')
 OWL = Namespace('http://www.w3.org/2002/07/owl')
 XSD = Namespace('http://www.w3.org/2001/XMLSchema#')
 
-OBO = Namespace("http://purl.obolibrary.org/obo/")
+OBO_URL = "http://purl.obolibrary.org/obo/"
+OBO = Namespace(OBO_URL)
 
 OBO_EXAMPLE = OBO['IAO_0000112']
 OBO_TERM_EDITOR = OBO['IAO_0000117']
@@ -40,3 +41,8 @@ OBO_READY = OBO['IAO_0000122']
 OBO_DEFINITION = OBO['IAO_0000115']
 
 HAS_CURATION_STATUS = OBO['IAO_0000114']
+
+STATO_OLS = OBO['ordinary_least_squares_estimation']
+STATO_OLS_STR = str(STATO_OLS).replace(OBO_URL, "stato:")
+STATO_GLS = OBO['STATO_0000372']
+STATO_GLS_STR = str(STATO_GLS).replace(OBO_URL, "stato:")

--- a/scripts/Constants.py
+++ b/scripts/Constants.py
@@ -42,7 +42,7 @@ OBO_DEFINITION = OBO['IAO_0000115']
 
 HAS_CURATION_STATUS = OBO['IAO_0000114']
 
-STATO_OLS = OBO['ordinary_least_squares_estimation']
+STATO_OLS = OBO['STATO_0000370']
 STATO_OLS_STR = str(STATO_OLS).replace(OBO_URL, "stato:")
 STATO_GLS = OBO['STATO_0000372']
 STATO_GLS_STR = str(STATO_GLS).replace(OBO_URL, "stato:")

--- a/scripts/Constants.py
+++ b/scripts/Constants.py
@@ -43,6 +43,9 @@ OBO_DEFINITION = OBO['IAO_0000115']
 HAS_CURATION_STATUS = OBO['IAO_0000114']
 
 STATO_OLS = OBO['STATO_0000370']
-STATO_OLS_STR = str(STATO_OLS).replace(OBO_URL, "stato:")
+STATO_OLS_STR = str(STATO_OLS).replace(OBO_URL, "obo:")
+# TODO: labels should be grabbed automatically from the corresponding owl file
+STATO_OLS_LABEL = "obo:'ordinary least squares estimation'"
 STATO_GLS = OBO['STATO_0000372']
-STATO_GLS_STR = str(STATO_GLS).replace(OBO_URL, "stato:")
+STATO_GLS_STR = str(STATO_GLS).replace(OBO_URL, "obo:")
+STATO_GLS_LABEL = "obo:'generalized least squares estimation'"

--- a/scripts/OwlReader.py
+++ b/scripts/OwlReader.py
@@ -13,8 +13,9 @@ import warnings
 
 class OwlReader():
 
-    def __init__(self, owl_file):
-        self.file = owl_file       
+    def __init__(self, owl_file, import_owl_files=None):
+        self.file = owl_file   
+        self.import_files = import_owl_files
         self.graph = self.get_graph()
         
         # Retreive all classes defined in the owl file
@@ -199,6 +200,25 @@ class OwlReader():
         owl_txt = owl_txt.replace("http://www.w3.org/2002/07/owl#", 
                         "http://www.w3.org/2002/07/owl")
         owl_graph.parse(data=owl_txt, format='turtle')
+
+        if self.import_files:
+            for import_file in self.import_files:
+                # Read owl (turtle) file
+                import_graph = Graph()
+                if self.file[0:4] == "http":
+                    import_txt = urllib.urlopen(import_file).read()
+                else:
+                    import_txt = open(import_file, 'r').read()
+
+                # This is a workaround to avoid issue with "#" in base prefix as 
+                # described in https://github.com/RDFLib/rdflib/issues/379,
+                # When the fix is introduced in rdflib these 2 lines will be replaced by:
+                # self.owl.parse(owl_file, format='turtle')
+                import_txt = import_txt.replace("http://www.w3.org/2002/07/owl#", 
+                                "http://www.w3.org/2002/07/owl")
+                import_graph.parse(data=import_txt, format='turtle')
+
+                owl_graph = owl_graph + import_graph
 
         return owl_graph
 

--- a/scripts/owl_to_webpage.py
+++ b/scripts/owl_to_webpage.py
@@ -284,7 +284,8 @@ class OwlSpecification(object):
                         else:
                             self.text += " (range "
                             for range_uri in sorted(self.owl.ranges[att]):
-                                self.text += '<a href="'+str(range_uri)+'">'+\
+                                self.text += '<a title="'+self.owl.graph.qname(range_uri)+\
+                                '" href="'+str(range_uri)+'">'+\
                                 self._get_name(range_uri)+'</a>, '
                             self.text = self.text[:-2]
                             self.text += ")"

--- a/scripts/owl_to_webpage.py
+++ b/scripts/owl_to_webpage.py
@@ -261,11 +261,39 @@ class OwlSpecification(object):
                         self.format_definition(att_def)
 
                     if att in self.owl.ranges:
-                        range_names = map(self._get_name, \
-                            sorted(self.owl.ranges[att]))
+                        # range_names = map(self._get_name, \
+                            # sorted(self.owl.ranges[att]))
+
+                        nidm_namespace = False
+                        if self._get_name(list(self.owl.ranges[att])[0]).startswith("nidm") or \
+                           self._get_name(list(self.owl.ranges[att])[0]).startswith("fsl") or \
+                           self._get_name(list(self.owl.ranges[att])[0]).startswith("spm"):
+                            nidm_namespace = True
+                            
+
+                        if nidm_namespace:
+                            if len(self.owl.ranges[att]) >= 2:
+                                self.text += " (range <a>"+"</a>, <a>".join(map(self._get_name, \
+                                    sorted(self.owl.ranges[att])[:-1]))+"</a> and <a>"+\
+                                    self._get_name(sorted(self.owl.ranges[att])[-1])+\
+                                    "</a>)"
+                            else:
+                                self.text += \
+                                    " (range <a>"+self._get_name(list(self.owl.ranges[att])[0])+\
+                                    "</a>)"
+                        else:
+                            self.text += " (range "
+                            for range_uri in sorted(self.owl.ranges[att]):
+                                self.text += '<a href="'+str(range_uri)+'">'+\
+                                self._get_name(range_uri)+'</a>, '
+                            self.text = self.text[:-2]
+                            self.text += ")"
+
+
 
                         # print map(startswith('nidm'), map(self.owl.graph.qname, sorted(self.owl.ranges[att])))
-                        self.text += " (range "+", ".join(range_names)+")"
+                        # self.text += " (range "+", ".join(range_names)+")"
+                        
 
                         for range_class in sorted(self.owl.ranges[att]):
                             if self._get_name(range_class).startswith('nidm'):

--- a/scripts/owl_to_webpage.py
+++ b/scripts/owl_to_webpage.py
@@ -10,9 +10,9 @@ INCLUDE_FOLDER = os.path.join(DOC_FOLDER, "include")
 
 class OwlSpecification(object):
 
-    def __init__(self, owl_file, spec_name, subcomponents=None, used_by=None, 
-        generated_by=None, derived_from=None, prefix=None):
-        self.owl = OwlReader(owl_file)
+    def __init__(self, owl_file, import_files, spec_name, subcomponents=None, 
+        used_by=None, generated_by=None, derived_from=None, prefix=None):
+        self.owl = OwlReader(owl_file, import_files)
         self.name = spec_name
         self.component = self.name.lower().replace("-", "_")
         self.section_open = 0


### PR DESCRIPTION
Following ISA-tools/stato#32, "Ordinary Least Squares estimation", "Weighted Least Squares estimation", "Generalised Least Squares estimation", "Feasible Generalized Least Squares estimation" and "Iteratively Reweighted Least Squares estimation" are now defined in STATO.

This pull request implements the re-use of these terms as a value for `nidm:withEstimationMethod` object property used in the `nidm:ModelParametersEstimation` activity ([current implementation](http://nidm.nidash.org/specs/nidm-results_dev.html#dfn-nidm-modelparametersestimation), [proposed update preview](http://htmlpreview.github.io/?https://raw.githubusercontent.com/incf-nidash/nidm/8c2daba767b1cc6707677e80b4e4b1e6db5b46e8/doc/content/specs/nidm-results_dev.html#dfn-nidm-modelparametersestimation)).