### PR TITLE
Term README: consider term as uncurated if curation status is missing

### DIFF
--- a/nidm/nidm-results/terms/README.md
+++ b/nidm/nidm-results/terms/README.md
@@ -40,6 +40,26 @@
     <td><b>nidm:SPM: </b>Statistical Parametric Mapping software package for the analysis of neuroimaging data from the FIL Methods Group</td>
 </tr>
 <tr>
+    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
+    <td><b>nidm:InferenceMaskMap: </b>mask defined by the user to restrain the space in which inference is performed</td>
+</tr>
+<tr>
+    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
+    <td><b>nidm:SpatialModel: </b>FIXME</td>
+</tr>
+<tr>
+    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
+    <td><b>nidm:SpatiallyGlobalModel: </b>FIXME</td>
+</tr>
+<tr>
+    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
+    <td><b>nidm:SpatiallyLocalModel: </b>FIXME</td>
+</tr>
+<tr>
+    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
+    <td><b>nidm:SpatiallyRegularizedModel: </b>FIXME</td>
+</tr>
+<tr>
     <td><img src="../../../doc/content/specs/img/yellow.png?raw=true"/>  </td>
     <td><b>nidm:ContrastEstimation: </b>The process of estimating a contrast from the estimated parameters of statistical model</td>
 </tr>
@@ -190,6 +210,30 @@
     <td><b>nidm:userSpecifiedThresholdType: </b>Type of method used to define a threshold (e.g. statistic value, uncorrected P-value or corrected P-value) (editor: Discussed in https://github.com/incf-nidash/nidm/pull/150)</td>
     <td>nidm:ExtentThreshold nidm:HeightThreshold </td>
     <td>xsd:string </td>
+</tr>
+<tr>
+    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
+    <td><b>nidm:dependenceSpatialModel: </b>FIXME</td>
+    <td>nidm:ErrorModel </td>
+    <td>nidm:SpatialModel </td>
+</tr>
+<tr>
+    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
+    <td><b>nidm:varianceSpatialModel: </b>FIXME</td>
+    <td>nidm:ErrorModel </td>
+    <td>nidm:SpatialModel </td>
+</tr>
+<tr>
+    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
+    <td><b>nidm:withEstimationMethod: </b>FIXME</td>
+    <td>nidm:ModelParametersEstimation </td>
+    <td>obo:STATO_0000119 </td>
+</tr>
+<tr>
+    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
+    <td><b>spm:searchVolumeInResels: </b>Total number of resels within the search volume</td>
+    <td>nidm:SearchSpaceMap </td>
+    <td></td>
 </tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>

--- a/scripts/OwlReader.py
+++ b/scripts/OwlReader.py
@@ -339,10 +339,12 @@ class OwlReader():
         return domain_display
 
     def get_curation_status(self, owl_term):
-        curation_status = OBO_UNCURATED
         curation_status = list(self.graph.objects(owl_term, HAS_CURATION_STATUS))
         if curation_status:
             curation_status = curation_status[0]
+        else:
+            # By default consider that term is "uncurated"
+            curation_status = OBO_UNCURATED    
         return curation_status
 
     def get_editor(self, owl_term):


### PR DESCRIPTION
In this pull request, we:
 - include a small update to consider a term as uncurated is its curation status is missing. 
 - update the README file describing the terms accordingly ([current README](https://github.com/incf-nidash/nidm/blob/master/nidm/nidm-results/terms/README.md), [updated README](https://github.com/incf-nidash/nidm/blob/9169227acee06fc36995e53d342689708d72ad96/nidm/nidm-results/terms/README.md)).