### PR TITLE
Retry on timeout when calling the ProvStore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ nidm/nidm-results/scripts/store_login_key.txt
 nidm/nidm-results/test/spmexport/**.nii.gz
 nidm/nidm-results/test/spmexport/**.csv
 nidm/nidm-results/test/spmexport/**.png
+
+### Ignore debug log file
+debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ install: pip install -r requirements.txt
 script:  
 - python -m unittest discover -s ./nidm/nidm-results/test/ -p '[t|T]est*.py'
 - python test/test_specifications.py 
+- cat debug.log

--- a/nidm/nidm-results/test/TestCommons.py
+++ b/nidm/nidm-results/test/TestCommons.py
@@ -12,7 +12,6 @@ import rdflib
 from rdflib.graph import Graph
 from rdflib.compare import *
 import logging
-# import threading
 import signal
 import socket
 
@@ -171,16 +170,12 @@ def _get_ttl_doc_content(doc):
                 logger.info(' urllib2 open ')
                 ttl_doc_req = urllib2.urlopen(doc, timeout=TIMEOUT)
 
-                # Signal handler
-                signal.signal(signal.SIGALRM, _raise_timeout)
                 # There is no mechanism to handle timeout on read() in urllib2, 
                 # so we need to use a timer
-                # t = threading.Timer(TIMEOUT, _re_run_on_timeout)
+                signal.signal(signal.SIGALRM, _raise_timeout)                
                 signal.alarm(TIMEOUT)
-                # t.start() 
                 logger.info(' urllib2 read ')
                 doc_content = ttl_doc_req.read()
-                # t.cancel()
                 signal.alarm(0)
 
             except (socket.timeout, TimeoutError, urllib2.URLError):

--- a/nidm/nidm-results/test/TestCommons.py
+++ b/nidm/nidm-results/test/TestCommons.py
@@ -16,8 +16,10 @@ import logging
 import signal
 import socket
 
-logging.basicConfig(level=logging.DEBUG)
+# Save debug info in a log file (debug.log)
+logging.basicConfig(filename='debug.log', level=logging.DEBUG, filemode='w')
 logger = logging.getLogger(__name__)
+logger.info(' ---------- Debug log ----------')
 
 # Examples used for unit testing
 import_test_filenames = set([
@@ -69,7 +71,7 @@ def get_turtle(provn_file):
             except (socket.timeout, urllib2.URLError):
                 # On timeout retry
                 retry = retry + 1 
-                logger.info('retry: '+str(retry))
+                logger.info('Retry #'+str(retry))
                 continue
             break
 
@@ -184,7 +186,7 @@ def _get_ttl_doc_content(doc):
             except (socket.timeout, TimeoutError, urllib2.URLError):
                 # On timeout retry
                 retry = retry + 1 
-                logger.info('retry: '+str(retry))
+                logger.info(' Retry #'+str(retry))
                 continue
             break
 
@@ -211,9 +213,7 @@ def compare_ttl_documents(ttl_doc1, ttl_doc2):
     doc2 = _get_ttl_doc_content(ttl_doc2)
     same_doc_graph.parse(data=doc2, format='turtle')
 
-    logger.info('start comparison')
     found_difference = compare_graphs(same_doc_graph, doc_graph)
-    logger.info('DIFF = '+str(found_difference))
 
     # # Use isomorphic to ignore BNode
     # iso1 = to_isomorphic(same_doc_graph)


### PR DESCRIPTION
In this pull request:
- we catch timeouts (>5s) on `urlopen` and `read` calls to the ProvStore (and Prov validator)
- retry the call on timeout (up to 15 times).

This fixes issue #254, though we will probably want to avoid calling the prov store in the future (and rather use the prov python toolbox). So I think #254 can remain open.