### PR TITLE
Use of rdfs:isDefinedBy or iao:"definition" for definitions

### DIFF
--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -3,6 +3,7 @@
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix fsl: <http://www.incf.org/ns/nidash/fsl#> .
 @prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
+@prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix spm: <http://www.incf.org/ns/nidash/spm#> .
@@ -13,7 +14,6 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#> .
 @prefix dctype: <http://purl.org/dc/dcmitype/> .
-@prefix obo: <http://purl.obolibrary.org/obo/> .
 @base <http://www.w3.org/2002/07/owl#> .
 
 [ rdf:type owl:Ontology ;
@@ -30,12 +30,6 @@
 #    Annotation properties
 #
 #################################################################
-
-
-###  http://www.w3.org/2000/01/rdf-schema#isDefinedBy
-
-rdfs:isDefinedBy rdf:type owl:AnnotationProperty .
-
 
 
 ###  http://www.w3.org/2002/07/owl#sameAs
@@ -63,7 +57,7 @@ dc:description rdfs:range dctype:Image .
 
 nidm:dependenceSpatialModel rdf:type owl:ObjectProperty ;
                             
-                            rdfs:isDefinedBy "FIXME" ;
+                            obo:IAO_0000115 "FIXME" ;
                             
                             rdfs:domain nidm:ErrorModel ;
                             
@@ -94,9 +88,9 @@ nidm:hasAlternativeHypothesis rdf:type owl:ObjectProperty ;
 
 nidm:hasClusterLabelsMap rdf:type owl:ObjectProperty ;
                          
-                         obo:IAO_0000112 "file:///path/to/cluster_labels.img" ;
+                         obo:IAO_0000115 "A map whose value at each location denotes cluster membership. Each cluster is denoted by a different integer." ;
                          
-                         rdfs:isDefinedBy "A map whose value at each location denotes cluster membership. Each cluster is denoted by a different integer." ;
+                         obo:IAO_0000112 "file:///path/to/cluster_labels.img" ;
                          
                          obo:IAO_0000114 obo:IAO_0000120 ;
                          
@@ -110,9 +104,9 @@ nidm:hasClusterLabelsMap rdf:type owl:ObjectProperty ;
 
 nidm:hasConnectivityCriterion rdf:type owl:ObjectProperty ;
                               
-                              rdfs:isDefinedBy "Property that associates a ConnectivityCriterion with a ClusterDefinitionCriteria." ;
-                              
                               obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/201." ;
+                              
+                              obo:IAO_0000115 "Property that associates a ConnectivityCriterion with a ClusterDefinitionCriteria." ;
                               
                               obo:IAO_0000114 obo:IAO_0000122 ;
                               
@@ -126,7 +120,7 @@ nidm:hasConnectivityCriterion rdf:type owl:ObjectProperty ;
 
 nidm:hasErrorDependence rdf:type owl:ObjectProperty ;
                         
-                        rdfs:isDefinedBy "Property that associates an ErrorDependence with an ErrorModel." ;
+                        obo:IAO_0000115 "Property that associates an ErrorDependence with an ErrorModel." ;
                         
                         obo:IAO_0000114 obo:IAO_0000122 ;
                         
@@ -140,7 +134,7 @@ nidm:hasErrorDependence rdf:type owl:ObjectProperty ;
 
 nidm:hasErrorDistribution rdf:type owl:ObjectProperty ;
                           
-                          rdfs:isDefinedBy "Property that associates an ErrorDistribution with an ErrorModel." ;
+                          obo:IAO_0000115 "Property that associates an ErrorDistribution with an ErrorModel." ;
                           
                           obo:IAO_0000114 obo:IAO_0000122 ;
                           
@@ -168,7 +162,7 @@ nidm:inCoordinateSpace rdf:type owl:ObjectProperty ;
                        
                        obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/171 by NN JT CM SG KH TN." ;
                        
-                       rdfs:isDefinedBy "Property of a DataArray to associate a CoordinateSpace with a physical file." ;
+                       obo:IAO_0000115 "Property of a DataArray to associate a CoordinateSpace with a physical file." ;
                        
                        obo:IAO_0000114 obo:IAO_0000122 ;
                        
@@ -182,7 +176,7 @@ nidm:inCoordinateSpace rdf:type owl:ObjectProperty ;
 
 nidm:inWorldCoordinateSystem rdf:type owl:ObjectProperty ;
                              
-                             rdfs:isDefinedBy "Type of coordinate system." ;
+                             obo:IAO_0000115 "Type of coordinate system." ;
                              
                              obo:IAO_0000112 "nidm:MNICoordinateSystem" ;
                              
@@ -224,7 +218,7 @@ nidm:statisticType rdf:type owl:ObjectProperty ;
 
 nidm:varianceSpatialModel rdf:type owl:ObjectProperty ;
                           
-                          rdfs:isDefinedBy "FIXME" ;
+                          obo:IAO_0000115 "FIXME" ;
                           
                           rdfs:domain nidm:ErrorModel ;
                           
@@ -236,7 +230,7 @@ nidm:varianceSpatialModel rdf:type owl:ObjectProperty ;
 
 nidm:withEstimationMethod rdf:type owl:ObjectProperty ;
                           
-                          rdfs:isDefinedBy "FIXME" ;
+                          obo:IAO_0000115 "FIXME" ;
                           
                           rdfs:range obo:STATO_0000119 ;
                           
@@ -248,9 +242,9 @@ nidm:withEstimationMethod rdf:type owl:ObjectProperty ;
 
 spm:hasMaximumIntensityProjection rdf:type owl:ObjectProperty ;
                                   
-                                  rdfs:isDefinedBy "Maximum intensity projection of a map." ;
-                                  
                                   obo:IAO_0000116 "Range: Path to an image (e.g.png)." ;
+                                  
+                                  obo:IAO_0000115 "Maximum intensity projection of a map." ;
                                   
                                   obo:IAO_0000112 "file:///path/to/MIP.png" ;
                                   
@@ -301,7 +295,7 @@ fsl:coordinate1InVoxels rdf:type owl:DatatypeProperty ;
                         
                         obo:IAO_0000112 "-60" ;
                         
-                        rdfs:isDefinedBy "Coordinate along the first dimension in voxels." ;
+                        obo:IAO_0000115 "Coordinate along the first dimension in voxels." ;
                         
                         obo:IAO_0000114 obo:IAO_0000120 ;
                         
@@ -315,7 +309,7 @@ fsl:coordinate1InVoxels rdf:type owl:DatatypeProperty ;
 
 fsl:coordinate2InVoxels rdf:type owl:DatatypeProperty ;
                         
-                        rdfs:isDefinedBy "Coordinate along the second dimension in voxels." ;
+                        obo:IAO_0000115 "Coordinate along the second dimension in voxels." ;
                         
                         obo:IAO_0000112 "-28" ;
                         
@@ -331,9 +325,9 @@ fsl:coordinate2InVoxels rdf:type owl:DatatypeProperty ;
 
 fsl:coordinate3InVoxels rdf:type owl:DatatypeProperty ;
                         
-                        rdfs:isDefinedBy "Coordinate along the third dimension in voxels" ;
-                        
                         obo:IAO_0000112 "13" ;
+                        
+                        obo:IAO_0000115 "Coordinate along the third dimension in voxels" ;
                         
                         obo:IAO_0000114 obo:IAO_0000120 ;
                         
@@ -405,7 +399,7 @@ nidm:clusterLabelId rdf:type owl:DatatypeProperty ;
                     
                     obo:IAO_0000112 "5" ;
                     
-                    rdfs:isDefinedBy "Integer associated with a particular cluster as specified in the clusterLabelsMap." ;
+                    obo:IAO_0000115 "Integer associated with a particular cluster as specified in the clusterLabelsMap." ;
                     
                     obo:IAO_0000114 obo:IAO_0000125 ;
                     
@@ -421,7 +415,7 @@ nidm:clusterSizeInVertices rdf:type owl:DatatypeProperty ;
                            
                            obo:IAO_0000112 "10" ;
                            
-                           rdfs:isDefinedBy "Number of vertices that make up the cluster." ;
+                           obo:IAO_0000115 "Number of vertices that make up the cluster." ;
                            
                            obo:IAO_0000114 obo:IAO_0000120 ;
                            
@@ -438,7 +432,7 @@ nidm:clusterSizeInVoxels rdf:type owl:DatatypeProperty ;
                          
                          obo:IAO_0000112 "18" ;
                          
-                         rdfs:isDefinedBy "Number of voxels that make up the cluster." ;
+                         obo:IAO_0000115 "Number of voxels that make up the cluster." ;
                          
                          obo:IAO_0000114 obo:IAO_0000125 ;
                          
@@ -453,9 +447,9 @@ nidm:clusterSizeInVoxels rdf:type owl:DatatypeProperty ;
 
 nidm:contrastName rdf:type owl:DatatypeProperty ;
                   
-                  obo:IAO_0000112 "\"Listening > Rest\"" ;
+                  obo:IAO_0000115 "Name of the contrast." ;
                   
-                  rdfs:isDefinedBy "Name of the contrast." ;
+                  obo:IAO_0000112 "\"Listening > Rest\"" ;
                   
                   obo:IAO_0000114 obo:IAO_0000120 ;
                   
@@ -473,7 +467,7 @@ nidm:coordinate1 rdf:type owl:DatatypeProperty ;
                  
                  obo:IAO_0000116 "Under discussion at: https://github.com/incf-nidash/nidm/issues/145" ;
                  
-                 rdfs:isDefinedBy "Coordinate along the first dimension in voxel units." ;
+                 obo:IAO_0000115 "Coordinate along the first dimension in voxel units." ;
                  
                  obo:IAO_0000112 "-60" ;
                  
@@ -491,7 +485,7 @@ nidm:coordinate2 rdf:type owl:DatatypeProperty ;
                  
                  obo:IAO_0000112 "-28" ;
                  
-                 rdfs:isDefinedBy "Coordinate along the second dimension in voxel units." ;
+                 obo:IAO_0000115 "Coordinate along the second dimension in voxel units." ;
                  
                  obo:IAO_0000114 obo:IAO_0000120 ;
                  
@@ -507,7 +501,7 @@ nidm:coordinate3 rdf:type owl:DatatypeProperty ;
                  
                  obo:IAO_0000112 "13" ;
                  
-                 rdfs:isDefinedBy "Coordinate along the third dimension in voxel units." ;
+                 obo:IAO_0000115 "Coordinate along the third dimension in voxel units." ;
                  
                  obo:IAO_0000114 obo:IAO_0000120 ;
                  
@@ -525,7 +519,7 @@ nidm:dimensionsInVoxels rdf:type owl:DatatypeProperty ;
                         
                         obo:IAO_0000112 "[64 64 20]" ;
                         
-                        rdfs:isDefinedBy "Dimensions of some N-dimensional data." ;
+                        obo:IAO_0000115 "Dimensions of some N-dimensional data." ;
                         
                         obo:IAO_0000116 "Under discussion at: https://github.com/incf-nidash/nidm/issues/146" ;
                         
@@ -543,7 +537,7 @@ nidm:effectDegreesOfFreedom rdf:type owl:DatatypeProperty ;
                             
                             obo:IAO_0000112 "1" ;
                             
-                            rdfs:isDefinedBy "Degrees of freedom of the effect." ;
+                            obo:IAO_0000115 "Degrees of freedom of the effect." ;
                             
                             obo:IAO_0000114 obo:IAO_0000120 ;
                             
@@ -562,7 +556,7 @@ nidm:effectDegreesOfFreedom rdf:type owl:DatatypeProperty ;
 
 nidm:equivalentZStatistic rdf:type owl:DatatypeProperty ;
                           
-                          rdfs:isDefinedBy "Statistic value transformed into Z units; the output of a process which takes a non-normal statistic and transforms it to an equivalent z score." ;
+                          obo:IAO_0000115 "Statistic value transformed into Z units; the output of a process which takes a non-normal statistic and transforms it to an equivalent z score." ;
                           
                           obo:IAO_0000112 "3.5" ;
                           
@@ -578,7 +572,7 @@ nidm:equivalentZStatistic rdf:type owl:DatatypeProperty ;
 
 nidm:errorDegreesOfFreedom rdf:type owl:DatatypeProperty ;
                            
-                           rdfs:isDefinedBy "Degrees of freedom of the error." ;
+                           obo:IAO_0000115 "Degrees of freedom of the error." ;
                            
                            obo:IAO_0000112 "72.999999" ;
                            
@@ -599,7 +593,7 @@ nidm:errorDegreesOfFreedom rdf:type owl:DatatypeProperty ;
 
 nidm:errorVarianceHomogeneous rdf:type owl:DatatypeProperty ;
                               
-                              rdfs:isDefinedBy "A boolean value reflecting how the variance of the error is modeled during parameter estimation; TRUE for constant variance over all observations in the model, FALSE for heterogeneous variance." ;
+                              obo:IAO_0000115 "A boolean value reflecting how the variance of the error is modeled during parameter estimation; TRUE for constant variance over all observations in the model, FALSE for heterogeneous variance." ;
                               
                               obo:IAO_0000114 obo:IAO_0000122 ;
                               
@@ -627,7 +621,7 @@ nidm:grandMeanScaling rdf:type owl:DatatypeProperty ;
                       
                       obo:IAO_0000112 "TRUE" ;
                       
-                      rdfs:isDefinedBy "Binary flag defining whether the data was scaled. Specifically, \"grand mean scaling\" refers to multipliciation of every voxel in every scan by a common value.  Grand mean scaling is essential for first-level fMRI, to transform the arbitrary MRI units, but is generally not used with second level analyses." ;
+                      obo:IAO_0000115 "Binary flag defining whether the data was scaled. Specifically, \"grand mean scaling\" refers to multipliciation of every voxel in every scan by a common value.  Grand mean scaling is essential for first-level fMRI, to transform the arbitrary MRI units, but is generally not used with second level analyses." ;
                       
                       obo:IAO_0000114 obo:IAO_0000125 ;
                       
@@ -641,7 +635,7 @@ nidm:grandMeanScaling rdf:type owl:DatatypeProperty ;
 
 nidm:inWorldCoordinateSystem rdf:type owl:DatatypeProperty ;
                              
-                             rdfs:isDefinedBy "Type of coordinate system." ;
+                             obo:IAO_0000115 "Type of coordinate system." ;
                              
                              obo:IAO_0000112 "nidm:MNICoordinateSystem" ;
                              
@@ -653,9 +647,9 @@ nidm:inWorldCoordinateSystem rdf:type owl:DatatypeProperty ;
 
 nidm:maskedMedian rdf:type owl:DatatypeProperty ;
                   
-                  rdfs:isDefinedBy "Median value considering only in-mask voxels. Useful diagnostic when computed on grand mean image when grandMeanScaling is TRUE, as the median should be close to targetIntensity." ;
-                  
                   obo:IAO_0000112 "155.23" ;
+                  
+                  obo:IAO_0000115 "Median value considering only in-mask voxels. Useful diagnostic when computed on grand mean image when grandMeanScaling is TRUE, as the median should be close to targetIntensity." ;
                   
                   rdfs:seeAlso "http://purl.obolibrary.org/obo/OBI_0200119" ;
                   
@@ -673,7 +667,7 @@ nidm:maskedMedian rdf:type owl:DatatypeProperty ;
 
 nidm:maxNumberOfPeaksPerCluster rdf:type owl:DatatypeProperty ;
                                 
-                                rdfs:isDefinedBy "Maximum number of peaks to be reported after inference within a cluster." ;
+                                obo:IAO_0000115 "Maximum number of peaks to be reported after inference within a cluster." ;
                                 
                                 obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/200." ;
                                 
@@ -689,9 +683,9 @@ nidm:maxNumberOfPeaksPerCluster rdf:type owl:DatatypeProperty ;
 
 nidm:minDistanceBetweenPeaks rdf:type owl:DatatypeProperty ;
                              
-                             obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/200." ;
+                             obo:IAO_0000115 "Minimum distance between two peaks to be reported after inference." ;
                              
-                             rdfs:isDefinedBy "Minimum distance between two peaks to be reported after inference." ;
+                             obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/200." ;
                              
                              obo:IAO_0000114 obo:IAO_0000122 ;
                              
@@ -709,7 +703,7 @@ nidm:noiseFWHM rdf:type owl:DatatypeProperty ;
                
                obo:IAO_0000112 "2.35" ;
                
-               rdfs:isDefinedBy "Estimated Full Width at Half Maximum of the noise distribution." ;
+               obo:IAO_0000115 "Estimated Full Width at Half Maximum of the noise distribution." ;
                
                rdfs:seeAlso "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#Full_Width_at_Half_Maximum" ;
                
@@ -735,7 +729,7 @@ nidm:numberOfClusters rdf:type owl:DatatypeProperty ;
 
 nidm:numberOfDimensions rdf:type owl:DatatypeProperty ;
                         
-                        rdfs:isDefinedBy "Number of dimensions of a data matrix." ;
+                        obo:IAO_0000115 "Number of dimensions of a data matrix." ;
                         
                         obo:IAO_0000112 "3" ;
                         
@@ -782,9 +776,9 @@ nidm:pValueFWER rdf:type owl:DatatypeProperty ;
                 
                 owl:sameAs "This definition is from OBI. Please update this note if the definition is modified." ;
                 
-                rdfs:seeAlso "Synonym of \"nidm:pFWE\"" ;
+                obo:IAO_0000115 "\"A quantitative confidence value resulting from a multiple testing error correction method which adjusts the p-value used as input to control for Type I error in the context of multiple pairwise tests\"" ;
                 
-                rdfs:isDefinedBy "\"A quantitative confidence value resulting from a multiple testing error correction method which adjusts the p-value used as input to control for Type I error in the context of multiple pairwise tests\"" ;
+                rdfs:seeAlso "Synonym of \"nidm:pFWE\"" ;
                 
                 obo:IAO_0000114 obo:IAO_0000423 ;
                 
@@ -810,7 +804,7 @@ nidm:pValueUncorrected rdf:type owl:DatatypeProperty ;
                        
                        obo:IAO_0000112 "0.0542" ;
                        
-                       rdfs:isDefinedBy "A p-value reported without correction for multiple testing.        " ;
+                       obo:IAO_0000115 "A p-value reported without correction for multiple testing.        " ;
                        
                        rdfs:seeAlso "http://purl.obolibrary.org/obo/IAO_0000121" ;
                        
@@ -836,9 +830,9 @@ nidm:pValueUncorrected rdf:type owl:DatatypeProperty ;
 
 nidm:qValueFDR rdf:type owl:DatatypeProperty ;
                
-               rdfs:isDefinedBy "A quantitative confidence value that measures the minimum false discovery rate that is incurred when calling that test significant. To compute q-values, it is necessary to know the p-value produced by a test and possibly set a false discovery rate level (same as OBI_0001442)." ;
-               
                owl:sameAs "http://purl.obolibrary.org/obo/OBI_0001442" ;
+               
+               obo:IAO_0000115 "A quantitative confidence value that measures the minimum false discovery rate that is incurred when calling that test significant. To compute q-values, it is necessary to know the p-value produced by a test and possibly set a false discovery rate level (same as OBI_0001442)." ;
                
                obo:IAO_0000112 "0.000154" ;
                
@@ -866,7 +860,7 @@ nidm:randomFieldStationarity rdf:type owl:DatatypeProperty ;
                              
                              obo:IAO_0000117 "Under discussion at https://github.com/incf-nidash/nidm/issues/130" ;
                              
-                             rdfs:isDefinedBy "Is the random field assumed to be stationary across the entire search volume?" ;
+                             obo:IAO_0000115 "Is the random field assumed to be stationary across the entire search volume?" ;
                              
                              obo:IAO_0000114 obo:IAO_0000120 ;
                              
@@ -882,7 +876,7 @@ nidm:softwareVersion rdf:type owl:DatatypeProperty ;
                      
                      obo:IAO_0000112 "SPM99, SPM2, SPM5, SPM8, SPM12b, FSL5.0.0" ;
                      
-                     rdfs:isDefinedBy "Name and number that specifies the software version." ;
+                     obo:IAO_0000115 "Name and number that specifies the software version." ;
                      
                      obo:IAO_0000114 obo:IAO_0000125 ;
                      
@@ -896,9 +890,9 @@ nidm:softwareVersion rdf:type owl:DatatypeProperty ;
 
 nidm:targetIntensity rdf:type owl:DatatypeProperty ;
                      
-                     rdfs:isDefinedBy "Value to which the grand mean of the Data was scaled (applies only if grandMeanScaling is true)." ;
-                     
                      obo:IAO_0000112 "100" ;
+                     
+                     obo:IAO_0000115 "Value to which the grand mean of the Data was scaled (applies only if grandMeanScaling is true)." ;
                      
                      obo:IAO_0000114 obo:IAO_0000125 ;
                      
@@ -917,7 +911,7 @@ nidm:targetIntensity rdf:type owl:DatatypeProperty ;
 
 nidm:userSpecifiedThresholdType rdf:type owl:DatatypeProperty ;
                                 
-                                rdfs:isDefinedBy "Type of method used to define a threshold (e.g. statistic value, uncorrected P-value or corrected P-value)." ;
+                                obo:IAO_0000115 "Type of method used to define a threshold (e.g. statistic value, uncorrected P-value or corrected P-value)." ;
                                 
                                 obo:IAO_0000112 "nidm:pValueFWER" ;
                                 
@@ -950,12 +944,12 @@ nidm:version rdf:type owl:DatatypeProperty ;
 
 nidm:voxelSize rdf:type owl:DatatypeProperty ;
                
-               rdfs:isDefinedBy "3D size of a voxel measured in voxelUnits." ;
-               
                obo:IAO_0000112 "[2 2 4]" ;
                
                rdfs:seeAlso """http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C95003 
 """ ;
+               
+               obo:IAO_0000115 "3D size of a voxel measured in voxelUnits." ;
                
                obo:IAO_0000116 "Range: Vector of floats." ;
                
@@ -971,11 +965,11 @@ nidm:voxelSize rdf:type owl:DatatypeProperty ;
 
 nidm:voxelToWorldMapping rdf:type owl:DatatypeProperty ;
                          
+                         obo:IAO_0000115 "Homogeneous transformation matrix to map from voxel coordinate system to world coordinate system." ;
+                         
                          obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/148" ;
                          
                          obo:IAO_0000112 "[3 0 0 0;0 3 0 0;0 0 3 0; 0 0 0 1] " ;
-                         
-                         rdfs:isDefinedBy "Homogeneous transformation matrix to map from voxel coordinate system to world coordinate system." ;
                          
                          obo:IAO_0000116 "Range: Matrix of float." ;
                          
@@ -993,7 +987,7 @@ nidm:voxelUnits rdf:type owl:DatatypeProperty ;
                 
                 obo:IAO_0000116 "Range: Vector of strings." ;
                 
-                rdfs:isDefinedBy "Units associated with each dimensions of some N-dimensional data." ;
+                obo:IAO_0000115 "Units associated with each dimensions of some N-dimensional data." ;
                 
                 obo:IAO_0000117 "Under discussion at https://github.com/incf-nidash/nidm/issues/147" ;
                 
@@ -1013,7 +1007,7 @@ spm:clusterSizeInResels rdf:type owl:DatatypeProperty ;
                         
                         obo:IAO_0000117 "Under discussion at: https://github.com/incf-nidash/nidm/issues/127" ;
                         
-                        rdfs:isDefinedBy "Size of cluster measured in resels." ;
+                        obo:IAO_0000115 "Size of cluster measured in resels." ;
                         
                         obo:IAO_0000112 "13" ;
                         
@@ -1035,9 +1029,9 @@ spm:clusterSizeInResels rdf:type owl:DatatypeProperty ;
 
 spm:expectedNumberOfClusters rdf:type owl:DatatypeProperty ;
                              
-                             rdfs:isDefinedBy "Expected number of clusters in an excursion set." ;
-                             
                              obo:IAO_0000112 "9.51" ;
+                             
+                             obo:IAO_0000115 "Expected number of clusters in an excursion set." ;
                              
                              obo:IAO_0000114 obo:IAO_0000125 ;
                              
@@ -1056,7 +1050,7 @@ spm:expectedNumberOfClusters rdf:type owl:DatatypeProperty ;
 
 spm:expectedNumberOfVerticesPerCluster rdf:type owl:DatatypeProperty ;
                                        
-                                       rdfs:isDefinedBy "Expected number of vertices in a cluster." ;
+                                       obo:IAO_0000115 "Expected number of vertices in a cluster." ;
                                        
                                        obo:IAO_0000112 "60.632" ;
                                        
@@ -1077,7 +1071,7 @@ spm:expectedNumberOfVerticesPerCluster rdf:type owl:DatatypeProperty ;
 
 spm:expectedNumberOfVoxelsPerCluster rdf:type owl:DatatypeProperty ;
                                      
-                                     rdfs:isDefinedBy "Expected number of voxels in a cluster." ;
+                                     obo:IAO_0000115 "Expected number of voxels in a cluster." ;
                                      
                                      obo:IAO_0000112 "60.632" ;
                                      
@@ -1098,7 +1092,7 @@ spm:expectedNumberOfVoxelsPerCluster rdf:type owl:DatatypeProperty ;
 
 spm:heightCriticalThresholdFDR05 rdf:type owl:DatatypeProperty ;
                                  
-                                 rdfs:isDefinedBy "Peak statistic threshold corrected for false discovery rate at a level of alpha = 0.05. " ;
+                                 obo:IAO_0000115 "Peak statistic threshold corrected for false discovery rate at a level of alpha = 0.05. " ;
                                  
                                  obo:IAO_0000112 "5.896" ;
                                  
@@ -1114,7 +1108,7 @@ spm:heightCriticalThresholdFDR05 rdf:type owl:DatatypeProperty ;
 
 spm:heightCriticalThresholdFWE05 rdf:type owl:DatatypeProperty ;
                                  
-                                 rdfs:isDefinedBy "Peak statistic threshold corrected for family-wise error at a level of alpha = 0.05. " ;
+                                 obo:IAO_0000115 "Peak statistic threshold corrected for family-wise error at a level of alpha = 0.05. " ;
                                  
                                  obo:IAO_0000112 "4.913" ;
                                  
@@ -1130,9 +1124,9 @@ spm:heightCriticalThresholdFWE05 rdf:type owl:DatatypeProperty ;
 
 spm:noiseFWHMInUnits rdf:type owl:DatatypeProperty ;
                      
-                     rdfs:isDefinedBy "Estimated Full Width at Half Maximum of the noise distribution in world units." ;
-                     
                      obo:IAO_0000116 "Range: Vector of positive floats." ;
+                     
+                     obo:IAO_0000115 "Estimated Full Width at Half Maximum of the noise distribution in world units." ;
                      
                      obo:IAO_0000112 "[8.87, 8.89, 7.83]" ;
                      
@@ -1152,9 +1146,9 @@ spm:noiseFWHMInVertices rdf:type owl:DatatypeProperty ;
                         
                         obo:IAO_0000112 "[2.95, 2.96, 2.61]" ;
                         
-                        obo:IAO_0000116 "Range: Vector of positive floats." ;
+                        obo:IAO_0000115 "Estimated Full Width at Half Maximum of the noise distribution in world vertices." ;
                         
-                        rdfs:isDefinedBy "Estimated Full Width at Half Maximum of the noise distribution in world vertices." ;
+                        obo:IAO_0000116 "Range: Vector of positive floats." ;
                         
                         obo:IAO_0000114 obo:IAO_0000120 ;
                         
@@ -1168,11 +1162,11 @@ spm:noiseFWHMInVertices rdf:type owl:DatatypeProperty ;
 
 spm:noiseFWHMInVoxels rdf:type owl:DatatypeProperty ;
                       
-                      rdfs:isDefinedBy "Estimated Full Width at Half Maximum of the noise distribution in voxels." ;
-                      
                       obo:IAO_0000116 "Range: Vector of positive floats." ;
                       
                       obo:IAO_0000112 "[3.7 3.7 3.1]" ;
+                      
+                      obo:IAO_0000115 "Estimated Full Width at Half Maximum of the noise distribution in voxels." ;
                       
                       rdfs:seeAlso "Synonyms of or close match with nidm:NoiseFWHM" ;
                       
@@ -1190,7 +1184,7 @@ spm:noiseFWHMInVoxels rdf:type owl:DatatypeProperty ;
 
 spm:reselSize rdf:type owl:DatatypeProperty ;
               
-              rdfs:isDefinedBy "Size of one resel in voxels or vertices." ;
+              obo:IAO_0000115 "Size of one resel in voxels or vertices." ;
               
               obo:IAO_0000112 "22.325" ;
               
@@ -1211,9 +1205,9 @@ spm:reselSize rdf:type owl:DatatypeProperty ;
 
 spm:searchVolumeInResels rdf:type owl:DatatypeProperty ;
                          
-                         obo:IAO_0000112 "151.3" ;
+                         obo:IAO_0000115 "Total number of resels within the search volume." ;
                          
-                         rdfs:isDefinedBy "Total number of resels within the search volume." ;
+                         obo:IAO_0000112 "151.3" ;
                          
                          rdfs:seeAlso "Synonyms of nidm:volumeInResels" ;
                          
@@ -1235,9 +1229,9 @@ spm:searchVolumeInUnits rdf:type owl:DatatypeProperty ;
                         obo:IAO_0000116 """Context: volumeInVoxels nidm_0025. Range: Positivefloat not found. BIRNLex or 
 NIDM Concept ID: spm_84. """ ;
                         
-                        obo:IAO_0000117 "Discussed at https://github.com/incf-nidash/nidm/pull/131" ;
+                        obo:IAO_0000115 "The volume of the searched region in units determined by the current coordinate space units (e.g., mm^3 for axis units of mm in a three dimensional image, sec.Hz for a time by frequency two dimensional image)." ;
                         
-                        rdfs:isDefinedBy "The volume of the searched region in units determined by the current coordinate space units (e.g., mm^3 for axis units of mm in a three dimensional image, sec.Hz for a time by frequency two dimensional image)." ;
+                        obo:IAO_0000117 "Discussed at https://github.com/incf-nidash/nidm/pull/131" ;
                         
                         obo:IAO_0000112 "1771011" ;
                         
@@ -1258,9 +1252,9 @@ NIDM Concept ID: spm_84. """ ;
 
 spm:searchVolumeInVertices rdf:type owl:DatatypeProperty ;
                            
-                           rdfs:isDefinedBy "Total number of vertices within the search volume." ;
-                           
                            obo:IAO_0000112 "151.3" ;
+                           
+                           obo:IAO_0000115 "Total number of vertices within the search volume." ;
                            
                            obo:IAO_0000114 obo:IAO_0000120 ;
                            
@@ -1283,7 +1277,7 @@ spm:searchVolumeInVoxels rdf:type owl:DatatypeProperty ;
                          
                          obo:IAO_0000116 "Check if this can be merged with fsl:searchVolumeInVoxels" ;
                          
-                         rdfs:isDefinedBy "Total number of voxels within the search volume." ;
+                         obo:IAO_0000115 "Total number of voxels within the search volume." ;
                          
                          obo:IAO_0000112 "68656" ;
                          
@@ -1301,9 +1295,9 @@ spm:searchVolumeReselsGeometry rdf:type owl:DatatypeProperty ;
                                
                                obo:IAO_0000112 "[6 68.8 589.1 1475.5]" ;
                                
-                               rdfs:seeAlso "http://www.ncbi.nlm.nih.gov/pubmed/20408186" ;
+                               obo:IAO_0000115 "Description of geometry of search volume.  As per Worsley et al. [ http://www.ncbi.nlm.nih.gov/pubmed/20408186 ], the first element is the Euler Characteristic of the search volume, the second element is twice the average caliper diameter, the third element is half the surface area, and the fourth element is the volume.  With the exception of the first element (which is a unitless integer) all quantities are in units of Resels." ;
                                
-                               rdfs:isDefinedBy "Description of geometry of search volume.  As per Worsley et al. [ http://www.ncbi.nlm.nih.gov/pubmed/20408186 ], the first element is the Euler Characteristic of the search volume, the second element is twice the average caliper diameter, the third element is half the surface area, and the fourth element is the volume.  With the exception of the first element (which is a unitless integer) all quantities are in units of Resels." ;
+                               rdfs:seeAlso "http://www.ncbi.nlm.nih.gov/pubmed/20408186" ;
                                
                                obo:IAO_0000116 "Range: Vector of 1 positive integer and 3 positive floats." ;
                                
@@ -1323,7 +1317,7 @@ spm:smallestSignifClusterSizeInVerticesFDR05 rdf:type owl:DatatypeProperty ;
                                              
                                              obo:IAO_0000112 "5" ;
                                              
-                                             rdfs:isDefinedBy "Smallest cluster size in vertices that are significant at a false discovery rate corrected alpha value of 0.05.  " ;
+                                             obo:IAO_0000115 "Smallest cluster size in vertices that are significant at a false discovery rate corrected alpha value of 0.05.  " ;
                                              
                                              obo:IAO_0000114 obo:IAO_0000125 ;
                                              
@@ -1337,10 +1331,10 @@ spm:smallestSignifClusterSizeInVerticesFDR05 rdf:type owl:DatatypeProperty ;
 
 spm:smallestSignifClusterSizeInVerticesFWE05 rdf:type owl:DatatypeProperty ;
                                              
-                                             rdfs:isDefinedBy """Smallest cluster size in vertices significant at family-wise error rate corrected alpha value of 0.05. 
-""" ;
-                                             
                                              obo:IAO_0000112 "2" ;
+                                             
+                                             obo:IAO_0000115 """Smallest cluster size in vertices significant at family-wise error rate corrected alpha value of 0.05. 
+""" ;
                                              
                                              obo:IAO_0000114 obo:IAO_0000125 ;
                                              
@@ -1354,9 +1348,9 @@ spm:smallestSignifClusterSizeInVerticesFWE05 rdf:type owl:DatatypeProperty ;
 
 spm:smallestSignifClusterSizeInVoxelsFDR05 rdf:type owl:DatatypeProperty ;
                                            
-                                           obo:IAO_0000112 "3" ;
+                                           obo:IAO_0000115 "Smallest cluster size in voxels significant at false discovery rate corrected alpha value of 0.05.  " ;
                                            
-                                           rdfs:isDefinedBy "Smallest cluster size in voxels significant at false discovery rate corrected alpha value of 0.05.  " ;
+                                           obo:IAO_0000112 "3" ;
                                            
                                            obo:IAO_0000114 obo:IAO_0000125 ;
                                            
@@ -1370,7 +1364,7 @@ spm:smallestSignifClusterSizeInVoxelsFDR05 rdf:type owl:DatatypeProperty ;
 
 spm:smallestSignifClusterSizeInVoxelsFWE05 rdf:type owl:DatatypeProperty ;
                                            
-                                           rdfs:isDefinedBy """Smallest cluster size in voxels significant at family-wise error corrected alpha value of 0.05. 
+                                           obo:IAO_0000115 """Smallest cluster size in voxels significant at family-wise error corrected alpha value of 0.05. 
 """ ;
                                            
                                            obo:IAO_0000112 "1" ;
@@ -1389,7 +1383,7 @@ spm:softwareRevision rdf:type owl:DatatypeProperty ;
                      
                      obo:IAO_0000112 "5417" ;
                      
-                     rdfs:isDefinedBy "revision number of a piece of software." ;
+                     obo:IAO_0000115 "revision number of a piece of software." ;
                      
                      obo:IAO_0000114 obo:IAO_0000120 ;
                      
@@ -1434,6 +1428,7 @@ dctype:Image rdf:type owl:Class ;
                              ] .
 
 
+
 ###  http://www.incf.org/ns/nidash/fsl#BinomialDistribution
 
 fsl:BinomialDistribution rdf:type owl:Class ;
@@ -1442,7 +1437,7 @@ fsl:BinomialDistribution rdf:type owl:Class ;
                          
                          owl:sameAs "http://purl.obolibrary.org/obo/STATO_0000276"^^xsd:anyURI ;
                          
-                         rdfs:isDefinedBy "The binomial distribution is a discrete probability distribution which describes the probability of k successes in n draws with replacement from a finite population of size N. The binomial distribution is frequently used to model the number of successes in a sample of size n drawn with replacement from a population of size N. The binomial distribution gives the discrete probability distribution of obtaining exactly n successes out of N Bernoulli trials (where the result of each Bernoulli trial is true with probability p and false with probability q=1-p ) notation: B(n,p) The mean is N*p The variance is N*p*q. (Definition from STATO)." ;
+                         obo:IAO_0000115 "The binomial distribution is a discrete probability distribution which describes the probability of k successes in n draws with replacement from a finite population of size N. The binomial distribution is frequently used to model the number of successes in a sample of size n drawn with replacement from a population of size N. The binomial distribution gives the discrete probability distribution of obtaining exactly n successes out of N Bernoulli trials (where the result of each Bernoulli trial is true with probability p and false with probability q=1-p ) notation: B(n,p) The mean is N*p The variance is N*p*q. (Definition from STATO)." ;
                          
                          obo:IAO_0000114 obo:IAO_0000122 .
 
@@ -1454,9 +1449,9 @@ fsl:CenterOfGravity rdf:type owl:Class ;
                     
                     rdfs:subClassOf prov:Entity ;
                     
-                    rdfs:isDefinedBy "Centre Of Gravity for the cluster, equivalent to the concept of Centre Of Gravity for a object with distributed mass, where intensity substitutes for mass in this case (definition from http://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Cluster)" ;
-                    
                     obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/FSL_CenterOfGravity.txt" ;
+                    
+                    obo:IAO_0000115 "Centre Of Gravity for the cluster, equivalent to the concept of Centre Of Gravity for a object with distributed mass, where intensity substitutes for mass in this case (definition from http://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Cluster)" ;
                     
                     rdfs:seeAlso "http://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Cluster" ;
                     
@@ -1492,7 +1487,7 @@ fsl:NonParametricSymmetricDistribution rdf:type owl:Class ;
                                        
                                        rdfs:subClassOf nidm:ErrorDistribution ;
                                        
-                                       rdfs:isDefinedBy "Probability distribution estimated empirically on the data assuming only symmetry of the probability distribution." ;
+                                       obo:IAO_0000115 "Probability distribution estimated empirically on the data assuming only symmetry of the probability distribution." ;
                                        
                                        obo:IAO_0000114 obo:IAO_0000122 .
 
@@ -1518,7 +1513,7 @@ nidm:Cluster rdf:type owl:Class ;
              
              obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/Cluster.txt" ;
              
-             rdfs:isDefinedBy "Statistic defined at the cluster-level in an excusion set. In SPM it is defined as the cluster size. FIXME (now Cluster instead of ClusterStatistic)" ;
+             obo:IAO_0000115 "Statistic defined at the cluster-level in an excusion set. In SPM it is defined as the cluster size. FIXME (now Cluster instead of ClusterStatistic)" ;
              
              obo:IAO_0000114 obo:IAO_0000120 .
 
@@ -1530,7 +1525,7 @@ nidm:ClusterDefinitionCriteria rdf:type owl:Class ;
                                
                                rdfs:subClassOf prov:Entity ;
                                
-                               rdfs:isDefinedBy "Set of criterion specified a priori to define the clusters reported after inference (e.g. pixel or voxel connectivity criterion)." ;
+                               obo:IAO_0000115 "Set of criterion specified a priori to define the clusters reported after inference (e.g. pixel or voxel connectivity criterion)." ;
                                
                                obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ClusterDefinitionCriteria.txt" ;
                                
@@ -1570,7 +1565,7 @@ nidm:ConjunctionInference rdf:type owl:Class ;
                           
                           obo:IAO_0000116 "Term discussed in https://github.com/incf-nidash/nidm/pull/134." ;
                           
-                          rdfs:isDefinedBy "Statistically testing for the joint significance of multiple effects, with emphasis on rejecting all (instead of one or more) of the respective null hypotheses." ;
+                          obo:IAO_0000115 "Statistically testing for the joint significance of multiple effects, with emphasis on rejecting all (instead of one or more) of the respective null hypotheses." ;
                           
                           obo:IAO_0000114 obo:IAO_0000122 .
 
@@ -1584,7 +1579,7 @@ nidm:ConnectivityCriterion rdf:type owl:Class ;
                            
                            obo:IAO_0000117 "TN, KH, CM" ;
                            
-                           rdfs:isDefinedBy "The criterion used to characterize two voxels, pixels or vertices as 'connected'." ;
+                           obo:IAO_0000115 "The criterion used to characterize two voxels, pixels or vertices as 'connected'." ;
                            
                            obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/201." ;
                            
@@ -1602,9 +1597,9 @@ nidm:ContrastEstimation rdf:type owl:Class ;
                         
                         obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ContrastEstimation.txt"^^xsd:anyURI ;
                         
-                        obo:IAO_0000116 "Under discussion at: https://github.com/ISA-tools/stato/issues/23" ;
+                        obo:IAO_0000115 "The process of estimating a contrast from the estimated parameters of statistical model." ;
                         
-                        rdfs:isDefinedBy "The process of estimating a contrast from the estimated parameters of statistical model." ;
+                        obo:IAO_0000116 "Under discussion at: https://github.com/ISA-tools/stato/issues/23" ;
                         
                         obo:IAO_0000114 obo:IAO_0000423 .
 
@@ -1618,7 +1613,7 @@ nidm:ContrastMap rdf:type owl:Class ;
                  
                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ContrastMap.txt"^^xsd:anyURI ;
                  
-                 rdfs:isDefinedBy "A map whose value at each location is statistical contrast estimate." ;
+                 obo:IAO_0000115 "A map whose value at each location is statistical contrast estimate." ;
                  
                  obo:IAO_0000114 obo:IAO_0000125 .
 
@@ -1632,7 +1627,7 @@ nidm:ContrastStandardErrorMap rdf:type owl:Class ;
                               
                               obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ContrastStandardErrorMap.txt"^^xsd:anyURI ;
                               
-                              rdfs:isDefinedBy "A map whose value at each location is the standard error of a given contrast." ;
+                              obo:IAO_0000115 "A map whose value at each location is the standard error of a given contrast." ;
                               
                               obo:IAO_0000114 obo:IAO_0000125 .
 
@@ -1646,11 +1641,11 @@ nidm:ContrastWeights rdf:type owl:Class ;
                      
                      obo:IAO_0000116 "Range: Vector of integers not found." ;
                      
+                     obo:IAO_0000115 "Vector defining the linear combination associated with a particular contrast. " ;
+                     
                      obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ContrastWeights.txt" ;
                      
                      obo:IAO_0000116 "Under discussion at: https://github.com/ISA-tools/stato/issues/23" ;
-                     
-                     rdfs:isDefinedBy "Vector defining the linear combination associated with a particular contrast. " ;
                      
                      obo:IAO_0000114 obo:IAO_0000423 .
 
@@ -1680,7 +1675,7 @@ nidm:CoordinateSpace rdf:type owl:Class ;
                      
                      obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/CoordinateSpace.txt"^^xsd:anyURI ;
                      
-                     rdfs:isDefinedBy "An entity with spatial attributes (e.g., dimensions, units, and voxel-to-world mapping) that provides context to a SpatialImage (e.g., a StatisticMap)." ;
+                     obo:IAO_0000115 "An entity with spatial attributes (e.g., dimensions, units, and voxel-to-world mapping) that provides context to a SpatialImage (e.g., a StatisticMap)." ;
                      
                      obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_21. """ ;
@@ -1709,7 +1704,7 @@ nidm:CustomMaskMap rdf:type owl:Class ;
                    
                    obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/CustomMaskMap.txt" ;
                    
-                   rdfs:isDefinedBy "mask defined by the user to restrain the space in which model fitting is performed." ;
+                   obo:IAO_0000115 "mask defined by the user to restrain the space in which model fitting is performed." ;
                    
                    obo:IAO_0000114 obo:IAO_0000120 .
 
@@ -1725,7 +1720,7 @@ nidm:Data rdf:type owl:Class ;
           
           owl:sameAs "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C25474" ;
           
-          rdfs:isDefinedBy "\"A collection or single item of factual information, derived from measurement or research, from which conclusions may be drawn.\"" ;
+          obo:IAO_0000115 "\"A collection or single item of factual information, derived from measurement or research, from which conclusions may be drawn.\"" ;
           
           obo:IAO_0000116 "This definition is from NCIT. Please update this note if the definition is modified." ;
           
@@ -1744,23 +1739,23 @@ nidm:DesignMatrix rdf:type owl:Class ;
                                     owl:onDataRange xsd:string
                                   ] ,
                                   [ rdf:type owl:Restriction ;
-                                    owl:onProperty dc:description ;
-                                    owl:onClass dctype:Image ;
-                                    owl:minQualifiedCardinality "0"^^xsd:nonNegativeInteger
-                                  ] ,
-                                  [ rdf:type owl:Restriction ;
                                     owl:onProperty dct:format ;
                                     owl:minQualifiedCardinality "0"^^xsd:nonNegativeInteger ;
                                     owl:onDataRange xsd:string
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty dc:description ;
+                                    owl:onClass dctype:Image ;
+                                    owl:minQualifiedCardinality "0"^^xsd:nonNegativeInteger
                                   ] ;
                   
                   obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/DesignMatrix.txt"^^xsd:anyURI ;
                   
+                  obo:IAO_0000115 "A matrix of values defining the explanatory variables used in a regression model.  Each column corresponds to one explanatory variable, each row corresponds to one observation." ;
+                  
                   obo:IAO_0000117 "TN" ;
                   
                   rdfs:seeAlso "stato:design matrix" ;
-                  
-                  rdfs:isDefinedBy "A matrix of values defining the explanatory variables used in a regression model.  Each column corresponds to one explanatory variable, each row corresponds to one observation." ;
                   
                   obo:IAO_0000114 obo:IAO_0000125 .
 
@@ -1788,7 +1783,7 @@ nidm:ErrorDependence rdf:type owl:Class ;
                      
                      rdfs:subClassOf prov:Entity ;
                      
-                     rdfs:isDefinedBy "Dependence structure of the error, used as part of model estimation." ;
+                     obo:IAO_0000115 "Dependence structure of the error, used as part of model estimation." ;
                      
                      obo:IAO_0000114 obo:IAO_0000122 .
 
@@ -1814,7 +1809,7 @@ nidm:ErrorModel rdf:type owl:Class ;
                 
                 obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ErrorModel.txt"^^xsd:anyURI ;
                 
-                rdfs:isDefinedBy "Model used to describe the random variation of the error term as part of parameter estimation, including specification of the error probability distribution, its variance and dependence both spatially and across observations." ;
+                obo:IAO_0000115 "Model used to describe the random variation of the error term as part of parameter estimation, including specification of the error probability distribution, its variance and dependence both spatially and across observations." ;
                 
                 obo:IAO_0000114 obo:IAO_0000122 .
 
@@ -1847,11 +1842,12 @@ nidm:ExcursionSetMap rdf:type owl:Class ;
                      
                      obo:IAO_0000116 "Discussed in the Neuroimaging terms spreadsheet and in https://github.com/incf-nidash/nidm/issues/256." ;
                      
-                     rdfs:isDefinedBy "A map in which the set of elements not selected by the inference activity is set to zero or NaN" ;
-                     
                      obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ExcursionSetMap.txt" ;
                      
+                     obo:IAO_0000115 "A map in which the set of elements not selected by the inference activity is set to zero or NaN" ;
+                     
                      obo:IAO_0000114 obo:IAO_0000122 .
+
 
 
 ###  http://www.incf.org/ns/nidash/nidm#ExtentThreshold
@@ -1862,7 +1858,7 @@ nidm:ExtentThreshold rdf:type owl:Class ;
                      
                      obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ExtentThreshold.txt"^^xsd:anyURI ;
                      
-                     rdfs:isDefinedBy """A numerical value that establishes a bound on a range of cluster-sizes. / [from extentThresh:]        Minimum cluster size used when thresholding a statistic image        5voxels
+                     obo:IAO_0000115 """A numerical value that establishes a bound on a range of cluster-sizes. / [from extentThresh:]        Minimum cluster size used when thresholding a statistic image        5voxels
 """ ;
                      
                      obo:IAO_0000114 obo:IAO_0000120 .
@@ -1877,7 +1873,7 @@ nidm:FSL rdf:type owl:Class ;
          
          rdfs:seeAlso "http://fsl.fmrib.ox.ac.uk" ;
          
-         rdfs:isDefinedBy "FMRIB Software Library software package for the analysis of neuroimaging data from the FMRIB." ;
+         obo:IAO_0000115 "FMRIB Software Library software package for the analysis of neuroimaging data from the FMRIB." ;
          
          obo:IAO_0000114 obo:IAO_0000125 .
 
@@ -1913,7 +1909,7 @@ nidm:GaussianDistribution rdf:type owl:Class ;
                           
                           owl:sameAs "http://purl.obolibrary.org/obo/STATO_0000227"^^xsd:anyURI ;
                           
-                          rdfs:isDefinedBy "A normal distribution is a continuous probability distribution described by a probability distribution function described here: http://mathworld.wolfram.com/NormalDistribution.html (Definition from STATO)." ;
+                          obo:IAO_0000115 "A normal distribution is a continuous probability distribution described by a probability distribution function described here: http://mathworld.wolfram.com/NormalDistribution.html (Definition from STATO)." ;
                           
                           obo:IAO_0000114 obo:IAO_0000122 .
 
@@ -1939,7 +1935,7 @@ nidm:HeightThreshold rdf:type owl:Class ;
                      
                      obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/HeightThreshold.txt"^^xsd:anyURI ;
                      
-                     rdfs:isDefinedBy """A numerical value that establishes a bound on a range of voxelwise or vertex-wise defined statistic.
+                     obo:IAO_0000115 """A numerical value that establishes a bound on a range of voxelwise or vertex-wise defined statistic.
 """ ;
                      
                      obo:IAO_0000114 obo:IAO_0000125 .
@@ -1966,9 +1962,9 @@ nidm:Inference rdf:type owl:Class ;
                
                obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/Inference.txt"^^xsd:anyURI ;
                
-               owl:sameAs "http://purl.obolibrary.org/obo/STATO_0000299" ;
+               obo:IAO_0000115 "Statistical inference is a process of drawing conclusions following data analysis using statistical methods (statistical tests) and evaluating whether to reject or accept null hypothesis. (definition from STATO)." ;
                
-               rdfs:isDefinedBy "Statistical inference is a process of drawing conclusions following data analysis using statistical methods (statistical tests) and evaluating whether to reject or accept null hypothesis. (definition from STATO)." ;
+               owl:sameAs "http://purl.obolibrary.org/obo/STATO_0000299" ;
                
                obo:IAO_0000114 obo:IAO_0000122 .
 
@@ -1980,7 +1976,7 @@ nidm:InferenceMaskMap rdf:type owl:Class ;
                       
                       rdfs:subClassOf nidm:Map ;
                       
-                      rdfs:isDefinedBy "mask defined by the user to restrain the space in which inference is performed." ;
+                      obo:IAO_0000115 "mask defined by the user to restrain the space in which inference is performed." ;
                       
                       obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/InferenceMaskMap.txt" ;
                       
@@ -1997,7 +1993,7 @@ nidm:MNICoordinateSystem rdf:type owl:Class ;
                          
                          rdfs:seeAlso "birnlex_2125" ;
                          
-                         rdfs:isDefinedBy "Coordinate system defined with reference to the MNI atlas." ;
+                         obo:IAO_0000115 "Coordinate system defined with reference to the MNI atlas." ;
                          
                          obo:IAO_0000114 obo:IAO_0000120 .
 
@@ -2021,7 +2017,7 @@ nidm:Map rdf:type owl:Class ;
          
          obo:IAO_0000116 "Discussed in https://github.com/incf-nidash/nidm/pull/149" ;
          
-         rdfs:isDefinedBy "Ordered set of values corresponding to the discrete sampling of some process (e.g. brain MRI data measured on a regular 3D lattice; or brain cortical surface data measured irregularly over the cortex)." ;
+         obo:IAO_0000115 "Ordered set of values corresponding to the discrete sampling of some process (e.g. brain MRI data measured on a regular 3D lattice; or brain cortical surface data measured irregularly over the cortex)." ;
          
          obo:IAO_0000114 obo:IAO_0000122 .
 
@@ -2033,12 +2029,12 @@ nidm:MapHeader rdf:type owl:Class ;
                
                rdfs:subClassOf prov:Entity ,
                                [ rdf:type owl:Restriction ;
-                                 owl:onProperty nfo:fileName ;
+                                 owl:onProperty dct:format ;
                                  owl:minQualifiedCardinality "0"^^xsd:nonNegativeInteger ;
                                  owl:onDataRange xsd:string
                                ] ,
                                [ rdf:type owl:Restriction ;
-                                 owl:onProperty dct:format ;
+                                 owl:onProperty nfo:fileName ;
                                  owl:minQualifiedCardinality "0"^^xsd:nonNegativeInteger ;
                                  owl:onDataRange xsd:string
                                ] ;
@@ -2053,7 +2049,7 @@ nidm:MaskMap rdf:type owl:Class ;
              
              rdfs:subClassOf nidm:Map ;
              
-             rdfs:isDefinedBy "map or surface on which the associated results are displayed. " ;
+             obo:IAO_0000115 "map or surface on which the associated results are displayed. " ;
              
              obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/155" ;
              
@@ -2073,7 +2069,7 @@ nidm:ModelParametersEstimation rdf:type owl:Class ;
                                
                                obo:IAO_0000116 "Discussed at: https://github.com/incf-nidash/nidm/issues/141" ;
                                
-                               rdfs:isDefinedBy "the process of performing a stato:\"Model Parameter Estimation\" at each element of a map" ;
+                               obo:IAO_0000115 "the process of performing a stato:\"Model Parameter Estimation\" at each element of a map" ;
                                
                                obo:IAO_0000114 obo:IAO_0000122 .
 
@@ -2095,7 +2091,7 @@ nidm:NonParametricDistribution rdf:type owl:Class ;
                                
                                rdfs:subClassOf nidm:ErrorDistribution ;
                                
-                               rdfs:isDefinedBy "Probability distribution estimated empirically on the data without assumptions on the shape of the probability distribution." ;
+                               obo:IAO_0000115 "Probability distribution estimated empirically on the data without assumptions on the shape of the probability distribution." ;
                                
                                obo:IAO_0000114 obo:IAO_0000122 .
 
@@ -2125,7 +2121,7 @@ nidm:ParameterEstimateMap rdf:type owl:Class ;
                           
                           obo:IAO_0000116 "Under discussion at: https://github.com/incf-nidash/nidm/issues/141 (see also https://github.com/ISA-tools/stato/issues/18)" ;
                           
-                          rdfs:isDefinedBy "A map whose value at each location is the estimate of a model parameter." ;
+                          obo:IAO_0000115 "A map whose value at each location is the estimate of a model parameter." ;
                           
                           obo:IAO_0000114 obo:IAO_0000120 .
 
@@ -2137,7 +2133,7 @@ nidm:Peak rdf:type owl:Class ;
           
           rdfs:subClassOf prov:Entity ;
           
-          rdfs:isDefinedBy "Statistic defined at the peak-level in an excursion set. FIXME (now Peak instead of PeakStatistic)" ;
+          obo:IAO_0000115 "Statistic defined at the peak-level in an excursion set. FIXME (now Peak instead of PeakStatistic)" ;
           
           obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/Peak.txt" ;
           
@@ -2153,7 +2149,7 @@ nidm:PeakDefinitionCriteria rdf:type owl:Class ;
                             
                             obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/PeakDefinitionCriteria.txt"^^xsd:anyURI ;
                             
-                            rdfs:isDefinedBy "Set of criterion specified a priori to define the peaks reported after inference (e.g. maximum number of peaks within a cluster, minimum distance between peaks)." ;
+                            obo:IAO_0000115 "Set of criterion specified a priori to define the peaks reported after inference (e.g. maximum number of peaks within a cluster, minimum distance between peaks)." ;
                             
                             obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/200." ;
                             
@@ -2169,7 +2165,7 @@ nidm:PixelConnectivityCriterion rdf:type owl:Class ;
                                 
                                 obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/201." ;
                                 
-                                rdfs:isDefinedBy "The criterion used to characterize two pixels as 'connected'. In two dimensions voxels that are connected can share an edge (4-connected) or, edge or corner (8-connected)." ;
+                                obo:IAO_0000115 "The criterion used to characterize two pixels as 'connected'. In two dimensions voxels that are connected can share an edge (4-connected) or, edge or corner (8-connected)." ;
                                 
                                 obo:IAO_0000114 obo:IAO_0000122 .
 
@@ -2183,7 +2179,7 @@ nidm:PoissonDistribution rdf:type owl:Class ;
                          
                          owl:sameAs "http://purl.obolibrary.org/obo/STATO_0000051"^^xsd:anyURI ;
                          
-                         rdfs:isDefinedBy "Poisson distribution is a probability distribution used to model the number of events occurring within a given time interval. It is defined by a real number (λ) and an integer k representing the number of events and a function. The expected value of a Poisson-distributed random variable is equal to λ and so is its variance. (Definition from STATO)." ;
+                         obo:IAO_0000115 "Poisson distribution is a probability distribution used to model the number of events occurring within a given time interval. It is defined by a real number (λ) and an integer k representing the number of events and a function. The expected value of a Poisson-distributed random variable is equal to λ and so is its variance. (Definition from STATO)." ;
                          
                          obo:IAO_0000114 obo:IAO_0000122 .
 
@@ -2199,7 +2195,7 @@ nidm:ResidualMeanSquaresMap rdf:type owl:Class ;
                             
                             obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ResidualMeanSquaresMap.txt" ;
                             
-                            rdfs:isDefinedBy "A map whose value at each location is the residual of the mean squares fit to the data." ;
+                            obo:IAO_0000115 "A map whose value at each location is the residual of the mean squares fit to the data." ;
                             
                             rdfs:seeAlso "This is a map of \"residuals\" as defined at http://bioportal.bioontology.org/ontologies/STATO/?p=classes&conceptid=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FSTATO_0000234 " ;
                             
@@ -2216,7 +2212,7 @@ nidm:SPM rdf:type owl:Class ;
          
          rdfs:subClassOf prov:SoftwareAgent ;
          
-         rdfs:isDefinedBy "Statistical Parametric Mapping software package for the analysis of neuroimaging data from the FIL Methods Group." ;
+         obo:IAO_0000115 "Statistical Parametric Mapping software package for the analysis of neuroimaging data from the FIL Methods Group." ;
          
          rdfs:seeAlso "http://www.fil.ion.ucl.ac.uk/spm/" ;
          
@@ -2242,9 +2238,9 @@ nidm:SearchSpaceMap rdf:type owl:Class ;
                     
                     rdfs:seeAlso "http://purl.obolibrary.org/obo/OBI_0000235" ;
                     
-                    rdfs:isDefinedBy "mask in which the inference was performed." ;
-                    
                     obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/SearchSpaceMap.txt" ;
+                    
+                    obo:IAO_0000115 "mask in which the inference was performed." ;
                     
                     obo:IAO_0000114 obo:IAO_0000120 .
 
@@ -2268,7 +2264,7 @@ nidm:SpatialModel rdf:type owl:Class ;
                   
                   rdfs:subClassOf prov:Entity ;
                   
-                  rdfs:isDefinedBy "FIXME" .
+                  obo:IAO_0000115 "FIXME" .
 
 
 
@@ -2278,7 +2274,7 @@ nidm:SpatiallyGlobalModel rdf:type owl:Class ;
                           
                           rdfs:subClassOf nidm:SpatialModel ;
                           
-                          rdfs:isDefinedBy "FIXME" .
+                          obo:IAO_0000115 "FIXME" .
 
 
 
@@ -2288,7 +2284,7 @@ nidm:SpatiallyLocalModel rdf:type owl:Class ;
                          
                          rdfs:subClassOf nidm:SpatialModel ;
                          
-                         rdfs:isDefinedBy "FIXME" .
+                         obo:IAO_0000115 "FIXME" .
 
 
 
@@ -2298,7 +2294,7 @@ nidm:SpatiallyRegularizedModel rdf:type owl:Class ;
                                
                                rdfs:subClassOf nidm:SpatialModel ;
                                
-                               rdfs:isDefinedBy "FIXME" .
+                               obo:IAO_0000115 "FIXME" .
 
 
 
@@ -2308,10 +2304,10 @@ nidm:StandardizedCoordinateSystem rdf:type owl:Class ;
                                   
                                   rdfs:subClassOf nidm:WorldCoordinateSystem ;
                                   
+                                  obo:IAO_0000115 "Parent of all reference spaces except \"Subject\"." ;
+                                  
                                   rdfs:comment "This is meant to be used for retrospective export when exact template is unknown." ,
                                                "FIXME. This definition needs to be re-worked and reviewed." ;
-                                  
-                                  rdfs:isDefinedBy "Parent of all reference spaces except \"Subject\"." ;
                                   
                                   obo:IAO_0000114 obo:IAO_0000120 .
 
@@ -2337,7 +2333,7 @@ nidm:StatisticMap rdf:type owl:Class ;
                   
                   obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/StatisticMap.txt"^^xsd:anyURI ;
                   
-                  rdfs:isDefinedBy "A map whose value at each location is a statistic. " ;
+                  obo:IAO_0000115 "A map whose value at each location is a statistic. " ;
                   
                   obo:IAO_0000114 obo:IAO_0000120 .
 
@@ -2349,9 +2345,9 @@ nidm:SubjectCoordinateSystem rdf:type owl:Class ;
                              
                              rdfs:subClassOf nidm:WorldCoordinateSystem ;
                              
-                             rdfs:comment "Used in FSL and SPM un-registered data." ;
+                             obo:IAO_0000115 "Coordinate system defined by the subject brain (no spatial normalisation applied)." ;
                              
-                             rdfs:isDefinedBy "Coordinate system defined by the subject brain (no spatial normalisation applied)." ;
+                             rdfs:comment "Used in FSL and SPM un-registered data." ;
                              
                              obo:IAO_0000114 obo:IAO_0000120 .
 
@@ -2375,7 +2371,7 @@ nidm:TalairachCoordinateSystem rdf:type owl:Class ;
                                
                                rdfs:subClassOf nidm:StandardizedCoordinateSystem ;
                                
-                               rdfs:isDefinedBy "Reference space defined by the dissected brain used for the Talairach and Tournoux atlas." ;
+                               obo:IAO_0000115 "Reference space defined by the dissected brain used for the Talairach and Tournoux atlas." ;
                                
                                rdfs:seeAlso "http://www.talairach.org/" ;
                                
@@ -2389,7 +2385,7 @@ nidm:TwoTailedTest rdf:type owl:Class ;
                    
                    rdfs:subClassOf prov:Entity ;
                    
-                   rdfs:isDefinedBy "Re-use \"two tailed test\" from STATO"^^xsd:anyURI ;
+                   obo:IAO_0000115 "Re-use \"two tailed test\" from STATO"^^xsd:anyURI ;
                    
                    owl:sameAs "http://purl.obolibrary.org/obo/STATO_0000287"^^xsd:anyURI ;
                    
@@ -2405,7 +2401,7 @@ nidm:VoxelConnectivityCriterion rdf:type owl:Class ;
                                 
                                 obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/201." ;
                                 
-                                rdfs:isDefinedBy "The criterion used to characterize two voxels as 'connected'. In three dimensions voxels that are connected can share a voxel face (6-connected), face or edge (18-connectec), or face, edge, or corner (26-connected)." ;
+                                obo:IAO_0000115 "The criterion used to characterize two voxels as 'connected'. In three dimensions voxels that are connected can share a voxel face (6-connected), face or edge (18-connectec), or face, edge, or corner (26-connected)." ;
                                 
                                 obo:IAO_0000114 obo:IAO_0000122 .
 
@@ -2437,7 +2433,7 @@ spm:KConjunctionInference rdf:type owl:Class ;
                           
                           rdfs:subClassOf nidm:Inference ;
                           
-                          rdfs:isDefinedBy "Inference testing for the joint significance of a subset of the effects." ;
+                          obo:IAO_0000115 "Inference testing for the joint significance of a subset of the effects." ;
                           
                           obo:IAO_0000114 obo:IAO_0000120 .
 
@@ -2451,7 +2447,7 @@ spm:ReselsPerVoxelMap rdf:type owl:Class ;
                       
                       obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/SPM_ReselsPerVoxelMap.txt"^^xsd:anyURI ;
                       
-                      rdfs:isDefinedBy "A map whose value at each location is the number of resels per voxel. " ;
+                      obo:IAO_0000115 "A map whose value at each location is the number of resels per voxel. " ;
                       
                       obo:IAO_0000114 obo:IAO_0000120 .
 
@@ -2471,13 +2467,12 @@ spm:ReselsPerVoxelMap rdf:type owl:Class ;
 nidm:Colin27CoordinateSystem rdf:type nidm:StandardizedCoordinateSystem ,
                                       owl:NamedIndividual ;
                              
+                             obo:IAO_0000115 "Coordinate system defined by the \"stereotaxic average of 27 T1-weighted MRI scans of the same individual\"." ;
+                             
                              rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/Colin27Highres" ;
                              
-                             rdfs:comment "used in SPM96 (cf. http://imaging.mrc-cbu.cam.ac.uk/imaging/MniTalairach)" ;
-                             
-                             rdfs:isDefinedBy "Coordinate system defined by the \"stereotaxic average of 27 T1-weighted MRI scans of the same individual\"." ;
-                             
-                             rdfs:comment "FIXME. This definition needs to be re-worked and reviewed." ;
+                             rdfs:comment "used in SPM96 (cf. http://imaging.mrc-cbu.cam.ac.uk/imaging/MniTalairach)" ,
+                                          "FIXME. This definition needs to be re-worked and reviewed." ;
                              
                              obo:IAO_0000114 obo:IAO_0000120 .
 
@@ -2490,7 +2485,7 @@ nidm:Icbm452AirCoordinateSystem rdf:type nidm:MNICoordinateSystem ,
                                 
                                 rdfs:seeAlso "http://www.loni.usc.edu/ICBM/Downloads/Downloads_452T1.shtml" ;
                                 
-                                rdfs:isDefinedBy "Coordinate system defined by the \"average of 452 T1-weighted MRIs of normal young adult brains\" with \"linear transforms of the subjects into the atlas space using a 12-parameter affine transformation\"" ;
+                                obo:IAO_0000115 "Coordinate system defined by the \"average of 452 T1-weighted MRIs of normal young adult brains\" with \"linear transforms of the subjects into the atlas space using a 12-parameter affine transformation\"" ;
                                 
                                 obo:IAO_0000114 obo:IAO_0000120 .
 
@@ -2503,7 +2498,7 @@ nidm:Icbm452Warp5CoordinateSystem rdf:type nidm:MNICoordinateSystem ,
                                   
                                   rdfs:seeAlso "http://www.loni.usc.edu/ICBM/Downloads/Downloads_452T1.shtml" ;
                                   
-                                  rdfs:isDefinedBy "Coordinate system defined by the \"average of 452 T1-weighted MRIs of normal young adult brains\" \"based on a 5th order polynomial transformation into the atlas space\"" ;
+                                  obo:IAO_0000115 "Coordinate system defined by the \"average of 452 T1-weighted MRIs of normal young adult brains\" \"based on a 5th order polynomial transformation into the atlas space\"" ;
                                   
                                   obo:IAO_0000114 obo:IAO_0000120 .
 
@@ -2514,11 +2509,11 @@ nidm:Icbm452Warp5CoordinateSystem rdf:type nidm:MNICoordinateSystem ,
 nidm:IcbmMni152LinearCoordinateSystem rdf:type nidm:MNICoordinateSystem ,
                                                owl:NamedIndividual ;
                                       
+                                      obo:IAO_0000115 "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, linearly transformed to Talairach space\"." ;
+                                      
                                       rdfs:comment "used in SPM99 to SPM8 (cf. http://imaging.mrc-cbu.cam.ac.uk/imaging/MniTalairach and spm8/spm_templates.man)" ;
                                       
                                       rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152Lin" ;
-                                      
-                                      rdfs:isDefinedBy "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, linearly transformed to Talairach space\"." ;
                                       
                                       obo:IAO_0000114 obo:IAO_0000120 .
 
@@ -2529,7 +2524,7 @@ nidm:IcbmMni152LinearCoordinateSystem rdf:type nidm:MNICoordinateSystem ,
 nidm:IcbmMni152NonLinear2009aAsymmetricCoordinateSystem rdf:type nidm:MNICoordinateSystem ,
                                                                  owl:NamedIndividual ;
                                                         
-                                                        rdfs:isDefinedBy "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." ;
+                                                        obo:IAO_0000115 "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." ;
                                                         
                                                         rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009" ;
                                                         
@@ -2544,7 +2539,7 @@ nidm:IcbmMni152NonLinear2009aSymmetricCoordinateSystem rdf:type nidm:MNICoordina
                                                        
                                                        rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009" ;
                                                        
-                                                       rdfs:isDefinedBy "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." ;
+                                                       obo:IAO_0000115 "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." ;
                                                        
                                                        obo:IAO_0000114 obo:IAO_0000120 .
 
@@ -2557,7 +2552,7 @@ nidm:IcbmMni152NonLinear2009bAsymmetricCoordinateSystem rdf:type nidm:MNICoordin
                                                         
                                                         rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009" ;
                                                         
-                                                        rdfs:isDefinedBy "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." ;
+                                                        obo:IAO_0000115 "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." ;
                                                         
                                                         obo:IAO_0000114 obo:IAO_0000120 .
 
@@ -2568,7 +2563,7 @@ nidm:IcbmMni152NonLinear2009bAsymmetricCoordinateSystem rdf:type nidm:MNICoordin
 nidm:IcbmMni152NonLinear2009bSymmetricCoordinateSystem rdf:type nidm:MNICoordinateSystem ,
                                                                 owl:NamedIndividual ;
                                                        
-                                                       rdfs:isDefinedBy "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." ;
+                                                       obo:IAO_0000115 "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." ;
                                                        
                                                        rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009" ;
                                                        
@@ -2585,7 +2580,7 @@ nidm:IcbmMni152NonLinear2009cAsymmetricCoordinateSystem rdf:type nidm:MNICoordin
                                                         
                                                         rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009" ;
                                                         
-                                                        rdfs:isDefinedBy "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." ;
+                                                        obo:IAO_0000115 "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." ;
                                                         
                                                         obo:IAO_0000114 obo:IAO_0000120 .
 
@@ -2596,9 +2591,9 @@ nidm:IcbmMni152NonLinear2009cAsymmetricCoordinateSystem rdf:type nidm:MNICoordin
 nidm:IcbmMni152NonLinear2009cSymmetricCoordinateSystem rdf:type nidm:MNICoordinateSystem ,
                                                                 owl:NamedIndividual ;
                                                        
-                                                       rdfs:isDefinedBy "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." ;
-                                                       
                                                        rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009" ;
+                                                       
+                                                       obo:IAO_0000115 "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." ;
                                                        
                                                        obo:IAO_0000114 obo:IAO_0000120 .
 
@@ -2611,7 +2606,7 @@ nidm:IcbmMni152NonLinear6thGenerationCoordinateSystem rdf:type nidm:MNICoordinat
                                                       
                                                       rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin6"^^xsd:anyURI ;
                                                       
-                                                      rdfs:isDefinedBy "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, linearly and non-linearly (6 iterations) transformed to form a symmetric model in Talairach space\"" ;
+                                                      obo:IAO_0000115 "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, linearly and non-linearly (6 iterations) transformed to form a symmetric model in Talairach space\"" ;
                                                       
                                                       rdfs:comment "Used in FSL (cf. http://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Atlases)" ;
                                                       
@@ -2626,9 +2621,9 @@ nidm:Ixi549CoordinateSystem rdf:type nidm:MNICoordinateSystem ,
                             
                             rdfs:seeAlso "http://biomedic.doc.ic.ac.uk/brain-development/index.php?n=Main.Datasets" ;
                             
-                            rdfs:isDefinedBy "Coordinate system defined by the average of the \"549 [...] subjects from the IXI dataset\" linearly transformed to ICBM MNI 452." ;
-                            
                             rdfs:comment "Used in SPM12b (cf. spm12b/spm_templates.man)" ;
+                            
+                            obo:IAO_0000115 "Coordinate system defined by the average of the \"549 [...] subjects from the IXI dataset\" linearly transformed to ICBM MNI 452." ;
                             
                             obo:IAO_0000114 obo:IAO_0000120 .
 
@@ -2639,9 +2634,9 @@ nidm:Ixi549CoordinateSystem rdf:type nidm:MNICoordinateSystem ,
 nidm:Mni305CoordinateSystem rdf:type nidm:MNICoordinateSystem ,
                                      owl:NamedIndividual ;
                             
-                            rdfs:isDefinedBy "Coordinate system defined by the \"average of 305 T1-weighted MRI scans, linearly transformed to Talairach space\"." ;
-                            
                             rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/MNI305" ;
+                            
+                            obo:IAO_0000115 "Coordinate system defined by the \"average of 305 T1-weighted MRI scans, linearly transformed to Talairach space\"." ;
                             
                             obo:IAO_0000114 obo:IAO_0000120 .
 
@@ -2690,7 +2685,7 @@ nidm:pixel4connected rdf:type nidm:PixelConnectivityCriterion ,
                      
                      obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/201." ;
                      
-                     rdfs:isDefinedBy "A pair of pixels are 4-Connected if they share an edge." ;
+                     obo:IAO_0000115 "A pair of pixels are 4-Connected if they share an edge." ;
                      
                      obo:IAO_0000114 obo:IAO_0000122 .
 
@@ -2701,7 +2696,7 @@ nidm:pixel4connected rdf:type nidm:PixelConnectivityCriterion ,
 nidm:pixel8connected rdf:type nidm:PixelConnectivityCriterion ,
                               owl:NamedIndividual ;
                      
-                     rdfs:isDefinedBy "A pair of pixels are 8-Connected if they share an edge or corner." ;
+                     obo:IAO_0000115 "A pair of pixels are 8-Connected if they share an edge or corner." ;
                      
                      obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/201." ;
                      
@@ -2714,9 +2709,9 @@ nidm:pixel8connected rdf:type nidm:PixelConnectivityCriterion ,
 nidm:voxel18connected rdf:type nidm:VoxelConnectivityCriterion ,
                                owl:NamedIndividual ;
                       
-                      obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/201." ;
+                      obo:IAO_0000115 "A pair of voxels are 18-Connected if they share a face or edge." ;
                       
-                      rdfs:isDefinedBy "A pair of voxels are 18-Connected if they share a face or edge." ;
+                      obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/201." ;
                       
                       obo:IAO_0000114 obo:IAO_0000122 .
 
@@ -2727,7 +2722,7 @@ nidm:voxel18connected rdf:type nidm:VoxelConnectivityCriterion ,
 nidm:voxel26connected rdf:type nidm:VoxelConnectivityCriterion ,
                                owl:NamedIndividual ;
                       
-                      rdfs:isDefinedBy "A pair of voxels are 26-Connected if they share a face, edge or corner." ;
+                      obo:IAO_0000115 "A pair of voxels are 26-Connected if they share a face, edge or corner." ;
                       
                       obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/201." ;
                       
@@ -2740,7 +2735,7 @@ nidm:voxel26connected rdf:type nidm:VoxelConnectivityCriterion ,
 nidm:voxel6connected rdf:type nidm:VoxelConnectivityCriterion ,
                               owl:NamedIndividual ;
                      
-                     rdfs:isDefinedBy "A pair of voxels are 6-Connected if they share a face." ;
+                     obo:IAO_0000115 "A pair of voxels are 6-Connected if they share a face." ;
                      
                      obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/201." ;
                      

--- a/scripts/OwlReader.py
+++ b/scripts/OwlReader.py
@@ -268,8 +268,7 @@ class OwlReader():
         return prov_class
 
     def get_definition(self, owl_term):
-        definition = list(self.graph.objects(owl_term, RDFS['isDefinedBy']))+\
-            list(self.graph.objects(owl_term, OBO_DEFINITION))
+        definition = list(self.graph.objects(owl_term, OBO_DEFINITION))
         if definition:
             definition = unicode(definition[0])
         else:


### PR DESCRIPTION
In `nidm-results.owl`, we use [rdfs:isDefinedBy](http://www.w3.org/TR/rdf-schema/#ch_isdefinedby) attribute to specify the definition while in `nidm-experiment.owl`, we use [IAO:"definition" (obo:IAO_0000115)](http://www.ontobee.org/browser/rdf.php?o=IAO&iri=http://purl.obolibrary.org/obo/IAO_0000115). The definition of the latter seems more appropriate but is directly linked with OBO while the former might be more generic. 

Do you know if there is a good practice?