### PR TITLE
Definition of "ModelParametersEstimation"

### DIFF
--- a/doc/content/specs/nidm-results_dev.html
+++ b/doc/content/specs/nidm-results_dev.html
@@ -562,7 +562,7 @@
             <section id="section-nidm:ModelParametersEstimation"> 
                 <h1 label="nidm:ModelParametersEstimation">nidm:ModelParametersEstimation</h1>
                 <div class="glossary-ref">
-                    A <dfn>nidm:ModelParametersEstimation</dfn>                    <sup><a title="nidm:ModelParametersEstimation">                    <span class="diamond">&#9826;</span></a></sup> is the process of estimating the parameters of a general linear model from the available data. <a>nidm:ModelParametersEstimation</a> is a prov:Activity that uses <a>nidm:CustomMaskMap</a>, <a>nidm:Data</a>, <a>nidm:DesignMatrix</a> and <a>nidm:ErrorModel</a> entities. This activity generates <a>nidm:MaskMap</a>, <a>nidm:ParameterEstimateMap</a> and <a>nidm:ResidualMeanSquaresMap</a> entities. 
+                    A <dfn>nidm:ModelParametersEstimation</dfn>                    <sup><a title="nidm:ModelParametersEstimation">                    <span class="diamond">&#9826;</span></a></sup> is the process of performing a stato:"Model Parameter Estimation" at each element of a map. <a>nidm:ModelParametersEstimation</a> is a prov:Activity that uses <a>nidm:CustomMaskMap</a>, <a>nidm:Data</a>, <a>nidm:DesignMatrix</a> and <a>nidm:ErrorModel</a> entities. This activity generates <a>nidm:MaskMap</a>, <a>nidm:ParameterEstimateMap</a> and <a>nidm:ResidualMeanSquaresMap</a> entities. 
                 </div>
                 <p></p>
                 <div class="attributes" id="attributes-nidm:ModelParametersEstimation"> A <a>nidm:ModelParametersEstimation</a> has attributes:

--- a/nidm/nidm-results/terms/README.md
+++ b/nidm/nidm-results/terms/README.md
@@ -48,10 +48,6 @@
     <td><b>nidm:ContrastWeights: </b>Vector defining the linear combination associated with a particular contrast. </td>
 </tr>
 <tr>
-    <td><img src="../../../doc/content/specs/img/yellow.png?raw=true"/>  </td>
-    <td><b>nidm:ModelParametersEstimation: </b>The process of estimating the parameters of a general linear model from the available data</td>
-</tr>
-<tr>
     <td><img src="../../../doc/content/specs/img/orange.png?raw=true"/>  </td>
     <td><b>fsl:CenterOfGravity: </b>Centre Of Gravity for the cluster, equivalent to the concept of Centre Of Gravity for a object with distributed mass, where intensity substitutes for mass in this case (definition from http://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Cluster)</td>
 </tr>

--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -2069,13 +2069,11 @@ nidm:ModelParametersEstimation rdf:type owl:Class ;
                                
                                iao:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ModelParametersEstimation.txt"^^xsd:anyURI ;
                                
-                               iao:IAO_0000116 "Under discussion at: https://github.com/incf-nidash/nidm/issues/141" ;
+                               iao:IAO_0000116 "Discussed at: https://github.com/incf-nidash/nidm/issues/141" ;
                                
-                               rdfs:seeAlso "stato:model parameter estimation" ;
+                               rdfs:isDefinedBy "the process of performing a stato:\"Model Parameter Estimation\" at each element of a map" ;
                                
-                               rdfs:isDefinedBy "The process of estimating the parameters of a general linear model from the available data." ;
-                               
-                               iao:IAO_0000114 iao:IAO_0000423 .
+                               iao:IAO_0000114 iao:IAO_0000122 .
 
 
 


### PR DESCRIPTION
**Term**: `ModelParametersEstimation`
**Definition**: "The process of estimating the parameters of a general linear model from the available data".
**Original comment**: [link](https://docs.google.com/spreadsheets/d/16pC2cDsdxlzv2CzlNMtStqt5-xHwDEsU6MjZVxWhrE4/edit?usp=sharing)
**Current link**:  [nidm-results.owl/ModelParametersEstimation](https://github.com/incf-nidash/nidm/blob/master/nidm/nidm-results/nidm-results.owl#L2162-L2177)

---

@cmaumet `11:46 25 Apr`
How about re-using the STATO definition: "model parameter estimation is a data transformation part of a regression analysis which applies specific mathematical transformation in order produced estimates on the parameter specified by the model based on the data used as input."
	
@cmaumet `12:11 8 May`
Awaiting STATO reply at ISA-tools/stato#18