### PR TITLE
Specification: small fixes to be implemented

### DIFF
--- a/doc/content/specs/nidm-results_020.html
+++ b/doc/content/specs/nidm-results_020.html
@@ -301,10 +301,10 @@
         <section>
             <h1>NIDM-Results: Types and relations</h1>
         
-        <section><h1>Model fitting</h1>
+        <section><h1>General</h1>
         <div style="text-align: left;">
             <table class="thinborder" style="margin-left: auto; margin-right: auto;">
-                <caption id="overview-types-and-relations"><span>Table 2<sup>                <a class="internalDFN" href="#overview-types-and-relations">                <span class="diamond"> &#9826;:</span></a></sup> </span>                Mapping of NIDM-Results Model fitting Core Concepts to types and relations                 and PROV core concepts</caption>                 <!-- Table 2 -->
+                <caption id="overview-types-and-relations"><span>Table 2<sup>                <a class="internalDFN" href="#overview-types-and-relations">                <span class="diamond"> &#9826;:</span></a></sup> </span>                Mapping of NIDM-Results General Core Concepts to types and relations                 and PROV core concepts</caption>                 <!-- Table 2 -->
                 <tbody>
                     <tr>
                         <td><b>NIDM-Results Concepts</b></td>
@@ -315,35 +315,352 @@
         <!-- HERE ------------- Beginning of PROV Entities ------------- -->
         
                         <tr>
-                            <td><a title="nidm:ContrastEstimation">nidm:ContrastEstimation</a>
+                            <td><a title="nidm:Map">nidm:Map</a>
                             </td>
                     
-                                <td rowspan="2" style="text-align: center;">NIDM-Results Types<br/>                                 (PROV Activity)</td>
+                                <td rowspan="1" style="text-align: center;">NIDM-Results Types<br/>                                 (PROV Entity)</td>
                         
-                                <td><a>nidm:ContrastEstimation</a></td>
+                                <td><a>nidm:Map</a></td>
                             </tr>
                 
+                </tbody>
+                </table>
+            </div>
+            <!-- nidm:Map -->
+            <section id="section-nidm:Map"> 
+                <h1 label="nidm:Map">nidm:Map</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:Map</dfn>                    <sup><a title="nidm:Map">                    <span class="diamond">&#9826;</span></a></sup> is ordered set of values corresponding to the discrete sampling of some process (e.g. brain MRI data measured on a regular 3D lattice; or brain cortical surface data measured irregularly over the cortex). <a>nidm:Map</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:Map"> A <a>nidm:Map</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:Map.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:Map.</li>
+                     
+                        <li><span class="attribute" id="nidm:Map.nidm:atCoordinateSpace">
+                        <dfn>nidm:atCoordinateSpace</dfn>
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range <a>nidm:CoordinateSpace</a>)</li> 
+                        <li><span class="attribute" id="nidm:Map.nidm:filename">
+                        <dfn>nidm:filename</dfn>
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li> 
+                        <li><span class="attribute" id="nidm:Map.nidm:hasMapHeader">
+                        <dfn>nidm:hasMapHeader</dfn>
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a>nidm:MapHeader</a>)</li>
+            <!-- nidm:CoordinateSpace -->
+            <section id="section-nidm:CoordinateSpace"> 
+                <h1 label="nidm:CoordinateSpace">nidm:CoordinateSpace</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:CoordinateSpace</dfn>                    <sup><a title="nidm:CoordinateSpace">                    <span class="diamond">&#9826;</span></a></sup> is an entity with spatial attributes (e.g., dimensions, units, and voxel-to-world mapping) that provides context to a SpatialImage (e.g., a StatisticMap). <a>nidm:CoordinateSpace</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:CoordinateSpace"> A <a>nidm:CoordinateSpace</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:CoordinateSpace.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:CoordinateSpace.</li>
+                     
+                        <li><span class="attribute" id="nidm:CoordinateSpace.nidm:dimensionsInVoxels">
+                        <dfn>nidm:dimensionsInVoxels</dfn>
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> dimensions of some N-dimensional data. (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li> 
+                        <li><span class="attribute" id="nidm:CoordinateSpace.nidm:inWorldCoordinateSystem">
+                        <dfn>nidm:inWorldCoordinateSystem</dfn>
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> type of coordinate system. (range <a>nidm:Colin27CoordinateSystem</a>, <a>nidm:CustomCoordinateSystem</a>, <a>nidm:Icbm452AirCoordinateSystem</a>, <a>nidm:Icbm452Warp5CoordinateSystem</a>, <a>nidm:IcbmMni152LinearCoordinateSystem</a>, <a>nidm:IcbmMni152NonLinear2009aAsymmetricCoordinateSystem</a>, <a>nidm:IcbmMni152NonLinear2009aSymmetricCoordinateSystem</a>, <a>nidm:IcbmMni152NonLinear2009bAsymmetricCoordinateSystem</a>, <a>nidm:IcbmMni152NonLinear2009bSymmetricCoordinateSystem</a>, <a>nidm:IcbmMni152NonLinear2009cAsymmetricCoordinateSystem</a>, <a>nidm:IcbmMni152NonLinear2009cSymmetricCoordinateSystem</a>, <a>nidm:IcbmMni152NonLinear6thGenerationCoordinateSystem</a>, <a>nidm:Ixi549Space</a>, <a>nidm:MNICoordinateSystem</a>, <a>nidm:Mni305CoordinateSystem</a>, <a>nidm:StandardizedCoordinateSystem</a>, <a>nidm:SubjectCoordinateSystem</a>, <a>nidm:TalairachCoordinateSystem</a> and <a>nidm:WorldCoordinateSystem</a>)</li> 
+                        <li><span class="attribute" id="nidm:CoordinateSpace.nidm:numberOfDimensions">
+                        <dfn>nidm:numberOfDimensions</dfn>
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> number of dimensions of a data matrix. (range <a title="xsd:positiveInteger" href="http://www.w3.org/2001/XMLSchema#positiveInteger">xsd:positiveInteger</a>)</li> 
+                        <li><span class="attribute" id="nidm:CoordinateSpace.nidm:voxelSize">
+                        <dfn>nidm:voxelSize</dfn>
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> 3D size of a voxel measured in voxelUnits. (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li> 
+                        <li><span class="attribute" id="nidm:CoordinateSpace.nidm:voxelToWorldMapping">
+                        <dfn>nidm:voxelToWorldMapping</dfn>
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> homogeneous transformation matrix to map from voxel coordinate system to world coordinate system. (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li> 
+                        <li><span class="attribute" id="nidm:CoordinateSpace.nidm:voxelUnits">
+                        <dfn>nidm:voxelUnits</dfn>
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> units associated with each dimensions of some N-dimensional data. (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li>        
+                </ul>
+                </div>
+                <pre class='example highlight'>entity(niiri:coordinate_space_id_1,
+      [prov:type = 'nidm:CoordinateSpace',
+      prov:label = "Coordinate space 1" %% xsd:string,
+      nidm:voxelToWorldMapping = "[[-3, 0, 0, 78],[0, 3, 0, -112],[0, 0, 3, -50],[0, 0, 0, 1]]" %% xsd:string,
+      nidm:voxelUnits = "['mm', 'mm', 'mm']" %% xsd:string,
+      nidm:voxelSize = "[3, 3, 3]" %% xsd:string,
+      nidm:inWorldCoordinateSystem = 'nidm:MNICoordinateSystem',
+      nidm:numberOfDimensions = "3" %% xsd:int,
+      nidm:dimensionsInVoxels = "[53,63,46]" %% xsd:string])</pre>
+            <!-- nidm:Colin27CoordinateSystem -->
+            <section id="section-nidm:Colin27CoordinateSystem"> 
+                <h1 label="nidm:Colin27CoordinateSystem">nidm:Colin27CoordinateSystem</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:Colin27CoordinateSystem</dfn>                    <sup><a title="nidm:Colin27CoordinateSystem">                    <span class="diamond">&#9826;</span></a></sup> is coordinate system defined by the "stereotaxic average of 27 T1-weighted MRI scans of the same individual". <a>nidm:Colin27CoordinateSystem</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:Colin27CoordinateSystem"> A <a>nidm:Colin27CoordinateSystem</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:Colin27CoordinateSystem.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:Colin27CoordinateSystem.</li>
+                      
+            </section>
+            <!-- nidm:CustomCoordinateSystem -->
+            <section id="section-nidm:CustomCoordinateSystem"> 
+                <h1 label="nidm:CustomCoordinateSystem">nidm:CustomCoordinateSystem</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:CustomCoordinateSystem</dfn>                    <sup><a title="nidm:CustomCoordinateSystem">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidm:CustomCoordinateSystem</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:CustomCoordinateSystem"> A <a>nidm:CustomCoordinateSystem</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:CustomCoordinateSystem.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:CustomCoordinateSystem.</li>
+                      
+            </section>
+            <!-- nidm:Icbm452AirCoordinateSystem -->
+            <section id="section-nidm:Icbm452AirCoordinateSystem"> 
+                <h1 label="nidm:Icbm452AirCoordinateSystem">nidm:Icbm452AirCoordinateSystem</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:Icbm452AirCoordinateSystem</dfn>                    <sup><a title="nidm:Icbm452AirCoordinateSystem">                    <span class="diamond">&#9826;</span></a></sup> is coordinate system defined by the "average of 452 T1-weighted MRIs of normal young adult brains" with "linear transforms of the subjects into the atlas space using a 12-parameter affine transformation". <a>nidm:Icbm452AirCoordinateSystem</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:Icbm452AirCoordinateSystem"> A <a>nidm:Icbm452AirCoordinateSystem</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:Icbm452AirCoordinateSystem.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:Icbm452AirCoordinateSystem.</li>
+                      
+            </section>
+            <!-- nidm:Icbm452Warp5CoordinateSystem -->
+            <section id="section-nidm:Icbm452Warp5CoordinateSystem"> 
+                <h1 label="nidm:Icbm452Warp5CoordinateSystem">nidm:Icbm452Warp5CoordinateSystem</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:Icbm452Warp5CoordinateSystem</dfn>                    <sup><a title="nidm:Icbm452Warp5CoordinateSystem">                    <span class="diamond">&#9826;</span></a></sup> is coordinate system defined by the "average of 452 T1-weighted MRIs of normal young adult brains" "based on a 5th order polynomial transformation into the atlas space". <a>nidm:Icbm452Warp5CoordinateSystem</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:Icbm452Warp5CoordinateSystem"> A <a>nidm:Icbm452Warp5CoordinateSystem</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:Icbm452Warp5CoordinateSystem.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:Icbm452Warp5CoordinateSystem.</li>
+                      
+            </section>
+            <!-- nidm:IcbmMni152LinearCoordinateSystem -->
+            <section id="section-nidm:IcbmMni152LinearCoordinateSystem"> 
+                <h1 label="nidm:IcbmMni152LinearCoordinateSystem">nidm:IcbmMni152LinearCoordinateSystem</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:IcbmMni152LinearCoordinateSystem</dfn>                    <sup><a title="nidm:IcbmMni152LinearCoordinateSystem">                    <span class="diamond">&#9826;</span></a></sup> is coordinate system defined by the "average of 152 T1-weighted MRI scans, linearly transformed to Talairach space". <a>nidm:IcbmMni152LinearCoordinateSystem</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:IcbmMni152LinearCoordinateSystem"> A <a>nidm:IcbmMni152LinearCoordinateSystem</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:IcbmMni152LinearCoordinateSystem.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:IcbmMni152LinearCoordinateSystem.</li>
+                      
+            </section>
+            <!-- nidm:IcbmMni152NonLinear2009aAsymmetricCoordinateSystem -->
+            <section id="section-nidm:IcbmMni152NonLinear2009aAsymmetricCoordinateSystem"> 
+                <h1 label="nidm:IcbmMni152NonLinear2009aAsymmetricCoordinateSystem">nidm:IcbmMni152NonLinear2009aAsymmetricCoordinateSystem</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:IcbmMni152NonLinear2009aAsymmetricCoordinateSystem</dfn>                    <sup><a title="nidm:IcbmMni152NonLinear2009aAsymmetricCoordinateSystem">                    <span class="diamond">&#9826;</span></a></sup> is coordinate system defined by the "average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space". <a>nidm:IcbmMni152NonLinear2009aAsymmetricCoordinateSystem</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:IcbmMni152NonLinear2009aAsymmetricCoordinateSystem"> A <a>nidm:IcbmMni152NonLinear2009aAsymmetricCoordinateSystem</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:IcbmMni152NonLinear2009aAsymmetricCoordinateSystem.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:IcbmMni152NonLinear2009aAsymmetricCoordinateSystem.</li>
+                      
+            </section>
+            <!-- nidm:IcbmMni152NonLinear2009aSymmetricCoordinateSystem -->
+            <section id="section-nidm:IcbmMni152NonLinear2009aSymmetricCoordinateSystem"> 
+                <h1 label="nidm:IcbmMni152NonLinear2009aSymmetricCoordinateSystem">nidm:IcbmMni152NonLinear2009aSymmetricCoordinateSystem</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:IcbmMni152NonLinear2009aSymmetricCoordinateSystem</dfn>                    <sup><a title="nidm:IcbmMni152NonLinear2009aSymmetricCoordinateSystem">                    <span class="diamond">&#9826;</span></a></sup> is coordinate system defined by the "average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space". <a>nidm:IcbmMni152NonLinear2009aSymmetricCoordinateSystem</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:IcbmMni152NonLinear2009aSymmetricCoordinateSystem"> A <a>nidm:IcbmMni152NonLinear2009aSymmetricCoordinateSystem</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:IcbmMni152NonLinear2009aSymmetricCoordinateSystem.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:IcbmMni152NonLinear2009aSymmetricCoordinateSystem.</li>
+                      
+            </section>
+            <!-- nidm:IcbmMni152NonLinear2009bAsymmetricCoordinateSystem -->
+            <section id="section-nidm:IcbmMni152NonLinear2009bAsymmetricCoordinateSystem"> 
+                <h1 label="nidm:IcbmMni152NonLinear2009bAsymmetricCoordinateSystem">nidm:IcbmMni152NonLinear2009bAsymmetricCoordinateSystem</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:IcbmMni152NonLinear2009bAsymmetricCoordinateSystem</dfn>                    <sup><a title="nidm:IcbmMni152NonLinear2009bAsymmetricCoordinateSystem">                    <span class="diamond">&#9826;</span></a></sup> is coordinate system defined by the "average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space". <a>nidm:IcbmMni152NonLinear2009bAsymmetricCoordinateSystem</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:IcbmMni152NonLinear2009bAsymmetricCoordinateSystem"> A <a>nidm:IcbmMni152NonLinear2009bAsymmetricCoordinateSystem</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:IcbmMni152NonLinear2009bAsymmetricCoordinateSystem.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:IcbmMni152NonLinear2009bAsymmetricCoordinateSystem.</li>
+                      
+            </section>
+            <!-- nidm:IcbmMni152NonLinear2009bSymmetricCoordinateSystem -->
+            <section id="section-nidm:IcbmMni152NonLinear2009bSymmetricCoordinateSystem"> 
+                <h1 label="nidm:IcbmMni152NonLinear2009bSymmetricCoordinateSystem">nidm:IcbmMni152NonLinear2009bSymmetricCoordinateSystem</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:IcbmMni152NonLinear2009bSymmetricCoordinateSystem</dfn>                    <sup><a title="nidm:IcbmMni152NonLinear2009bSymmetricCoordinateSystem">                    <span class="diamond">&#9826;</span></a></sup> is coordinate system defined by the "average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space". <a>nidm:IcbmMni152NonLinear2009bSymmetricCoordinateSystem</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:IcbmMni152NonLinear2009bSymmetricCoordinateSystem"> A <a>nidm:IcbmMni152NonLinear2009bSymmetricCoordinateSystem</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:IcbmMni152NonLinear2009bSymmetricCoordinateSystem.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:IcbmMni152NonLinear2009bSymmetricCoordinateSystem.</li>
+                      
+            </section>
+            <!-- nidm:IcbmMni152NonLinear2009cAsymmetricCoordinateSystem -->
+            <section id="section-nidm:IcbmMni152NonLinear2009cAsymmetricCoordinateSystem"> 
+                <h1 label="nidm:IcbmMni152NonLinear2009cAsymmetricCoordinateSystem">nidm:IcbmMni152NonLinear2009cAsymmetricCoordinateSystem</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:IcbmMni152NonLinear2009cAsymmetricCoordinateSystem</dfn>                    <sup><a title="nidm:IcbmMni152NonLinear2009cAsymmetricCoordinateSystem">                    <span class="diamond">&#9826;</span></a></sup> is coordinate system defined by the "average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space". <a>nidm:IcbmMni152NonLinear2009cAsymmetricCoordinateSystem</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:IcbmMni152NonLinear2009cAsymmetricCoordinateSystem"> A <a>nidm:IcbmMni152NonLinear2009cAsymmetricCoordinateSystem</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:IcbmMni152NonLinear2009cAsymmetricCoordinateSystem.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:IcbmMni152NonLinear2009cAsymmetricCoordinateSystem.</li>
+                      
+            </section>
+            <!-- nidm:IcbmMni152NonLinear2009cSymmetricCoordinateSystem -->
+            <section id="section-nidm:IcbmMni152NonLinear2009cSymmetricCoordinateSystem"> 
+                <h1 label="nidm:IcbmMni152NonLinear2009cSymmetricCoordinateSystem">nidm:IcbmMni152NonLinear2009cSymmetricCoordinateSystem</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:IcbmMni152NonLinear2009cSymmetricCoordinateSystem</dfn>                    <sup><a title="nidm:IcbmMni152NonLinear2009cSymmetricCoordinateSystem">                    <span class="diamond">&#9826;</span></a></sup> is coordinate system defined by the "average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space". <a>nidm:IcbmMni152NonLinear2009cSymmetricCoordinateSystem</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:IcbmMni152NonLinear2009cSymmetricCoordinateSystem"> A <a>nidm:IcbmMni152NonLinear2009cSymmetricCoordinateSystem</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:IcbmMni152NonLinear2009cSymmetricCoordinateSystem.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:IcbmMni152NonLinear2009cSymmetricCoordinateSystem.</li>
+                      
+            </section>
+            <!-- nidm:IcbmMni152NonLinear6thGenerationCoordinateSystem -->
+            <section id="section-nidm:IcbmMni152NonLinear6thGenerationCoordinateSystem"> 
+                <h1 label="nidm:IcbmMni152NonLinear6thGenerationCoordinateSystem">nidm:IcbmMni152NonLinear6thGenerationCoordinateSystem</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:IcbmMni152NonLinear6thGenerationCoordinateSystem</dfn>                    <sup><a title="nidm:IcbmMni152NonLinear6thGenerationCoordinateSystem">                    <span class="diamond">&#9826;</span></a></sup> is coordinate system defined by the "average of 152 T1-weighted MRI scans, linearly and non-linearly (6 iterations) transformed to form a symmetric model in Talairach space". <a>nidm:IcbmMni152NonLinear6thGenerationCoordinateSystem</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:IcbmMni152NonLinear6thGenerationCoordinateSystem"> A <a>nidm:IcbmMni152NonLinear6thGenerationCoordinateSystem</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:IcbmMni152NonLinear6thGenerationCoordinateSystem.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:IcbmMni152NonLinear6thGenerationCoordinateSystem.</li>
+                      
+            </section>
+            <!-- nidm:Ixi549Space -->
+            <section id="section-nidm:Ixi549Space"> 
+                <h1 label="nidm:Ixi549Space">nidm:Ixi549Space</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:Ixi549Space</dfn>                    <sup><a title="nidm:Ixi549Space">                    <span class="diamond">&#9826;</span></a></sup> is coordinate system defined by the average of the "549 [...] subjects from the IXI dataset" linearly transformed to ICBM MNI 452. <a>nidm:Ixi549Space</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:Ixi549Space"> A <a>nidm:Ixi549Space</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:Ixi549Space.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:Ixi549Space.</li>
+                      
+            </section>
+            <!-- nidm:MNICoordinateSystem -->
+            <section id="section-nidm:MNICoordinateSystem"> 
+                <h1 label="nidm:MNICoordinateSystem">nidm:MNICoordinateSystem</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:MNICoordinateSystem</dfn>                    <sup><a title="nidm:MNICoordinateSystem">                    <span class="diamond">&#9826;</span></a></sup> is coordinate system defined with reference to the MNI atlas. <a>nidm:MNICoordinateSystem</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:MNICoordinateSystem"> A <a>nidm:MNICoordinateSystem</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:MNICoordinateSystem.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:MNICoordinateSystem.</li>
+                      
+            </section>
+            <!-- nidm:Mni305CoordinateSystem -->
+            <section id="section-nidm:Mni305CoordinateSystem"> 
+                <h1 label="nidm:Mni305CoordinateSystem">nidm:Mni305CoordinateSystem</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:Mni305CoordinateSystem</dfn>                    <sup><a title="nidm:Mni305CoordinateSystem">                    <span class="diamond">&#9826;</span></a></sup> is coordinate system defined by the "average of 305 T1-weighted MRI scans, linearly transformed to Talairach space". <a>nidm:Mni305CoordinateSystem</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:Mni305CoordinateSystem"> A <a>nidm:Mni305CoordinateSystem</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:Mni305CoordinateSystem.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:Mni305CoordinateSystem.</li>
+                      
+            </section>
+            <!-- nidm:StandardizedCoordinateSystem -->
+            <section id="section-nidm:StandardizedCoordinateSystem"> 
+                <h1 label="nidm:StandardizedCoordinateSystem">nidm:StandardizedCoordinateSystem</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:StandardizedCoordinateSystem</dfn>                    <sup><a title="nidm:StandardizedCoordinateSystem">                    <span class="diamond">&#9826;</span></a></sup> is parent of all reference spaces except "Subject". <a>nidm:StandardizedCoordinateSystem</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:StandardizedCoordinateSystem"> A <a>nidm:StandardizedCoordinateSystem</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:StandardizedCoordinateSystem.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:StandardizedCoordinateSystem.</li>
+                      
+            </section>
+            <!-- nidm:SubjectCoordinateSystem -->
+            <section id="section-nidm:SubjectCoordinateSystem"> 
+                <h1 label="nidm:SubjectCoordinateSystem">nidm:SubjectCoordinateSystem</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:SubjectCoordinateSystem</dfn>                    <sup><a title="nidm:SubjectCoordinateSystem">                    <span class="diamond">&#9826;</span></a></sup> is coordinate system defined by the subject brain (no spatial normalisation applied). <a>nidm:SubjectCoordinateSystem</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:SubjectCoordinateSystem"> A <a>nidm:SubjectCoordinateSystem</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:SubjectCoordinateSystem.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:SubjectCoordinateSystem.</li>
+                      
+            </section>
+            <!-- nidm:TalairachCoordinateSystem -->
+            <section id="section-nidm:TalairachCoordinateSystem"> 
+                <h1 label="nidm:TalairachCoordinateSystem">nidm:TalairachCoordinateSystem</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:TalairachCoordinateSystem</dfn>                    <sup><a title="nidm:TalairachCoordinateSystem">                    <span class="diamond">&#9826;</span></a></sup> is reference space defined by the dissected brain used for the Talairach and Tournoux atlas. <a>nidm:TalairachCoordinateSystem</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:TalairachCoordinateSystem"> A <a>nidm:TalairachCoordinateSystem</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:TalairachCoordinateSystem.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:TalairachCoordinateSystem.</li>
+                      
+            </section>
+            <!-- nidm:WorldCoordinateSystem -->
+            <section id="section-nidm:WorldCoordinateSystem"> 
+                <h1 label="nidm:WorldCoordinateSystem">nidm:WorldCoordinateSystem</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:WorldCoordinateSystem</dfn>                    <sup><a title="nidm:WorldCoordinateSystem">                    <span class="diamond">&#9826;</span></a></sup> is fIXME. <a>nidm:WorldCoordinateSystem</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:WorldCoordinateSystem"> A <a>nidm:WorldCoordinateSystem</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:WorldCoordinateSystem.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:WorldCoordinateSystem.</li>
+                      
+            </section>  
+            </section>
+            <!-- nidm:MapHeader -->
+            <section id="section-nidm:MapHeader"> 
+                <h1 label="nidm:MapHeader">nidm:MapHeader</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:MapHeader</dfn>                    <sup><a title="nidm:MapHeader">                    <span class="diamond">&#9826;</span></a></sup> is fIXME. <a>nidm:MapHeader</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:MapHeader"> A <a>nidm:MapHeader</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:MapHeader.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:MapHeader.</li>
+                     
+                        <li><span class="attribute" id="nidm:MapHeader.nidm:filename">
+                        <a>nidm:filename</a>
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li>  
+            </section>  
+            </section>
+            </section>
+        <section><h1>Parameters estimation</h1>
+        <div style="text-align: left;">
+            <table class="thinborder" style="margin-left: auto; margin-right: auto;">
+                <caption id="overview-types-and-relations"><span>Table 2<sup>                <a class="internalDFN" href="#overview-types-and-relations">                <span class="diamond"> &#9826;:</span></a></sup> </span>                Mapping of NIDM-Results Parameters estimation Core Concepts to types and relations                 and PROV core concepts</caption>                 <!-- Table 2 -->
+                <tbody>
+                    <tr>
+                        <td><b>NIDM-Results Concepts</b></td>
+                        <td><b>Types or Relation (PROV concepts)</b></td>
+                        <td><b>Name</b></td>
+                    </tr>
+        
+        <!-- HERE ------------- Beginning of PROV Entities ------------- -->
+        
                         <tr>
                             <td><a title="nidm:ModelParametersEstimation">nidm:ModelParametersEstimation</a>
                             </td>
                     
+                                <td rowspan="1" style="text-align: center;">NIDM-Results Types<br/>                                 (PROV Activity)</td>
+                        
                                 <td><a>nidm:ModelParametersEstimation</a></td>
                             </tr>
                 
                         <tr>
-                            <td><a title="nidm:ContrastMap">nidm:ContrastMap</a>
+                            <td><a title="nidm:CustomMaskMap">nidm:CustomMaskMap</a>
                             </td>
                     
-                                <td rowspan="10" style="text-align: center;">NIDM-Results Types<br/>                                 (PROV Entity)</td>
+                                <td rowspan="8" style="text-align: center;">NIDM-Results Types<br/>                                 (PROV Entity)</td>
                         
-                                <td><a>nidm:ContrastMap</a></td>
-                            </tr>
-                
-                        <tr>
-                            <td><a title="nidm:ContrastWeights">nidm:ContrastWeights</a>
-                            </td>
-                    
-                                <td><a>nidm:ContrastWeights</a></td>
+                                <td><a>nidm:CustomMaskMap</a></td>
                             </tr>
                 
                         <tr>
@@ -395,115 +712,121 @@
                                 <td><a>nidm:ResidualMeanSquaresMap</a></td>
                             </tr>
                 
-                        <tr>
-                            <td><a title="nidm:StatisticMap">nidm:StatisticMap</a>
-                            </td>
-                    
-                                <td><a>nidm:StatisticMap</a></td>
-                            </tr>
-                
                 </tbody>
                 </table>
             </div>
-            <!-- nidm:ContrastEstimation -->
-            <section id="section-nidm:ContrastEstimation"> 
-                <h1 label="nidm:ContrastEstimation">nidm:ContrastEstimation</h1>
-                <div class="glossary-ref">
-                    A <dfn>nidm:ContrastEstimation</dfn>                    <sup><a title="nidm:ContrastEstimation">                    <span class="diamond">&#9826;</span></a></sup> is the process of estimating a contrast from the estimated parameters of statistical model. <a>nidm:ContrastEstimation</a> is a prov:Activity that uses <a>nidm:ContrastWeights</a>, <a>nidm:DesignMatrix</a>, <a>nidm:MaskMap</a>, <a>nidm:ParameterEstimateMap</a> and <a>nidm:ResidualMeanSquaresMap</a> entities. This activity generates <a>nidm:ContrastMap</a> and <a>nidm:StatisticMap</a> entities. 
-                </div>
-                <p></p>
-                <div class="attributes" id="attributes-nidm:ContrastEstimation"> A <a>nidm:ContrastEstimation</a> has attributes:
-                <ul>
-                    <li><span class="attribute" id="nidm:ContrastEstimation.label">prov:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:ContrastEstimation.</li>
-                            
-                </ul>
-                </div>
-                <pre class='example highlight'>activity(niiri:contrast_estimation_id,
-      [prov:type = 'nidm:ContrastEstimation',
-      prov:label = "Contrast estimation"])</pre>  
-            </section>
             <!-- nidm:ModelParametersEstimation -->
             <section id="section-nidm:ModelParametersEstimation"> 
                 <h1 label="nidm:ModelParametersEstimation">nidm:ModelParametersEstimation</h1>
                 <div class="glossary-ref">
-                    A <dfn>nidm:ModelParametersEstimation</dfn>                    <sup><a title="nidm:ModelParametersEstimation">                    <span class="diamond">&#9826;</span></a></sup> is the process of estimating the parameters of a general linear model from the available data. <a>nidm:ModelParametersEstimation</a> is a prov:Activity that uses <a>nidm:Data</a>, <a>nidm:DesignMatrix</a> and <a>nidm:NoiseModel</a> entities. This activity generates <a>nidm:MaskMap</a>, <a>nidm:ParameterEstimateMap</a> and <a>nidm:ResidualMeanSquaresMap</a> entities. 
+                    A <dfn>nidm:ModelParametersEstimation</dfn>                    <sup><a title="nidm:ModelParametersEstimation">                    <span class="diamond">&#9826;</span></a></sup> is the process of estimating the parameters of a general linear model from the available data. <a>nidm:ModelParametersEstimation</a> is a prov:Activity that uses <a>nidm:CustomMaskMap</a>, <a>nidm:Data</a>, <a>nidm:DesignMatrix</a> and <a>nidm:NoiseModel</a> entities. This activity generates <a>nidm:MaskMap</a>, <a>nidm:ParameterEstimateMap</a> and <a>nidm:ResidualMeanSquaresMap</a> entities. 
                 </div>
                 <p></p>
                 <div class="attributes" id="attributes-nidm:ModelParametersEstimation"> A <a>nidm:ModelParametersEstimation</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:ModelParametersEstimation.label">prov:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:ModelParametersEstimation.</li>
+                    <li><span class="attribute" id="nidm:ModelParametersEstimation.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:ModelParametersEstimation.</li>
                      
                         <li><span class="attribute" id="nidm:ModelParametersEstimation.nidm:withEstimationMethod">
                         <dfn>nidm:withEstimationMethod</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range nidm:EstimationMethod, nidm:GeneralizedLeastSquares, nidm:OrdinaryLeastSquares, nidm:RobustIterativelyReweighedLeastSquares, nidm:WeightedLeastSquares)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a>nidm:EstimationMethod</a>, <a>nidm:GeneralizedLeastSquares</a>, <a>nidm:OrdinaryLeastSquares</a>, <a>nidm:RobustIterativelyReweighedLeastSquares</a> and <a>nidm:WeightedLeastSquares</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>activity(niiri:model_pe_id,
       [prov:type = 'nidm:ModelParametersEstimation',
       prov:label = "Model parameters estimation",
       nidm:withEstimationMethod = 'nidm:OrdinaryLeastSquares'
-      ])</pre>  
-            </section>
-            <!-- nidm:ContrastMap -->
-            <section id="section-nidm:ContrastMap"> 
-                <h1 label="nidm:ContrastMap">nidm:ContrastMap</h1>
+      ])</pre>
+            <!-- nidm:EstimationMethod -->
+            <section id="section-nidm:EstimationMethod"> 
+                <h1 label="nidm:EstimationMethod">nidm:EstimationMethod</h1>
                 <div class="glossary-ref">
-                    A <dfn>nidm:ContrastMap</dfn>                    <sup><a title="nidm:ContrastMap">                    <span class="diamond">&#9826;</span></a></sup> is a map whose value at each location is statistical contrast estimate. <a>nidm:ContrastMap</a> is a prov:Entity used by <a>nidm:Inference</a> and  generated by <a>nidm:ContrastEstimation</a>. 
+                    A <dfn>nidm:EstimationMethod</dfn>                    <sup><a title="nidm:EstimationMethod">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidm:EstimationMethod</a> is a prov:Entity. 
                 </div>
                 <p></p>
-                <div class="attributes" id="attributes-nidm:ContrastMap"> A <a>nidm:ContrastMap</a> has attributes:
+                <div class="attributes" id="attributes-nidm:EstimationMethod"> A <a>nidm:EstimationMethod</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:ContrastMap.label">prov:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:ContrastMap.</li>
+                    <li><span class="attribute" id="nidm:EstimationMethod.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:EstimationMethod.</li>
+                      
+            </section>
+            <!-- nidm:GeneralizedLeastSquares -->
+            <section id="section-nidm:GeneralizedLeastSquares"> 
+                <h1 label="nidm:GeneralizedLeastSquares">nidm:GeneralizedLeastSquares</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:GeneralizedLeastSquares</dfn>                    <sup><a title="nidm:GeneralizedLeastSquares">                    <span class="diamond">&#9826;</span></a></sup> is fIXME. <a>nidm:GeneralizedLeastSquares</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:GeneralizedLeastSquares"> A <a>nidm:GeneralizedLeastSquares</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:GeneralizedLeastSquares.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:GeneralizedLeastSquares.</li>
+                      
+            </section>
+            <!-- nidm:OrdinaryLeastSquares -->
+            <section id="section-nidm:OrdinaryLeastSquares"> 
+                <h1 label="nidm:OrdinaryLeastSquares">nidm:OrdinaryLeastSquares</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:OrdinaryLeastSquares</dfn>                    <sup><a title="nidm:OrdinaryLeastSquares">                    <span class="diamond">&#9826;</span></a></sup> is fIXME. <a>nidm:OrdinaryLeastSquares</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:OrdinaryLeastSquares"> A <a>nidm:OrdinaryLeastSquares</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:OrdinaryLeastSquares.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:OrdinaryLeastSquares.</li>
+                      
+            </section>
+            <!-- nidm:RobustIterativelyReweighedLeastSquares -->
+            <section id="section-nidm:RobustIterativelyReweighedLeastSquares"> 
+                <h1 label="nidm:RobustIterativelyReweighedLeastSquares">nidm:RobustIterativelyReweighedLeastSquares</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:RobustIterativelyReweighedLeastSquares</dfn>                    <sup><a title="nidm:RobustIterativelyReweighedLeastSquares">                    <span class="diamond">&#9826;</span></a></sup> is fIXME. <a>nidm:RobustIterativelyReweighedLeastSquares</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:RobustIterativelyReweighedLeastSquares"> A <a>nidm:RobustIterativelyReweighedLeastSquares</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:RobustIterativelyReweighedLeastSquares.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:RobustIterativelyReweighedLeastSquares.</li>
+                      
+            </section>
+            <!-- nidm:WeightedLeastSquares -->
+            <section id="section-nidm:WeightedLeastSquares"> 
+                <h1 label="nidm:WeightedLeastSquares">nidm:WeightedLeastSquares</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:WeightedLeastSquares</dfn>                    <sup><a title="nidm:WeightedLeastSquares">                    <span class="diamond">&#9826;</span></a></sup> is fIXME. <a>nidm:WeightedLeastSquares</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:WeightedLeastSquares"> A <a>nidm:WeightedLeastSquares</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:WeightedLeastSquares.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:WeightedLeastSquares.</li>
+                      
+            </section>  
+            </section>
+            <!-- nidm:CustomMaskMap -->
+            <section id="section-nidm:CustomMaskMap"> 
+                <h1 label="nidm:CustomMaskMap">nidm:CustomMaskMap</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:CustomMaskMap</dfn>                    <sup><a title="nidm:CustomMaskMap">                    <span class="diamond">&#9826;</span></a></sup> is mask defined by the user to restrain the space in which model fitting is performed. <a>nidm:CustomMaskMap</a> is a prov:Entity used by <a>nidm:ModelParametersEstimation</a>. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:CustomMaskMap"> A <a>nidm:CustomMaskMap</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:CustomMaskMap.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:CustomMaskMap.</li>
                      
-                        <li><span class="attribute" id="nidm:ContrastMap.nidm:atCoordinateSpace">
-                        <dfn>nidm:atCoordinateSpace</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range nidm:CoordinateSpace)</li> 
-                        <li><span class="attribute" id="nidm:ContrastMap.nidm:contrastName">
-                        <dfn>nidm:contrastName</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> name of the contrast. (range xsd:string)</li> 
-                        <li><span class="attribute" id="nidm:ContrastMap.nidm:filename">
-                        <dfn>nidm:filename</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range xsd:string)</li> 
-                        <li><span class="attribute" id="nidm:ContrastMap.nidm:hasMapHeader">
-                        <dfn>nidm:hasMapHeader</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range nidm:MapHeader)</li>        
+                        <li><span class="attribute" id="nidm:CustomMaskMap.nidm:atCoordinateSpace">
+                        <a>nidm:atCoordinateSpace</a>
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range <a>nidm:CoordinateSpace</a>)</li> 
+                        <li><span class="attribute" id="nidm:CustomMaskMap.nidm:filename">
+                        <a>nidm:filename</a>
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li> 
+                        <li><span class="attribute" id="nidm:CustomMaskMap.nidm:hasMapHeader">
+                        <a>nidm:hasMapHeader</a>
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a>nidm:MapHeader</a>)</li>        
                 </ul>
                 </div>
-                <pre class='example highlight'>entity(niiri:contrast_map_id,
-      [prov:type = 'nidm:ContrastMap',
-      prov:location = "file:///path/to/Contrast.nii.gz" %% xsd:anyURI,
-      dct:format = 'nidm:Nifti1Gz',
-      nidm:filename = "Contrast.nii.gz" %% xsd:string,
-      prov:label = "Contrast Map: listening > rest" %% xsd:string,
-      nidm:contrastName = "listening > rest" %% xsd:string,
+                <pre class='example highlight'>entity(niiri:custom_mask_id_1,
+      [prov:type = 'nidm:CustomMaskMap',
+      prov:location = "file:///path/to/CustomMask.nii.gz" %% xsd:anyURI,
+      nidm:filename = "CustomMask.nii.gz" %% xsd:string,
+      dct:format = "image/nifti",
+      prov:label = "Custom mask" %% xsd:string,
       nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])</pre>  
-            </section>
-            <!-- nidm:ContrastWeights -->
-            <section id="section-nidm:ContrastWeights"> 
-                <h1 label="nidm:ContrastWeights">nidm:ContrastWeights</h1>
-                <div class="glossary-ref">
-                    A <dfn>nidm:ContrastWeights</dfn>                    <sup><a title="nidm:ContrastWeights">                    <span class="diamond">&#9826;</span></a></sup> is vector defining the linear combination associated with a particular contrast. . <a>nidm:ContrastWeights</a> is a prov:Entity used by <a>nidm:ContrastEstimation</a>. 
-                </div>
-                <p></p>
-                <div class="attributes" id="attributes-nidm:ContrastWeights"> A <a>nidm:ContrastWeights</a> has attributes:
-                <ul>
-                    <li><span class="attribute" id="nidm:ContrastWeights.label">prov:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:ContrastWeights.</li>
-                     
-                        <li><span class="attribute" id="nidm:ContrastWeights.nidm:contrastName">
-                        <a>nidm:contrastName</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> name of the contrast. (range xsd:string)</li> 
-                        <li><span class="attribute" id="nidm:ContrastWeights.nidm:statisticType">
-                        <dfn>nidm:statisticType</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range nidm:FStatistic, nidm:Statistic, nidm:TStatistic, nidm:ZStatistic)</li>        
-                </ul>
-                </div>
-                <pre class='example highlight'>entity(niiri:contrast_weights_id,
-      [prov:type = 'nidm:ContrastWeights',
-      nidm:statisticType = 'nidm:TStatistic',
-      nidm:contrastName = "listening > rest" %% xsd:string,
-      prov:label = "Contrast: Listening > Rest" %% xsd:string,
-      prov:value = "[1, 0, 0]" %% xsd:string])</pre>  
             </section>
             <!-- nidm:Data -->
             <section id="section-nidm:Data"> 
@@ -514,14 +837,14 @@
                 <p></p>
                 <div class="attributes" id="attributes-nidm:Data"> A <a>nidm:Data</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:Data.label">prov:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:Data.</li>
+                    <li><span class="attribute" id="nidm:Data.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:Data.</li>
                      
                         <li><span class="attribute" id="nidm:Data.nidm:grandMeanScaling">
                         <dfn>nidm:grandMeanScaling</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> binary flag defining whether the data was scaled. Specifically, "grand mean scaling" refers to multipliciation of every voxel in every scan by a common value.  Grand mean scaling is essential for first-level fMRI, to transform the arbitrary MRI units, but is generally not used with second level analyses. (range xsd:boolean)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> binary flag defining whether the data was scaled. Specifically, "grand mean scaling" refers to multipliciation of every voxel in every scan by a common value.  Grand mean scaling is essential for first-level fMRI, to transform the arbitrary MRI units, but is generally not used with second level analyses. (range <a title="xsd:boolean" href="http://www.w3.org/2001/XMLSchema#boolean">xsd:boolean</a>)</li> 
                         <li><span class="attribute" id="nidm:Data.nidm:targetIntensity">
                         <dfn>nidm:targetIntensity</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> value to which the grand mean of the Data was scaled (applies only if grandMeanScaling is true). (range xsd:float)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> value to which the grand mean of the Data was scaled (applies only if grandMeanScaling is true). (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>entity(niiri:data_id,
@@ -540,14 +863,14 @@
                 <p></p>
                 <div class="attributes" id="attributes-nidm:DesignMatrix"> A <a>nidm:DesignMatrix</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:DesignMatrix.label">prov:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:DesignMatrix.</li>
+                    <li><span class="attribute" id="nidm:DesignMatrix.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:DesignMatrix.</li>
                      
                         <li><span class="attribute" id="nidm:DesignMatrix.nidm:filename">
                         <a>nidm:filename</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range xsd:string)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li> 
                         <li><span class="attribute" id="nidm:DesignMatrix.nidm:visualisation">
                         <dfn>nidm:visualisation</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> graphical representation of an entity. (range nidm:Image)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> graphical representation of an entity. (range <a>nidm:Image</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>entity(niiri:design_matrix_id,
@@ -556,7 +879,36 @@
       dct:format = "text/csv",
       nidm:filename = "DesignMatrix.csv",
       nidm:visualisation = 'niiri:design_matrix_png_id',
-      prov:label = "Design Matrix" %% xsd:string])</pre>  
+      prov:label = "Design Matrix" %% xsd:string])</pre>
+            <!-- nidm:Image -->
+            <section id="section-nidm:Image"> 
+                <h1 label="nidm:Image">nidm:Image</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:Image</dfn>                    <sup><a title="nidm:Image">                    <span class="diamond">&#9826;</span></a></sup> is fIXME. <a>nidm:Image</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:Image"> A <a>nidm:Image</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:Image.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:Image.</li>
+                     
+                        <li><span class="attribute" id="nidm:Image.nidm:filename">
+                        <a>nidm:filename</a>
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li>        
+                </ul>
+                </div>
+                <pre class='example highlight'>entity(niiri:design_matrix_png_id,
+      [prov:type = 'nidm:Image',
+      prov:location = "file:///path/to/DesignMatrix.png" %% xsd:anyURI,
+      nidm:filename = "DesignMatrix.png",
+      dct:format = "image/png"])</pre>        
+                </ul>
+                </div>
+                <pre class='example highlight'>entity(niiri:maximum_intensity_projection_id,
+      [prov:type = 'nidm:Image',
+      prov:location = "file:///path/to/MaximumIntensityProjection.png" %% xsd:anyURI,
+      nidm:filename = "MaximumIntensityProjection.png" %% xsd:string,
+      dct:format = "image/png"])</pre>  
+            </section>  
             </section>
             <!-- nidm:GrandMeanMap -->
             <section id="section-nidm:GrandMeanMap"> 
@@ -567,20 +919,20 @@
                 <p></p>
                 <div class="attributes" id="attributes-nidm:GrandMeanMap"> A <a>nidm:GrandMeanMap</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:GrandMeanMap.label">prov:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:GrandMeanMap.</li>
+                    <li><span class="attribute" id="nidm:GrandMeanMap.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:GrandMeanMap.</li>
                      
                         <li><span class="attribute" id="nidm:GrandMeanMap.nidm:atCoordinateSpace">
                         <a>nidm:atCoordinateSpace</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range nidm:CoordinateSpace)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range <a>nidm:CoordinateSpace</a>)</li> 
                         <li><span class="attribute" id="nidm:GrandMeanMap.nidm:filename">
                         <a>nidm:filename</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range xsd:string)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li> 
                         <li><span class="attribute" id="nidm:GrandMeanMap.nidm:hasMapHeader">
                         <a>nidm:hasMapHeader</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range nidm:MapHeader)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a>nidm:MapHeader</a>)</li> 
                         <li><span class="attribute" id="nidm:GrandMeanMap.nidm:maskedMedian">
                         <dfn>nidm:maskedMedian</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> median value considering only in-mask voxels. Useful diagnostic when computed on grand mean image when grandMeanScaling is TRUE, as the median should be close to targetIntensity. (range xsd:float)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> median value considering only in-mask voxels. Useful diagnostic when computed on grand mean image when grandMeanScaling is TRUE, as the median should be close to targetIntensity. (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>entity(niiri:grand_mean_map_id,
@@ -602,17 +954,17 @@
                 <p></p>
                 <div class="attributes" id="attributes-nidm:MaskMap"> A <a>nidm:MaskMap</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:MaskMap.label">prov:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:MaskMap.</li>
+                    <li><span class="attribute" id="nidm:MaskMap.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:MaskMap.</li>
                      
                         <li><span class="attribute" id="nidm:MaskMap.nidm:atCoordinateSpace">
                         <a>nidm:atCoordinateSpace</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range nidm:CoordinateSpace)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range <a>nidm:CoordinateSpace</a>)</li> 
                         <li><span class="attribute" id="nidm:MaskMap.nidm:filename">
                         <a>nidm:filename</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range xsd:string)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li> 
                         <li><span class="attribute" id="nidm:MaskMap.nidm:hasMapHeader">
                         <a>nidm:hasMapHeader</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range nidm:MapHeader)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a>nidm:MapHeader</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>entity(niiri:mask_id_2,
@@ -633,23 +985,23 @@
                 <p></p>
                 <div class="attributes" id="attributes-nidm:NoiseModel"> A <a>nidm:NoiseModel</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:NoiseModel.label">prov:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:NoiseModel.</li>
+                    <li><span class="attribute" id="nidm:NoiseModel.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:NoiseModel.</li>
                      
                         <li><span class="attribute" id="nidm:NoiseModel.nidm:dependenceSpatialModel">
                         <dfn>nidm:dependenceSpatialModel</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range nidm:SpatialModel, nidm:SpatiallyGlobalModel, nidm:SpatiallyLocalModel, nidm:SpatiallyRegularizedModel)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a>nidm:SpatialModel</a>, <a>nidm:SpatiallyGlobalModel</a>, <a>nidm:SpatiallyLocalModel</a> and <a>nidm:SpatiallyRegularizedModel</a>)</li> 
                         <li><span class="attribute" id="nidm:NoiseModel.nidm:hasNoiseDependence">
                         <dfn>nidm:hasNoiseDependence</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range nidm:ArbitrarilyCorrelatedNoise, nidm:CompoundSymmetricNoise, nidm:ExchangeableNoise, nidm:IndependentNoise, nidm:NoiseDependence, nidm:SeriallyCorrelatedNoise)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a>nidm:ArbitrarilyCorrelatedNoise</a>, <a>nidm:CompoundSymmetricNoise</a>, <a>nidm:ExchangeableNoise</a>, <a>nidm:IndependentNoise</a>, <a>nidm:NoiseDependence</a> and <a>nidm:SeriallyCorrelatedNoise</a>)</li> 
                         <li><span class="attribute" id="nidm:NoiseModel.nidm:hasNoiseDistribution">
                         <dfn>nidm:hasNoiseDistribution</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range fsl:BinomialDistribution, fsl:NonParametricSymmetricDistribution, nidm:GaussianDistribution, nidm:NoiseDistribution, nidm:NonParametricDistribution, nidm:PoissonDistribution)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a>nidm:BinomialDistribution</a>, <a>nidm:GaussianDistribution</a>, <a>nidm:NoiseDistribution</a>, <a>nidm:NonParametricDistribution</a>, <a>nidm:NonParametricSymmetricDistribution</a> and <a>nidm:PoissonDistribution</a>)</li> 
                         <li><span class="attribute" id="nidm:NoiseModel.nidm:noiseVarianceHomogeneous">
                         <dfn>nidm:noiseVarianceHomogeneous</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range xsd:boolean)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a title="xsd:boolean" href="http://www.w3.org/2001/XMLSchema#boolean">xsd:boolean</a>)</li> 
                         <li><span class="attribute" id="nidm:NoiseModel.nidm:varianceSpatialModel">
                         <dfn>nidm:varianceSpatialModel</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range nidm:SpatialModel, nidm:SpatiallyGlobalModel, nidm:SpatiallyLocalModel, nidm:SpatiallyRegularizedModel)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a>nidm:SpatialModel</a>, <a>nidm:SpatiallyGlobalModel</a>, <a>nidm:SpatiallyLocalModel</a> and <a>nidm:SpatiallyRegularizedModel</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>entity(niiri:noise_model_id,
@@ -658,7 +1010,199 @@
       nidm:noiseVarianceHomogeneous = "true" %%xsd:boolean,
       nidm:varianceSpatialModel = 'nidm:SpatiallyLocal',
       nidm:hasNoiseDependence = 'nidm:IndependentNoise',
-      nidm:dependenceSpatialModel = 'nidm:SpatiallyLocal'])</pre>  
+      nidm:dependenceSpatialModel = 'nidm:SpatiallyLocal'])</pre>
+            <!-- nidm:SpatialModel -->
+            <section id="section-nidm:SpatialModel"> 
+                <h1 label="nidm:SpatialModel">nidm:SpatialModel</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:SpatialModel</dfn>                    <sup><a title="nidm:SpatialModel">                    <span class="diamond">&#9826;</span></a></sup> is fIXME. <a>nidm:SpatialModel</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:SpatialModel"> A <a>nidm:SpatialModel</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:SpatialModel.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:SpatialModel.</li>
+                      
+            </section>
+            <!-- nidm:SpatiallyGlobalModel -->
+            <section id="section-nidm:SpatiallyGlobalModel"> 
+                <h1 label="nidm:SpatiallyGlobalModel">nidm:SpatiallyGlobalModel</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:SpatiallyGlobalModel</dfn>                    <sup><a title="nidm:SpatiallyGlobalModel">                    <span class="diamond">&#9826;</span></a></sup> is fIXME. <a>nidm:SpatiallyGlobalModel</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:SpatiallyGlobalModel"> A <a>nidm:SpatiallyGlobalModel</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:SpatiallyGlobalModel.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:SpatiallyGlobalModel.</li>
+                      
+            </section>
+            <!-- nidm:SpatiallyLocalModel -->
+            <section id="section-nidm:SpatiallyLocalModel"> 
+                <h1 label="nidm:SpatiallyLocalModel">nidm:SpatiallyLocalModel</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:SpatiallyLocalModel</dfn>                    <sup><a title="nidm:SpatiallyLocalModel">                    <span class="diamond">&#9826;</span></a></sup> is fIXME. <a>nidm:SpatiallyLocalModel</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:SpatiallyLocalModel"> A <a>nidm:SpatiallyLocalModel</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:SpatiallyLocalModel.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:SpatiallyLocalModel.</li>
+                      
+            </section>
+            <!-- nidm:SpatiallyRegularizedModel -->
+            <section id="section-nidm:SpatiallyRegularizedModel"> 
+                <h1 label="nidm:SpatiallyRegularizedModel">nidm:SpatiallyRegularizedModel</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:SpatiallyRegularizedModel</dfn>                    <sup><a title="nidm:SpatiallyRegularizedModel">                    <span class="diamond">&#9826;</span></a></sup> is fIXME. <a>nidm:SpatiallyRegularizedModel</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:SpatiallyRegularizedModel"> A <a>nidm:SpatiallyRegularizedModel</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:SpatiallyRegularizedModel.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:SpatiallyRegularizedModel.</li>
+                      
+            </section>
+            <!-- nidm:ArbitrarilyCorrelatedNoise -->
+            <section id="section-nidm:ArbitrarilyCorrelatedNoise"> 
+                <h1 label="nidm:ArbitrarilyCorrelatedNoise">nidm:ArbitrarilyCorrelatedNoise</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:ArbitrarilyCorrelatedNoise</dfn>                    <sup><a title="nidm:ArbitrarilyCorrelatedNoise">                    <span class="diamond">&#9826;</span></a></sup> is fIXME. <a>nidm:ArbitrarilyCorrelatedNoise</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:ArbitrarilyCorrelatedNoise"> A <a>nidm:ArbitrarilyCorrelatedNoise</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:ArbitrarilyCorrelatedNoise.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:ArbitrarilyCorrelatedNoise.</li>
+                      
+            </section>
+            <!-- nidm:CompoundSymmetricNoise -->
+            <section id="section-nidm:CompoundSymmetricNoise"> 
+                <h1 label="nidm:CompoundSymmetricNoise">nidm:CompoundSymmetricNoise</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:CompoundSymmetricNoise</dfn>                    <sup><a title="nidm:CompoundSymmetricNoise">                    <span class="diamond">&#9826;</span></a></sup> is fIXME. <a>nidm:CompoundSymmetricNoise</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:CompoundSymmetricNoise"> A <a>nidm:CompoundSymmetricNoise</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:CompoundSymmetricNoise.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:CompoundSymmetricNoise.</li>
+                      
+            </section>
+            <!-- nidm:ExchangeableNoise -->
+            <section id="section-nidm:ExchangeableNoise"> 
+                <h1 label="nidm:ExchangeableNoise">nidm:ExchangeableNoise</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:ExchangeableNoise</dfn>                    <sup><a title="nidm:ExchangeableNoise">                    <span class="diamond">&#9826;</span></a></sup> is fIXME. <a>nidm:ExchangeableNoise</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:ExchangeableNoise"> A <a>nidm:ExchangeableNoise</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:ExchangeableNoise.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:ExchangeableNoise.</li>
+                      
+            </section>
+            <!-- nidm:IndependentNoise -->
+            <section id="section-nidm:IndependentNoise"> 
+                <h1 label="nidm:IndependentNoise">nidm:IndependentNoise</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:IndependentNoise</dfn>                    <sup><a title="nidm:IndependentNoise">                    <span class="diamond">&#9826;</span></a></sup> is fIXME. <a>nidm:IndependentNoise</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:IndependentNoise"> A <a>nidm:IndependentNoise</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:IndependentNoise.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:IndependentNoise.</li>
+                      
+            </section>
+            <!-- nidm:NoiseDependence -->
+            <section id="section-nidm:NoiseDependence"> 
+                <h1 label="nidm:NoiseDependence">nidm:NoiseDependence</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:NoiseDependence</dfn>                    <sup><a title="nidm:NoiseDependence">                    <span class="diamond">&#9826;</span></a></sup> is fIXME. <a>nidm:NoiseDependence</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:NoiseDependence"> A <a>nidm:NoiseDependence</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:NoiseDependence.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:NoiseDependence.</li>
+                      
+            </section>
+            <!-- nidm:SeriallyCorrelatedNoise -->
+            <section id="section-nidm:SeriallyCorrelatedNoise"> 
+                <h1 label="nidm:SeriallyCorrelatedNoise">nidm:SeriallyCorrelatedNoise</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:SeriallyCorrelatedNoise</dfn>                    <sup><a title="nidm:SeriallyCorrelatedNoise">                    <span class="diamond">&#9826;</span></a></sup> is fIXME. <a>nidm:SeriallyCorrelatedNoise</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:SeriallyCorrelatedNoise"> A <a>nidm:SeriallyCorrelatedNoise</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:SeriallyCorrelatedNoise.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:SeriallyCorrelatedNoise.</li>
+                      
+            </section>
+            <!-- nidm:BinomialDistribution -->
+            <section id="section-nidm:BinomialDistribution"> 
+                <h1 label="nidm:BinomialDistribution">nidm:BinomialDistribution</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:BinomialDistribution</dfn>                    <sup><a title="nidm:BinomialDistribution">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidm:BinomialDistribution</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:BinomialDistribution"> A <a>nidm:BinomialDistribution</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:BinomialDistribution.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:BinomialDistribution.</li>
+                      
+            </section>
+            <!-- nidm:GaussianDistribution -->
+            <section id="section-nidm:GaussianDistribution"> 
+                <h1 label="nidm:GaussianDistribution">nidm:GaussianDistribution</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:GaussianDistribution</dfn>                    <sup><a title="nidm:GaussianDistribution">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidm:GaussianDistribution</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:GaussianDistribution"> A <a>nidm:GaussianDistribution</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:GaussianDistribution.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:GaussianDistribution.</li>
+                      
+            </section>
+            <!-- nidm:NoiseDistribution -->
+            <section id="section-nidm:NoiseDistribution"> 
+                <h1 label="nidm:NoiseDistribution">nidm:NoiseDistribution</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:NoiseDistribution</dfn>                    <sup><a title="nidm:NoiseDistribution">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidm:NoiseDistribution</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:NoiseDistribution"> A <a>nidm:NoiseDistribution</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:NoiseDistribution.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:NoiseDistribution.</li>
+                      
+            </section>
+            <!-- nidm:NonParametricDistribution -->
+            <section id="section-nidm:NonParametricDistribution"> 
+                <h1 label="nidm:NonParametricDistribution">nidm:NonParametricDistribution</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:NonParametricDistribution</dfn>                    <sup><a title="nidm:NonParametricDistribution">                    <span class="diamond">&#9826;</span></a></sup> is fIXME. <a>nidm:NonParametricDistribution</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:NonParametricDistribution"> A <a>nidm:NonParametricDistribution</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:NonParametricDistribution.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:NonParametricDistribution.</li>
+                      
+            </section>
+            <!-- nidm:NonParametricSymmetricDistribution -->
+            <section id="section-nidm:NonParametricSymmetricDistribution"> 
+                <h1 label="nidm:NonParametricSymmetricDistribution">nidm:NonParametricSymmetricDistribution</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:NonParametricSymmetricDistribution</dfn>                    <sup><a title="nidm:NonParametricSymmetricDistribution">                    <span class="diamond">&#9826;</span></a></sup> is fIXME. <a>nidm:NonParametricSymmetricDistribution</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:NonParametricSymmetricDistribution"> A <a>nidm:NonParametricSymmetricDistribution</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:NonParametricSymmetricDistribution.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:NonParametricSymmetricDistribution.</li>
+                      
+            </section>
+            <!-- nidm:PoissonDistribution -->
+            <section id="section-nidm:PoissonDistribution"> 
+                <h1 label="nidm:PoissonDistribution">nidm:PoissonDistribution</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:PoissonDistribution</dfn>                    <sup><a title="nidm:PoissonDistribution">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidm:PoissonDistribution</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:PoissonDistribution"> A <a>nidm:PoissonDistribution</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:PoissonDistribution.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:PoissonDistribution.</li>
+                      
+            </section>  
             </section>
             <!-- nidm:ParameterEstimateMap -->
             <section id="section-nidm:ParameterEstimateMap"> 
@@ -669,17 +1213,17 @@
                 <p></p>
                 <div class="attributes" id="attributes-nidm:ParameterEstimateMap"> A <a>nidm:ParameterEstimateMap</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:ParameterEstimateMap.label">prov:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:ParameterEstimateMap.</li>
+                    <li><span class="attribute" id="nidm:ParameterEstimateMap.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:ParameterEstimateMap.</li>
                      
                         <li><span class="attribute" id="nidm:ParameterEstimateMap.nidm:atCoordinateSpace">
                         <a>nidm:atCoordinateSpace</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range nidm:CoordinateSpace)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range <a>nidm:CoordinateSpace</a>)</li> 
                         <li><span class="attribute" id="nidm:ParameterEstimateMap.nidm:filename">
                         <a>nidm:filename</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range xsd:string)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li> 
                         <li><span class="attribute" id="nidm:ParameterEstimateMap.nidm:hasMapHeader">
                         <a>nidm:hasMapHeader</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range nidm:MapHeader)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a>nidm:MapHeader</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>entity(niiri:parameter_estimate_map_id_1,
@@ -701,17 +1245,17 @@
                 <p></p>
                 <div class="attributes" id="attributes-nidm:ResidualMeanSquaresMap"> A <a>nidm:ResidualMeanSquaresMap</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:ResidualMeanSquaresMap.label">prov:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:ResidualMeanSquaresMap.</li>
+                    <li><span class="attribute" id="nidm:ResidualMeanSquaresMap.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:ResidualMeanSquaresMap.</li>
                      
                         <li><span class="attribute" id="nidm:ResidualMeanSquaresMap.nidm:atCoordinateSpace">
                         <a>nidm:atCoordinateSpace</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range nidm:CoordinateSpace)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range <a>nidm:CoordinateSpace</a>)</li> 
                         <li><span class="attribute" id="nidm:ResidualMeanSquaresMap.nidm:filename">
                         <a>nidm:filename</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range xsd:string)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li> 
                         <li><span class="attribute" id="nidm:ResidualMeanSquaresMap.nidm:hasMapHeader">
                         <a>nidm:hasMapHeader</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range nidm:MapHeader)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a>nidm:MapHeader</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>entity(niiri:residual_mean_squares_map_id,
@@ -723,6 +1267,219 @@
       nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])</pre>  
             </section>
+            </section>
+        <section><h1>Contrast estimation</h1>
+        <div style="text-align: left;">
+            <table class="thinborder" style="margin-left: auto; margin-right: auto;">
+                <caption id="overview-types-and-relations"><span>Table 2<sup>                <a class="internalDFN" href="#overview-types-and-relations">                <span class="diamond"> &#9826;:</span></a></sup> </span>                Mapping of NIDM-Results Contrast estimation Core Concepts to types and relations                 and PROV core concepts</caption>                 <!-- Table 2 -->
+                <tbody>
+                    <tr>
+                        <td><b>NIDM-Results Concepts</b></td>
+                        <td><b>Types or Relation (PROV concepts)</b></td>
+                        <td><b>Name</b></td>
+                    </tr>
+        
+        <!-- HERE ------------- Beginning of PROV Entities ------------- -->
+        
+                        <tr>
+                            <td><a title="nidm:ContrastEstimation">nidm:ContrastEstimation</a>
+                            </td>
+                    
+                                <td rowspan="1" style="text-align: center;">NIDM-Results Types<br/>                                 (PROV Activity)</td>
+                        
+                                <td><a>nidm:ContrastEstimation</a></td>
+                            </tr>
+                
+                        <tr>
+                            <td><a title="nidm:ContrastMap">nidm:ContrastMap</a>
+                            </td>
+                    
+                                <td rowspan="4" style="text-align: center;">NIDM-Results Types<br/>                                 (PROV Entity)</td>
+                        
+                                <td><a>nidm:ContrastMap</a></td>
+                            </tr>
+                
+                        <tr>
+                            <td><a title="nidm:ContrastStandardErrorMap">nidm:ContrastStandardErrorMap</a>
+                            </td>
+                    
+                                <td><a>nidm:ContrastStandardErrorMap</a></td>
+                            </tr>
+                
+                        <tr>
+                            <td><a title="nidm:ContrastWeights">nidm:ContrastWeights</a>
+                            </td>
+                    
+                                <td><a>nidm:ContrastWeights</a></td>
+                            </tr>
+                
+                        <tr>
+                            <td><a title="nidm:StatisticMap">nidm:StatisticMap</a>
+                            </td>
+                    
+                                <td><a>nidm:StatisticMap</a></td>
+                            </tr>
+                
+                </tbody>
+                </table>
+            </div>
+            <!-- nidm:ContrastEstimation -->
+            <section id="section-nidm:ContrastEstimation"> 
+                <h1 label="nidm:ContrastEstimation">nidm:ContrastEstimation</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:ContrastEstimation</dfn>                    <sup><a title="nidm:ContrastEstimation">                    <span class="diamond">&#9826;</span></a></sup> is the process of estimating a contrast from the estimated parameters of statistical model. <a>nidm:ContrastEstimation</a> is a prov:Activity that uses <a>nidm:ContrastWeights</a>, <a>nidm:DesignMatrix</a>, <a>nidm:MaskMap</a>, <a>nidm:ParameterEstimateMap</a> and <a>nidm:ResidualMeanSquaresMap</a> entities. This activity generates <a>nidm:ContrastMap</a>, <a>nidm:ContrastStandardErrorMap</a> and <a>nidm:StatisticMap</a> entities. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:ContrastEstimation"> A <a>nidm:ContrastEstimation</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:ContrastEstimation.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:ContrastEstimation.</li>
+                            
+                </ul>
+                </div>
+                <pre class='example highlight'>activity(niiri:contrast_estimation_id,
+      [prov:type = 'nidm:ContrastEstimation',
+      prov:label = "Contrast estimation"])</pre>  
+            </section>
+            <!-- nidm:ContrastMap -->
+            <section id="section-nidm:ContrastMap"> 
+                <h1 label="nidm:ContrastMap">nidm:ContrastMap</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:ContrastMap</dfn>                    <sup><a title="nidm:ContrastMap">                    <span class="diamond">&#9826;</span></a></sup> is a map whose value at each location is statistical contrast estimate. <a>nidm:ContrastMap</a> is a prov:Entity used by <a>nidm:Inference</a> and  generated by <a>nidm:ContrastEstimation</a>. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:ContrastMap"> A <a>nidm:ContrastMap</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:ContrastMap.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:ContrastMap.</li>
+                     
+                        <li><span class="attribute" id="nidm:ContrastMap.nidm:atCoordinateSpace">
+                        <a>nidm:atCoordinateSpace</a>
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range <a>nidm:CoordinateSpace</a>)</li> 
+                        <li><span class="attribute" id="nidm:ContrastMap.nidm:contrastName">
+                        <dfn>nidm:contrastName</dfn>
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> name of the contrast. (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li> 
+                        <li><span class="attribute" id="nidm:ContrastMap.nidm:filename">
+                        <a>nidm:filename</a>
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li> 
+                        <li><span class="attribute" id="nidm:ContrastMap.nidm:hasMapHeader">
+                        <a>nidm:hasMapHeader</a>
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a>nidm:MapHeader</a>)</li>        
+                </ul>
+                </div>
+                <pre class='example highlight'>entity(niiri:contrast_map_id,
+      [prov:type = 'nidm:ContrastMap',
+      prov:location = "file:///path/to/Contrast.nii.gz" %% xsd:anyURI,
+      dct:format = "image/nifti",
+      nidm:filename = "Contrast.nii.gz" %% xsd:string,
+      prov:label = "Contrast Map: listening > rest" %% xsd:string,
+      nidm:contrastName = "listening > rest" %% xsd:string,
+      nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+      crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])</pre>  
+            </section>
+            <!-- nidm:ContrastStandardErrorMap -->
+            <section id="section-nidm:ContrastStandardErrorMap"> 
+                <h1 label="nidm:ContrastStandardErrorMap">nidm:ContrastStandardErrorMap</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:ContrastStandardErrorMap</dfn>                    <sup><a title="nidm:ContrastStandardErrorMap">                    <span class="diamond">&#9826;</span></a></sup> is a map whose value at each location is the standard error of a given contrast. <a>nidm:ContrastStandardErrorMap</a> is a prov:Entity generated by <a>nidm:ContrastEstimation</a>. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:ContrastStandardErrorMap"> A <a>nidm:ContrastStandardErrorMap</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:ContrastStandardErrorMap.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:ContrastStandardErrorMap.</li>
+                     
+                        <li><span class="attribute" id="nidm:ContrastStandardErrorMap.nidm:atCoordinateSpace">
+                        <a>nidm:atCoordinateSpace</a>
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range <a>nidm:CoordinateSpace</a>)</li> 
+                        <li><span class="attribute" id="nidm:ContrastStandardErrorMap.nidm:filename">
+                        <a>nidm:filename</a>
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li> 
+                        <li><span class="attribute" id="nidm:ContrastStandardErrorMap.nidm:hasMapHeader">
+                        <a>nidm:hasMapHeader</a>
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a>nidm:MapHeader</a>)</li>        
+                </ul>
+                </div>
+                <pre class='example highlight'>entity(niiri:contrast_standard_error_map_id,
+      [prov:type = 'nidm:ContrastStandardErrorMap',
+      prov:location = "file:///path/to/ContrastStandardError.nii.gz" %% xsd:anyURI,
+      nidm:filename = "ContrastStandardError.nii.gz" %% xsd:string,
+      dct:format = "image/nifti",
+      prov:label = "Contrast Standard Error Map" %% xsd:string,
+      nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
+      crypto:sha512 = "e43b6e01b0463fe7d40782137867a..." %% xsd:string])</pre>  
+            </section>
+            <!-- nidm:ContrastWeights -->
+            <section id="section-nidm:ContrastWeights"> 
+                <h1 label="nidm:ContrastWeights">nidm:ContrastWeights</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:ContrastWeights</dfn>                    <sup><a title="nidm:ContrastWeights">                    <span class="diamond">&#9826;</span></a></sup> is vector defining the linear combination associated with a particular contrast. . <a>nidm:ContrastWeights</a> is a prov:Entity used by <a>nidm:ContrastEstimation</a>. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:ContrastWeights"> A <a>nidm:ContrastWeights</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:ContrastWeights.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:ContrastWeights.</li>
+                     
+                        <li><span class="attribute" id="nidm:ContrastWeights.nidm:contrastName">
+                        <a>nidm:contrastName</a>
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> name of the contrast. (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li> 
+                        <li><span class="attribute" id="nidm:ContrastWeights.nidm:statisticType">
+                        <dfn>nidm:statisticType</dfn>
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a>nidm:FStatistic</a>, <a>nidm:Statistic</a>, <a>nidm:TStatistic</a> and <a>nidm:ZStatistic</a>)</li>        
+                </ul>
+                </div>
+                <pre class='example highlight'>entity(niiri:contrast_weights_id,
+      [prov:type = 'nidm:ContrastWeights',
+      nidm:statisticType = 'nidm:TStatistic',
+      nidm:contrastName = "listening > rest" %% xsd:string,
+      prov:label = "Contrast: Listening > Rest" %% xsd:string,
+      prov:value = "[1, 0, 0]" %% xsd:string])</pre>
+            <!-- nidm:FStatistic -->
+            <section id="section-nidm:FStatistic"> 
+                <h1 label="nidm:FStatistic">nidm:FStatistic</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:FStatistic</dfn>                    <sup><a title="nidm:FStatistic">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidm:FStatistic</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:FStatistic"> A <a>nidm:FStatistic</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:FStatistic.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:FStatistic.</li>
+                      
+            </section>
+            <!-- nidm:Statistic -->
+            <section id="section-nidm:Statistic"> 
+                <h1 label="nidm:Statistic">nidm:Statistic</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:Statistic</dfn>                    <sup><a title="nidm:Statistic">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidm:Statistic</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:Statistic"> A <a>nidm:Statistic</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:Statistic.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:Statistic.</li>
+                      
+            </section>
+            <!-- nidm:TStatistic -->
+            <section id="section-nidm:TStatistic"> 
+                <h1 label="nidm:TStatistic">nidm:TStatistic</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:TStatistic</dfn>                    <sup><a title="nidm:TStatistic">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidm:TStatistic</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:TStatistic"> A <a>nidm:TStatistic</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:TStatistic.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:TStatistic.</li>
+                      
+            </section>
+            <!-- nidm:ZStatistic -->
+            <section id="section-nidm:ZStatistic"> 
+                <h1 label="nidm:ZStatistic">nidm:ZStatistic</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:ZStatistic</dfn>                    <sup><a title="nidm:ZStatistic">                    <span class="diamond">&#9826;</span></a></sup> is fIXME. <a>nidm:ZStatistic</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:ZStatistic"> A <a>nidm:ZStatistic</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:ZStatistic.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:ZStatistic.</li>
+                      
+            </section>  
+            </section>
             <!-- nidm:StatisticMap -->
             <section id="section-nidm:StatisticMap"> 
                 <h1 label="nidm:StatisticMap">nidm:StatisticMap</h1>
@@ -732,29 +1489,29 @@
                 <p></p>
                 <div class="attributes" id="attributes-nidm:StatisticMap"> A <a>nidm:StatisticMap</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:StatisticMap.label">prov:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:StatisticMap.</li>
+                    <li><span class="attribute" id="nidm:StatisticMap.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:StatisticMap.</li>
                      
                         <li><span class="attribute" id="nidm:StatisticMap.nidm:atCoordinateSpace">
                         <a>nidm:atCoordinateSpace</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range nidm:CoordinateSpace)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range <a>nidm:CoordinateSpace</a>)</li> 
                         <li><span class="attribute" id="nidm:StatisticMap.nidm:contrastName">
                         <a>nidm:contrastName</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> name of the contrast. (range xsd:string)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> name of the contrast. (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li> 
                         <li><span class="attribute" id="nidm:StatisticMap.nidm:effectDegreesOfFreedom">
                         <dfn>nidm:effectDegreesOfFreedom</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> degrees of freedom of the effect. (range xsd:float)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> degrees of freedom of the effect. (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li> 
                         <li><span class="attribute" id="nidm:StatisticMap.nidm:errorDegreesOfFreedom">
                         <dfn>nidm:errorDegreesOfFreedom</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> degrees of freedom of the error. (range xsd:float)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> degrees of freedom of the error. (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li> 
                         <li><span class="attribute" id="nidm:StatisticMap.nidm:filename">
                         <a>nidm:filename</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range xsd:string)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li> 
                         <li><span class="attribute" id="nidm:StatisticMap.nidm:hasMapHeader">
                         <a>nidm:hasMapHeader</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range nidm:MapHeader)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a>nidm:MapHeader</a>)</li> 
                         <li><span class="attribute" id="nidm:StatisticMap.nidm:statisticType">
                         <a>nidm:statisticType</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range nidm:FStatistic, nidm:Statistic, nidm:TStatistic, nidm:ZStatistic)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a>nidm:FStatistic</a>, <a>nidm:Statistic</a>, <a>nidm:TStatistic</a> and <a>nidm:ZStatistic</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>entity(niiri:statistic_map_id,
@@ -858,25 +1615,49 @@
             <section id="section-nidm:Inference"> 
                 <h1 label="nidm:Inference">nidm:Inference</h1>
                 <div class="glossary-ref">
-                    A <dfn>nidm:Inference</dfn>                    <sup><a title="nidm:Inference">                    <span class="diamond">&#9826;</span></a></sup> is the process of inferring the excursion set from a statistical map. <a>nidm:Inference</a> is a prov:Activity that uses <a>nidm:ContrastMap</a> and <a>nidm:StatisticMap</a> entities. 
+                    A <dfn>nidm:Inference</dfn>                    <sup><a title="nidm:Inference">                    <span class="diamond">&#9826;</span></a></sup> is the process of inferring the excursion set from a statistical map. <a>nidm:Inference</a> is a prov:Activity that uses <a>nidm:ClusterDefinitionCriteria</a>, <a>nidm:ContrastMap</a>, <a>nidm:DisplayMaskMap</a>, <a>nidm:PeakDefinitionCriteria</a> and <a>nidm:StatisticMap</a> entities. 
                 </div>
                 <p></p>
                 <div class="attributes" id="attributes-nidm:Inference"> A <a>nidm:Inference</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:Inference.label">prov:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:Inference.</li>
+                    <li><span class="attribute" id="nidm:Inference.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:Inference.</li>
                      
                         <li><span class="attribute" id="nidm:Inference.nidm:alternativeHypothesis">
                         <dfn>nidm:alternativeHypothesis</dfn>
                         </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME.</li> 
                         <li><span class="attribute" id="nidm:Inference.nidm:hasAlternativeHypothesis">
                         <dfn>nidm:hasAlternativeHypothesis</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range nidm:OneTailedTest, nidm:TwoTailedTest)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a>nidm:OneTailedTest</a> and <a>nidm:TwoTailedTest</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>activity(niiri:inference_id,
       [prov:type = 'nidm:Inference',
       nidm:hasAlternativeHypothesis = 'nidm:OneTailedTest',
-      prov:label = "Inference"])</pre>  
+      prov:label = "Inference"])</pre>
+            <!-- nidm:OneTailedTest -->
+            <section id="section-nidm:OneTailedTest"> 
+                <h1 label="nidm:OneTailedTest">nidm:OneTailedTest</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:OneTailedTest</dfn>                    <sup><a title="nidm:OneTailedTest">                    <span class="diamond">&#9826;</span></a></sup> is re-use "one tailed test" from STATO. <a>nidm:OneTailedTest</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:OneTailedTest"> A <a>nidm:OneTailedTest</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:OneTailedTest.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:OneTailedTest.</li>
+                      
+            </section>
+            <!-- nidm:TwoTailedTest -->
+            <section id="section-nidm:TwoTailedTest"> 
+                <h1 label="nidm:TwoTailedTest">nidm:TwoTailedTest</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:TwoTailedTest</dfn>                    <sup><a title="nidm:TwoTailedTest">                    <span class="diamond">&#9826;</span></a></sup> is re-use "two tailed test" from STATO. <a>nidm:TwoTailedTest</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:TwoTailedTest"> A <a>nidm:TwoTailedTest</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:TwoTailedTest.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:TwoTailedTest.</li>
+                      
+            </section>  
             </section>
             <!-- nidm:Cluster -->
             <section id="section-nidm:Cluster"> 
@@ -887,26 +1668,26 @@
                 <p></p>
                 <div class="attributes" id="attributes-nidm:Cluster"> A <a>nidm:Cluster</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:Cluster.label">prov:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:Cluster.</li>
+                    <li><span class="attribute" id="nidm:Cluster.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:Cluster.</li>
                      
                         <li><span class="attribute" id="nidm:Cluster.nidm:clusterLabelId">
                         <dfn>nidm:clusterLabelId</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> integer associated with a particular cluster as specified in the clusterLabelsMap. (range xsd:int)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> integer associated with a particular cluster as specified in the clusterLabelsMap. (range <a title="xsd:int" href="http://www.w3.org/2001/XMLSchema#int">xsd:int</a>)</li> 
                         <li><span class="attribute" id="nidm:Cluster.nidm:clusterSizeInVertices">
                         <dfn>nidm:clusterSizeInVertices</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> number of vertices that make up the cluster. (range xsd:positiveInteger)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> number of vertices that make up the cluster. (range <a title="xsd:positiveInteger" href="http://www.w3.org/2001/XMLSchema#positiveInteger">xsd:positiveInteger</a>)</li> 
                         <li><span class="attribute" id="nidm:Cluster.nidm:clusterSizeInVoxels">
                         <dfn>nidm:clusterSizeInVoxels</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> number of voxels that make up the cluster. (range xsd:positiveInteger)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> number of voxels that make up the cluster. (range <a title="xsd:positiveInteger" href="http://www.w3.org/2001/XMLSchema#positiveInteger">xsd:positiveInteger</a>)</li> 
                         <li><span class="attribute" id="nidm:Cluster.nidm:pValueFWER">
                         <dfn>nidm:pValueFWER</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> "A quantitative confidence value resulting from a multiple testing error correction method which adjusts the p-value used as input to control for Type I error in the context of multiple pairwise tests". (range xsd:float)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> "A quantitative confidence value resulting from a multiple testing error correction method which adjusts the p-value used as input to control for Type I error in the context of multiple pairwise tests". (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li> 
                         <li><span class="attribute" id="nidm:Cluster.nidm:pValueUncorrected">
                         <dfn>nidm:pValueUncorrected</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a p-value reported without correction for multiple testing.        . (range xsd:float)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a p-value reported without correction for multiple testing.        . (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li> 
                         <li><span class="attribute" id="nidm:Cluster.nidm:qValueFDR">
                         <dfn>nidm:qValueFDR</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> p-value adjusted for the multiple testing, controlling for the False Discovery Rate. (range xsd:float)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> p-value adjusted for the multiple testing, controlling for the False Discovery Rate. (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>entity(niiri:cluster_0001,
@@ -928,17 +1709,17 @@
                 <p></p>
                 <div class="attributes" id="attributes-nidm:ClusterLabelsMap"> A <a>nidm:ClusterLabelsMap</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:ClusterLabelsMap.label">prov:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:ClusterLabelsMap.</li>
+                    <li><span class="attribute" id="nidm:ClusterLabelsMap.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:ClusterLabelsMap.</li>
                      
                         <li><span class="attribute" id="nidm:ClusterLabelsMap.nidm:atCoordinateSpace">
                         <a>nidm:atCoordinateSpace</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range nidm:CoordinateSpace)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range <a>nidm:CoordinateSpace</a>)</li> 
                         <li><span class="attribute" id="nidm:ClusterLabelsMap.nidm:filename">
                         <a>nidm:filename</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range xsd:string)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li> 
                         <li><span class="attribute" id="nidm:ClusterLabelsMap.nidm:hasMapHeader">
                         <a>nidm:hasMapHeader</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range nidm:MapHeader)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a>nidm:MapHeader</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>entity(niiri:cluster_label_map_id,
@@ -956,17 +1737,17 @@
                 <p></p>
                 <div class="attributes" id="attributes-nidm:Coordinate"> A <a>nidm:Coordinate</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:Coordinate.label">prov:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:Coordinate.</li>
+                    <li><span class="attribute" id="nidm:Coordinate.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:Coordinate.</li>
                      
                         <li><span class="attribute" id="nidm:Coordinate.nidm:coordinate1">
                         <dfn>nidm:coordinate1</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> coordinate along the first dimension in voxel units. (range xsd:float)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> coordinate along the first dimension in voxel units. (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li> 
                         <li><span class="attribute" id="nidm:Coordinate.nidm:coordinate2">
                         <dfn>nidm:coordinate2</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> coordinate along the second dimension in voxel units. (range xsd:float)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> coordinate along the second dimension in voxel units. (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li> 
                         <li><span class="attribute" id="nidm:Coordinate.nidm:coordinate3">
                         <dfn>nidm:coordinate3</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> coordinate along the third dimension in voxel units. (range xsd:float)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> coordinate along the third dimension in voxel units. (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>entity(niiri:coordinate_0001,
@@ -998,32 +1779,32 @@
                 <p></p>
                 <div class="attributes" id="attributes-nidm:ExcursionSet"> A <a>nidm:ExcursionSet</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:ExcursionSet.label">prov:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:ExcursionSet.</li>
+                    <li><span class="attribute" id="nidm:ExcursionSet.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:ExcursionSet.</li>
                      
                         <li><span class="attribute" id="nidm:ExcursionSet.nidm:atCoordinateSpace">
                         <a>nidm:atCoordinateSpace</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range nidm:CoordinateSpace)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range <a>nidm:CoordinateSpace</a>)</li> 
                         <li><span class="attribute" id="nidm:ExcursionSet.nidm:filename">
                         <a>nidm:filename</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range xsd:string)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li> 
                         <li><span class="attribute" id="nidm:ExcursionSet.nidm:hasClusterLabelsMap">
                         <dfn>nidm:hasClusterLabelsMap</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a map whose value at each location denotes cluster membership. Each cluster is denoted by a different integer. (range nidm:ClusterLabelsMap)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a map whose value at each location denotes cluster membership. Each cluster is denoted by a different integer. (range <a>nidm:ClusterLabelsMap</a>)</li> 
                         <li><span class="attribute" id="nidm:ExcursionSet.nidm:hasMapHeader">
                         <a>nidm:hasMapHeader</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range nidm:MapHeader)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a>nidm:MapHeader</a>)</li> 
                         <li><span class="attribute" id="nidm:ExcursionSet.nidm:numberOfClusters">
                         <dfn>nidm:numberOfClusters</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range xsd:int)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a title="xsd:int" href="http://www.w3.org/2001/XMLSchema#int">xsd:int</a>)</li> 
                         <li><span class="attribute" id="nidm:ExcursionSet.nidm:pValue">
                         <dfn>nidm:pValue</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range xsd:float)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li> 
                         <li><span class="attribute" id="nidm:ExcursionSet.nidm:underlayFile">
                         <dfn>nidm:underlayFile</dfn>
                         </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> map or surface on which the associated results are displayed. .</li> 
                         <li><span class="attribute" id="nidm:ExcursionSet.nidm:visualisation">
                         <a>nidm:visualisation</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> graphical representation of an entity. (range nidm:Image)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> graphical representation of an entity. (range <a>nidm:Image</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>entity(niiri:excursion_set_id,
@@ -1049,26 +1830,26 @@
                 <p></p>
                 <div class="attributes" id="attributes-nidm:ExtentThreshold"> A <a>nidm:ExtentThreshold</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:ExtentThreshold.label">prov:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:ExtentThreshold.</li>
+                    <li><span class="attribute" id="nidm:ExtentThreshold.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:ExtentThreshold.</li>
                      
                         <li><span class="attribute" id="nidm:ExtentThreshold.nidm:clusterSizeInVertices">
                         <a>nidm:clusterSizeInVertices</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> number of vertices that make up the cluster. (range xsd:positiveInteger)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> number of vertices that make up the cluster. (range <a title="xsd:positiveInteger" href="http://www.w3.org/2001/XMLSchema#positiveInteger">xsd:positiveInteger</a>)</li> 
                         <li><span class="attribute" id="nidm:ExtentThreshold.nidm:clusterSizeInVoxels">
                         <a>nidm:clusterSizeInVoxels</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> number of voxels that make up the cluster. (range xsd:positiveInteger)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> number of voxels that make up the cluster. (range <a title="xsd:positiveInteger" href="http://www.w3.org/2001/XMLSchema#positiveInteger">xsd:positiveInteger</a>)</li> 
                         <li><span class="attribute" id="nidm:ExtentThreshold.nidm:pValueFWER">
                         <a>nidm:pValueFWER</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> "A quantitative confidence value resulting from a multiple testing error correction method which adjusts the p-value used as input to control for Type I error in the context of multiple pairwise tests". (range xsd:float)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> "A quantitative confidence value resulting from a multiple testing error correction method which adjusts the p-value used as input to control for Type I error in the context of multiple pairwise tests". (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li> 
                         <li><span class="attribute" id="nidm:ExtentThreshold.nidm:pValueUncorrected">
                         <a>nidm:pValueUncorrected</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a p-value reported without correction for multiple testing.        . (range xsd:float)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a p-value reported without correction for multiple testing.        . (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li> 
                         <li><span class="attribute" id="nidm:ExtentThreshold.nidm:qValueFDR">
                         <a>nidm:qValueFDR</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> p-value adjusted for the multiple testing, controlling for the False Discovery Rate. (range xsd:float)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> p-value adjusted for the multiple testing, controlling for the False Discovery Rate. (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li> 
                         <li><span class="attribute" id="nidm:ExtentThreshold.nidm:userSpecifiedThresholdType">
                         <dfn>nidm:userSpecifiedThresholdType</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> type of method used to define a threshold (e.g. statistic value, uncorrected P-value or corrected P-value). (range xsd:string)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> type of method used to define a threshold (e.g. statistic value, uncorrected P-value or corrected P-value). (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>entity(niiri:extent_threshold_id,
@@ -1089,20 +1870,20 @@
                 <p></p>
                 <div class="attributes" id="attributes-nidm:HeightThreshold"> A <a>nidm:HeightThreshold</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:HeightThreshold.label">prov:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:HeightThreshold.</li>
+                    <li><span class="attribute" id="nidm:HeightThreshold.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:HeightThreshold.</li>
                      
                         <li><span class="attribute" id="nidm:HeightThreshold.nidm:pValueFWER">
                         <a>nidm:pValueFWER</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> "A quantitative confidence value resulting from a multiple testing error correction method which adjusts the p-value used as input to control for Type I error in the context of multiple pairwise tests". (range xsd:float)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> "A quantitative confidence value resulting from a multiple testing error correction method which adjusts the p-value used as input to control for Type I error in the context of multiple pairwise tests". (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li> 
                         <li><span class="attribute" id="nidm:HeightThreshold.nidm:pValueUncorrected">
                         <a>nidm:pValueUncorrected</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a p-value reported without correction for multiple testing.        . (range xsd:float)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a p-value reported without correction for multiple testing.        . (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li> 
                         <li><span class="attribute" id="nidm:HeightThreshold.nidm:qValueFDR">
                         <a>nidm:qValueFDR</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> p-value adjusted for the multiple testing, controlling for the False Discovery Rate. (range xsd:float)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> p-value adjusted for the multiple testing, controlling for the False Discovery Rate. (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li> 
                         <li><span class="attribute" id="nidm:HeightThreshold.nidm:userSpecifiedThresholdType">
                         <a>nidm:userSpecifiedThresholdType</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> type of method used to define a threshold (e.g. statistic value, uncorrected P-value or corrected P-value). (range xsd:string)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> type of method used to define a threshold (e.g. statistic value, uncorrected P-value or corrected P-value). (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>entity(niiri:height_threshold_id,
@@ -1122,20 +1903,20 @@
                 <p></p>
                 <div class="attributes" id="attributes-nidm:Peak"> A <a>nidm:Peak</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:Peak.label">prov:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:Peak.</li>
+                    <li><span class="attribute" id="nidm:Peak.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:Peak.</li>
                      
                         <li><span class="attribute" id="nidm:Peak.nidm:equivalentZStatistic">
                         <dfn>nidm:equivalentZStatistic</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> statistic value transformed into Z units; the output of a process which takes a non-normal statistic and transforms it to an equivalent z score. (range xsd:float)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> statistic value transformed into Z units; the output of a process which takes a non-normal statistic and transforms it to an equivalent z score. (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li> 
                         <li><span class="attribute" id="nidm:Peak.nidm:pValueFWER">
                         <a>nidm:pValueFWER</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> "A quantitative confidence value resulting from a multiple testing error correction method which adjusts the p-value used as input to control for Type I error in the context of multiple pairwise tests". (range xsd:float)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> "A quantitative confidence value resulting from a multiple testing error correction method which adjusts the p-value used as input to control for Type I error in the context of multiple pairwise tests". (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li> 
                         <li><span class="attribute" id="nidm:Peak.nidm:pValueUncorrected">
                         <a>nidm:pValueUncorrected</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a p-value reported without correction for multiple testing.        . (range xsd:float)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a p-value reported without correction for multiple testing.        . (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li> 
                         <li><span class="attribute" id="nidm:Peak.nidm:qValueFDR">
                         <a>nidm:qValueFDR</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> p-value adjusted for the multiple testing, controlling for the False Discovery Rate. (range xsd:float)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> p-value adjusted for the multiple testing, controlling for the False Discovery Rate. (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>entity(niiri:peak_0001,
@@ -1157,20 +1938,20 @@
                 <p></p>
                 <div class="attributes" id="attributes-nidm:SearchSpaceMap"> A <a>nidm:SearchSpaceMap</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:SearchSpaceMap.label">prov:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:SearchSpaceMap.</li>
+                    <li><span class="attribute" id="nidm:SearchSpaceMap.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:SearchSpaceMap.</li>
                      
                         <li><span class="attribute" id="nidm:SearchSpaceMap.nidm:atCoordinateSpace">
                         <a>nidm:atCoordinateSpace</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range nidm:CoordinateSpace)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range <a>nidm:CoordinateSpace</a>)</li> 
                         <li><span class="attribute" id="nidm:SearchSpaceMap.nidm:filename">
                         <a>nidm:filename</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range xsd:string)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li> 
                         <li><span class="attribute" id="nidm:SearchSpaceMap.nidm:hasMapHeader">
                         <a>nidm:hasMapHeader</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range nidm:MapHeader)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a>nidm:MapHeader</a>)</li> 
                         <li><span class="attribute" id="nidm:SearchSpaceMap.nidm:randomFieldStationarity">
                         <dfn>nidm:randomFieldStationarity</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> is the random field assumed to be stationary across the entire search volume?. (range xsd:boolean)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> is the random field assumed to be stationary across the entire search volume?. (range <a title="xsd:boolean" href="http://www.w3.org/2001/XMLSchema#boolean">xsd:boolean</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>entity(niiri:search_space_id,
@@ -1264,11 +2045,11 @@
                 <p></p>
                 <div class="attributes" id="attributes-nidm:SPM"> A <a>nidm:SPM</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:SPM.label">prov:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:SPM.</li>
+                    <li><span class="attribute" id="nidm:SPM.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:SPM.</li>
                      
                         <li><span class="attribute" id="nidm:SPM.nidm:softwareVersion">
                         <dfn>nidm:softwareVersion</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> name and number that specifies the software version. (range xsd:string)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> name and number that specifies the software version. (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>agent(niiri:software_id,
@@ -1287,17 +2068,17 @@
                 <p></p>
                 <div class="attributes" id="attributes-spm:ReselsPerVoxelMap"> A <a>spm:ReselsPerVoxelMap</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="spm:ReselsPerVoxelMap.label">prov:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the spm:ReselsPerVoxelMap.</li>
+                    <li><span class="attribute" id="spm:ReselsPerVoxelMap.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the spm:ReselsPerVoxelMap.</li>
                      
                         <li><span class="attribute" id="spm:ReselsPerVoxelMap.nidm:atCoordinateSpace">
                         <a>nidm:atCoordinateSpace</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range nidm:CoordinateSpace)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range <a>nidm:CoordinateSpace</a>)</li> 
                         <li><span class="attribute" id="spm:ReselsPerVoxelMap.nidm:filename">
                         <a>nidm:filename</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range xsd:string)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li> 
                         <li><span class="attribute" id="spm:ReselsPerVoxelMap.nidm:hasMapHeader">
                         <a>nidm:hasMapHeader</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range nidm:MapHeader)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a>nidm:MapHeader</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>entity(niiri:resels_per_voxel_map_id,
@@ -1353,11 +2134,11 @@
                 <p></p>
                 <div class="attributes" id="attributes-nidm:FSL"> A <a>nidm:FSL</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:FSL.label">prov:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:FSL.</li>
+                    <li><span class="attribute" id="nidm:FSL.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:FSL.</li>
                      
                         <li><span class="attribute" id="nidm:FSL.nidm:softwareVersion">
                         <a>nidm:softwareVersion</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> name and number that specifies the software version. (range xsd:string)</li>  
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> name and number that specifies the software version. (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li>  
             </section>
             <!-- fsl:CenterOfGravity -->
             <section id="section-fsl:CenterOfGravity"> 
@@ -1368,7 +2149,7 @@
                 <p></p>
                 <div class="attributes" id="attributes-fsl:CenterOfGravity"> A <a>fsl:CenterOfGravity</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="fsl:CenterOfGravity.label">prov:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the fsl:CenterOfGravity.</li>
+                    <li><span class="attribute" id="fsl:CenterOfGravity.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the fsl:CenterOfGravity.</li>
                             
                 </ul>
                 </div>

--- a/doc/content/specs/nidm-results_020.html
+++ b/doc/content/specs/nidm-results_020.html
@@ -362,7 +362,7 @@
                         </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> dimensions of some N-dimensional data. (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li> 
                         <li><span class="attribute" id="nidm:CoordinateSpace.nidm:inWorldCoordinateSystem">
                         <dfn>nidm:inWorldCoordinateSystem</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> type of coordinate system. (range <a>nidm:Colin27CoordinateSystem</a>, <a>nidm:CustomCoordinateSystem</a>, <a>nidm:Icbm452AirCoordinateSystem</a>, <a>nidm:Icbm452Warp5CoordinateSystem</a>, <a>nidm:IcbmMni152LinearCoordinateSystem</a>, <a>nidm:IcbmMni152NonLinear2009aAsymmetricCoordinateSystem</a>, <a>nidm:IcbmMni152NonLinear2009aSymmetricCoordinateSystem</a>, <a>nidm:IcbmMni152NonLinear2009bAsymmetricCoordinateSystem</a>, <a>nidm:IcbmMni152NonLinear2009bSymmetricCoordinateSystem</a>, <a>nidm:IcbmMni152NonLinear2009cAsymmetricCoordinateSystem</a>, <a>nidm:IcbmMni152NonLinear2009cSymmetricCoordinateSystem</a>, <a>nidm:IcbmMni152NonLinear6thGenerationCoordinateSystem</a>, <a>nidm:Ixi549Space</a>, <a>nidm:MNICoordinateSystem</a>, <a>nidm:Mni305CoordinateSystem</a>, <a>nidm:StandardizedCoordinateSystem</a>, <a>nidm:SubjectCoordinateSystem</a>, <a>nidm:TalairachCoordinateSystem</a> and <a>nidm:WorldCoordinateSystem</a>)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> type of coordinate system. (range <a>nidm:WorldCoordinateSystem</a> such as <a>nidm:Colin27CoordinateSystem</a>, <a>nidm:CustomCoordinateSystem</a>, <a>nidm:Icbm452AirCoordinateSystem</a>, <a>nidm:Icbm452Warp5CoordinateSystem</a>, <a>nidm:IcbmMni152LinearCoordinateSystem</a>, <a>nidm:IcbmMni152NonLinear2009aAsymmetricCoordinateSystem</a>, <a>nidm:IcbmMni152NonLinear2009aSymmetricCoordinateSystem</a>, <a>nidm:IcbmMni152NonLinear2009bAsymmetricCoordinateSystem</a>, <a>nidm:IcbmMni152NonLinear2009bSymmetricCoordinateSystem</a>, <a>nidm:IcbmMni152NonLinear2009cAsymmetricCoordinateSystem</a>, <a>nidm:IcbmMni152NonLinear2009cSymmetricCoordinateSystem</a>, <a>nidm:IcbmMni152NonLinear6thGenerationCoordinateSystem</a>, <a>nidm:Ixi549Space</a>, <a>nidm:MNICoordinateSystem</a>, <a>nidm:Mni305CoordinateSystem</a>, <a>nidm:StandardizedCoordinateSystem</a>, <a>nidm:SubjectCoordinateSystem</a> or <a>nidm:TalairachCoordinateSystem</a>)</li> 
                         <li><span class="attribute" id="nidm:CoordinateSpace.nidm:numberOfDimensions">
                         <dfn>nidm:numberOfDimensions</dfn>
                         </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> number of dimensions of a data matrix. (range <a title="xsd:positiveInteger" href="http://www.w3.org/2001/XMLSchema#positiveInteger">xsd:positiveInteger</a>)</li> 
@@ -728,7 +728,7 @@
                      
                         <li><span class="attribute" id="nidm:ModelParametersEstimation.nidm:withEstimationMethod">
                         <dfn>nidm:withEstimationMethod</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a>nidm:EstimationMethod</a>, <a>nidm:GeneralizedLeastSquares</a>, <a>nidm:OrdinaryLeastSquares</a>, <a>nidm:RobustIterativelyReweighedLeastSquares</a> and <a>nidm:WeightedLeastSquares</a>)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a>nidm:EstimationMethod</a> such as <a>nidm:GeneralizedLeastSquares</a>, <a>nidm:OrdinaryLeastSquares</a>, <a>nidm:RobustIterativelyReweighedLeastSquares</a> or <a>nidm:WeightedLeastSquares</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>activity(niiri:model_pe_id,
@@ -989,19 +989,19 @@
                      
                         <li><span class="attribute" id="nidm:NoiseModel.nidm:dependenceSpatialModel">
                         <dfn>nidm:dependenceSpatialModel</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a>nidm:SpatialModel</a>, <a>nidm:SpatiallyGlobalModel</a>, <a>nidm:SpatiallyLocalModel</a> and <a>nidm:SpatiallyRegularizedModel</a>)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a>nidm:SpatialModel</a> such as <a>nidm:SpatiallyGlobalModel</a>, <a>nidm:SpatiallyLocalModel</a> or <a>nidm:SpatiallyRegularizedModel</a>)</li> 
                         <li><span class="attribute" id="nidm:NoiseModel.nidm:hasNoiseDependence">
                         <dfn>nidm:hasNoiseDependence</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a>nidm:ArbitrarilyCorrelatedNoise</a>, <a>nidm:CompoundSymmetricNoise</a>, <a>nidm:ExchangeableNoise</a>, <a>nidm:IndependentNoise</a>, <a>nidm:NoiseDependence</a> and <a>nidm:SeriallyCorrelatedNoise</a>)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a>nidm:NoiseDependence</a> such as <a>nidm:ArbitrarilyCorrelatedNoise</a>, <a>nidm:CompoundSymmetricNoise</a>, <a>nidm:ExchangeableNoise</a>, <a>nidm:IndependentNoise</a> or <a>nidm:SeriallyCorrelatedNoise</a>)</li> 
                         <li><span class="attribute" id="nidm:NoiseModel.nidm:hasNoiseDistribution">
                         <dfn>nidm:hasNoiseDistribution</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a>nidm:BinomialDistribution</a>, <a>nidm:GaussianDistribution</a>, <a>nidm:NoiseDistribution</a>, <a>nidm:NonParametricDistribution</a>, <a>nidm:NonParametricSymmetricDistribution</a> and <a>nidm:PoissonDistribution</a>)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a>nidm:NoiseDistribution</a> such as <a>nidm:BinomialDistribution</a>, <a>nidm:GaussianDistribution</a>, <a>nidm:NonParametricDistribution</a>, <a>nidm:NonParametricSymmetricDistribution</a> or <a>nidm:PoissonDistribution</a>)</li> 
                         <li><span class="attribute" id="nidm:NoiseModel.nidm:noiseVarianceHomogeneous">
                         <dfn>nidm:noiseVarianceHomogeneous</dfn>
                         </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a title="xsd:boolean" href="http://www.w3.org/2001/XMLSchema#boolean">xsd:boolean</a>)</li> 
                         <li><span class="attribute" id="nidm:NoiseModel.nidm:varianceSpatialModel">
                         <dfn>nidm:varianceSpatialModel</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a>nidm:SpatialModel</a>, <a>nidm:SpatiallyGlobalModel</a>, <a>nidm:SpatiallyLocalModel</a> and <a>nidm:SpatiallyRegularizedModel</a>)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a>nidm:SpatialModel</a> such as <a>nidm:SpatiallyGlobalModel</a>, <a>nidm:SpatiallyLocalModel</a> or <a>nidm:SpatiallyRegularizedModel</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>entity(niiri:noise_model_id,
@@ -1422,7 +1422,7 @@
                         </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> name of the contrast. (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li> 
                         <li><span class="attribute" id="nidm:ContrastWeights.nidm:statisticType">
                         <dfn>nidm:statisticType</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a>nidm:FStatistic</a>, <a>nidm:Statistic</a>, <a>nidm:TStatistic</a> and <a>nidm:ZStatistic</a>)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a>nidm:Statistic</a> such as <a>nidm:FStatistic</a>, <a>nidm:TStatistic</a> or <a>nidm:ZStatistic</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>entity(niiri:contrast_weights_id,
@@ -1511,7 +1511,7 @@
                         </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a>nidm:MapHeader</a>)</li> 
                         <li><span class="attribute" id="nidm:StatisticMap.nidm:statisticType">
                         <a>nidm:statisticType</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a>nidm:FStatistic</a>, <a>nidm:Statistic</a>, <a>nidm:TStatistic</a> and <a>nidm:ZStatistic</a>)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a>nidm:Statistic</a> such as <a>nidm:FStatistic</a>, <a>nidm:TStatistic</a> or <a>nidm:ZStatistic</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>entity(niiri:statistic_map_id,
@@ -1933,7 +1933,7 @@
             <section id="section-nidm:SearchSpaceMap"> 
                 <h1 label="nidm:SearchSpaceMap">nidm:SearchSpaceMap</h1>
                 <div class="glossary-ref">
-                    A <dfn>nidm:SearchSpaceMap</dfn>                    <sup><a title="nidm:SearchSpaceMap">                    <span class="diamond">&#9826;</span></a></sup> is mask in which the inference was performed. <a>nidm:SearchSpaceMap</a> is a prov:Entity. 
+                    A <dfn>nidm:SearchSpaceMap</dfn>                    <sup><a title="nidm:SearchSpaceMap">                    <span class="diamond">&#9826;</span></a></sup> is properties of the underlying statistical process. <a>nidm:SearchSpaceMap</a> is a prov:Entity. 
                 </div>
                 <p></p>
                 <div class="attributes" id="attributes-nidm:SearchSpaceMap"> A <a>nidm:SearchSpaceMap</a> has attributes:

--- a/doc/content/specs/nidm-results_dev.html
+++ b/doc/content/specs/nidm-results_dev.html
@@ -371,7 +371,7 @@
                         </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> dimensions of some N-dimensional data. (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li> 
                         <li><span class="attribute" id="nidm:CoordinateSpace.nidm:inWorldCoordinateSystem">
                         <dfn>nidm:inWorldCoordinateSystem</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> type of coordinate system. (range <a>nidm:CustomCoordinateSystem</a>, <a>nidm:MNICoordinateSystem</a>, <a>nidm:StandardizedCoordinateSystem</a>, <a>nidm:SubjectCoordinateSystem</a>, <a>nidm:TalairachCoordinateSystem</a> and <a>nidm:WorldCoordinateSystem</a>)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> type of coordinate system. (range <a>nidm:WorldCoordinateSystem</a> such as <a>nidm:CustomCoordinateSystem</a>, <a>nidm:MNICoordinateSystem</a>, <a>nidm:StandardizedCoordinateSystem</a>, <a>nidm:SubjectCoordinateSystem</a> or <a>nidm:TalairachCoordinateSystem</a>)</li> 
                         <li><span class="attribute" id="nidm:CoordinateSpace.nidm:numberOfDimensions">
                         <dfn>nidm:numberOfDimensions</dfn>
                         </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> number of dimensions of a data matrix. (range <a title="xsd:positiveInteger" href="http://www.w3.org/2001/XMLSchema#positiveInteger">xsd:positiveInteger</a>)</li> 
@@ -565,7 +565,7 @@
                      
                         <li><span class="attribute" id="nidm:ModelParametersEstimation.nidm:withEstimationMethod">
                         <dfn>nidm:withEstimationMethod</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a title="obo:STATO_0000119" href="http://purl.obolibrary.org/obo/STATO_0000119">obo:'model parameter estimation'</a>, <a title="obo:STATO_0000370" href="http://purl.obolibrary.org/obo/STATO_0000370">obo:'ordinary least squares estimation'</a>, <a title="obo:STATO_0000371" href="http://purl.obolibrary.org/obo/STATO_0000371">obo:'weighted least squares estimation'</a>, <a title="obo:STATO_0000372" href="http://purl.obolibrary.org/obo/STATO_0000372">obo:'generalized least squares estimation'</a>, <a title="obo:STATO_0000373" href="http://purl.obolibrary.org/obo/STATO_0000373">obo:'iteratively reweighted least squares estimation'</a>, <a title="obo:STATO_0000374" href="http://purl.obolibrary.org/obo/STATO_0000374">obo:'feasible generalized least squares estimation'</a>)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a title="obo:STATO_0000119" href="http://purl.obolibrary.org/obo/STATO_0000119">obo:'model parameter estimation'</a> such as <a title="obo:STATO_0000370" href="http://purl.obolibrary.org/obo/STATO_0000370">obo:'ordinary least squares estimation'</a>, <a title="obo:STATO_0000371" href="http://purl.obolibrary.org/obo/STATO_0000371">obo:'weighted least squares estimation'</a>, <a title="obo:STATO_0000372" href="http://purl.obolibrary.org/obo/STATO_0000372">obo:'generalized least squares estimation'</a>, <a title="obo:STATO_0000373" href="http://purl.obolibrary.org/obo/STATO_0000373">obo:'iteratively reweighted least squares estimation'</a> or <a title="obo:STATO_0000374" href="http://purl.obolibrary.org/obo/STATO_0000374">obo:'feasible generalized least squares estimation'</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>niiri:model_pe_id prov:used niiri:error_model_id ;
@@ -661,19 +661,19 @@
                      
                         <li><span class="attribute" id="nidm:ErrorModel.nidm:dependenceSpatialModel">
                         <dfn>nidm:dependenceSpatialModel</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a>nidm:SpatialModel</a>, <a>nidm:SpatiallyGlobalModel</a>, <a>nidm:SpatiallyLocalModel</a> and <a>nidm:SpatiallyRegularizedModel</a>)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a>nidm:SpatialModel</a> such as <a>nidm:SpatiallyGlobalModel</a>, <a>nidm:SpatiallyLocalModel</a> or <a>nidm:SpatiallyRegularizedModel</a>)</li> 
                         <li><span class="attribute" id="nidm:ErrorModel.nidm:errorVarianceHomogeneous">
                         <dfn>nidm:errorVarianceHomogeneous</dfn>
                         </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a boolean value reflecting how the variance of the error is modeled during parameter estimation; TRUE for constant variance over all observations in the model, FALSE for heterogeneous variance. (range <a title="xsd:boolean" href="http://www.w3.org/2001/XMLSchema#boolean">xsd:boolean</a>)</li> 
                         <li><span class="attribute" id="nidm:ErrorModel.nidm:hasErrorDependence">
                         <dfn>nidm:hasErrorDependence</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property that associates an ErrorDependence with an ErrorModel. (range <a>nidm:ArbitrarilyCorrelatedError</a>, <a>nidm:CompoundSymmetricError</a>, <a>nidm:ErrorDependence</a>, <a>nidm:ExchangeableError</a>, <a>nidm:IndependentError</a> and <a>nidm:SeriallyCorrelatedError</a>)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property that associates an ErrorDependence with an ErrorModel. (range <a>nidm:ErrorDependence</a> such as <a>nidm:ArbitrarilyCorrelatedError</a>, <a>nidm:CompoundSymmetricError</a>, <a>nidm:ExchangeableError</a>, <a>nidm:IndependentError</a> or <a>nidm:SeriallyCorrelatedError</a>)</li> 
                         <li><span class="attribute" id="nidm:ErrorModel.nidm:hasErrorDistribution">
                         <dfn>nidm:hasErrorDistribution</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property that associates an ErrorDistribution with an ErrorModel. (range <a>nidm:BinomialDistribution</a>, <a>nidm:ErrorDistribution</a>, <a>nidm:GaussianDistribution</a>, <a>nidm:NonParametricDistribution</a>, <a>nidm:NonParametricSymmetricDistribution</a> and <a>nidm:PoissonDistribution</a>)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property that associates an ErrorDistribution with an ErrorModel. (range <a>nidm:ErrorDistribution</a> such as <a>nidm:BinomialDistribution</a>, <a>nidm:GaussianDistribution</a>, <a>nidm:NonParametricDistribution</a>, <a>nidm:NonParametricSymmetricDistribution</a> or <a>nidm:PoissonDistribution</a>)</li> 
                         <li><span class="attribute" id="nidm:ErrorModel.nidm:varianceSpatialModel">
                         <dfn>nidm:varianceSpatialModel</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a>nidm:SpatialModel</a>, <a>nidm:SpatiallyGlobalModel</a>, <a>nidm:SpatiallyLocalModel</a> and <a>nidm:SpatiallyRegularizedModel</a>)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a>nidm:SpatialModel</a> such as <a>nidm:SpatiallyGlobalModel</a>, <a>nidm:SpatiallyLocalModel</a> or <a>nidm:SpatiallyRegularizedModel</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>niiri:error_model_id a prov:Entity , nidm:ErrorModel ;
@@ -1142,7 +1142,7 @@
                         </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> name of the contrast. (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li> 
                         <li><span class="attribute" id="nidm:ContrastWeights.nidm:statisticType">
                         <dfn>nidm:statisticType</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a>nidm:FStatistic</a>, <a>nidm:Statistic</a>, <a>nidm:TStatistic</a> and <a>nidm:ZStatistic</a>)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a>nidm:Statistic</a> such as <a>nidm:FStatistic</a>, <a>nidm:TStatistic</a> or <a>nidm:ZStatistic</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>niiri:contrast_id a prov:Entity , nidm:ContrastWeights ;
@@ -1227,7 +1227,7 @@
                         </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range <a>nidm:CoordinateSpace</a>)</li> 
                         <li><span class="attribute" id="nidm:StatisticMap.nidm:statisticType">
                         <a>nidm:statisticType</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a>nidm:FStatistic</a>, <a>nidm:Statistic</a>, <a>nidm:TStatistic</a> and <a>nidm:ZStatistic</a>)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a>nidm:Statistic</a> such as <a>nidm:FStatistic</a>, <a>nidm:TStatistic</a> or <a>nidm:ZStatistic</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>niiri:statistic_map_id a prov:Entity , nidm:StatisticMap ;
@@ -1436,7 +1436,7 @@
                      
                         <li><span class="attribute" id="nidm:ClusterDefinitionCriteria.nidm:hasConnectivityCriterion">
                         <dfn>nidm:hasConnectivityCriterion</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property that associates a ConnectivityCriterion with a ClusterDefinitionCriteria. (range <a>nidm:ConnectivityCriterion</a>, <a>nidm:PixelConnectivityCriterion</a> and <a>nidm:VoxelConnectivityCriterion</a>)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property that associates a ConnectivityCriterion with a ClusterDefinitionCriteria. (range <a>nidm:ConnectivityCriterion</a> such as <a>nidm:PixelConnectivityCriterion</a> or <a>nidm:VoxelConnectivityCriterion</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>niiri:cluster_definition_criteria_id a prov:Entity , nidm:ClusterDefinitionCriteria ;

--- a/doc/content/specs/nidm-results_dev.html
+++ b/doc/content/specs/nidm-results_dev.html
@@ -670,7 +670,7 @@
                         </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property that associates an ErrorDependence with an ErrorModel. (range <a>nidm:ArbitrarilyCorrelatedError</a>, <a>nidm:CompoundSymmetricError</a>, <a>nidm:ErrorDependence</a>, <a>nidm:ExchangeableError</a>, <a>nidm:IndependentError</a> and <a>nidm:SeriallyCorrelatedError</a>)</li> 
                         <li><span class="attribute" id="nidm:ErrorModel.nidm:hasErrorDistribution">
                         <dfn>nidm:hasErrorDistribution</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property that associates an ErrorDistribution with an ErrorModel. (range <a>fsl:BinomialDistribution</a>, <a>fsl:NonParametricSymmetricDistribution</a>, <a>nidm:ErrorDistribution</a>, <a>nidm:GaussianDistribution</a>, <a>nidm:NonParametricDistribution</a> and <a>nidm:PoissonDistribution</a>)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property that associates an ErrorDistribution with an ErrorModel. (range <a>nidm:BinomialDistribution</a>, <a>nidm:ErrorDistribution</a>, <a>nidm:GaussianDistribution</a>, <a>nidm:NonParametricDistribution</a>, <a>nidm:NonParametricSymmetricDistribution</a> and <a>nidm:PoissonDistribution</a>)</li> 
                         <li><span class="attribute" id="nidm:ErrorModel.nidm:varianceSpatialModel">
                         <dfn>nidm:varianceSpatialModel</dfn>
                         </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a>nidm:SpatialModel</a>, <a>nidm:SpatiallyGlobalModel</a>, <a>nidm:SpatiallyLocalModel</a> and <a>nidm:SpatiallyRegularizedModel</a>)</li>        
@@ -802,6 +802,18 @@
                     <li><span class="attribute" id="nidm:SeriallyCorrelatedError.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:SeriallyCorrelatedError.</li>
                       
             </section>
+            <!-- nidm:BinomialDistribution -->
+            <section id="section-nidm:BinomialDistribution"> 
+                <h1 label="nidm:BinomialDistribution">nidm:BinomialDistribution</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:BinomialDistribution</dfn>                    <sup><a title="nidm:BinomialDistribution">                    <span class="diamond">&#9826;</span></a></sup> is the binomial distribution is a discrete probability distribution which describes the probability of k successes in n draws with replacement from a finite population of size N. The binomial distribution is frequently used to model the number of successes in a sample of size n drawn with replacement from a population of size N. The binomial distribution gives the discrete probability distribution of obtaining exactly n successes out of N Bernoulli trials (where the result of each Bernoulli trial is true with probability p and false with probability q=1-p ) notation: B(n,p) The mean is N*p The variance is N*p*q. (Definition from STATO). <a>nidm:BinomialDistribution</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:BinomialDistribution"> A <a>nidm:BinomialDistribution</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:BinomialDistribution.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:BinomialDistribution.</li>
+                      
+            </section>
             <!-- nidm:ErrorDistribution -->
             <section id="section-nidm:ErrorDistribution"> 
                 <h1 label="nidm:ErrorDistribution">nidm:ErrorDistribution</h1>
@@ -836,6 +848,18 @@
                 <div class="attributes" id="attributes-nidm:NonParametricDistribution"> A <a>nidm:NonParametricDistribution</a> has attributes:
                 <ul>
                     <li><span class="attribute" id="nidm:NonParametricDistribution.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:NonParametricDistribution.</li>
+                      
+            </section>
+            <!-- nidm:NonParametricSymmetricDistribution -->
+            <section id="section-nidm:NonParametricSymmetricDistribution"> 
+                <h1 label="nidm:NonParametricSymmetricDistribution">nidm:NonParametricSymmetricDistribution</h1>
+                <div class="glossary-ref">
+                    A <dfn>nidm:NonParametricSymmetricDistribution</dfn>                    <sup><a title="nidm:NonParametricSymmetricDistribution">                    <span class="diamond">&#9826;</span></a></sup> is probability distribution estimated empirically on the data assuming only symmetry of the probability distribution. <a>nidm:NonParametricSymmetricDistribution</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:NonParametricSymmetricDistribution"> A <a>nidm:NonParametricSymmetricDistribution</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:NonParametricSymmetricDistribution.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:NonParametricSymmetricDistribution.</li>
                       
             </section>
             <!-- nidm:PoissonDistribution -->

--- a/nidm/nidm-results/scripts/create_results_specification.py
+++ b/nidm/nidm-results/scripts/create_results_specification.py
@@ -104,12 +104,13 @@ def main():
 
     if nidm_version == "020":
         # In version 0.2.0 "ErrorModel" was called "NoiseModel"
-        components["Model fitting"][1] = NIDM['NoiseModel']
+        components["Parameters estimation"][1] = NIDM['NoiseModel']
         used_by.pop(NIDM['ErrorModel'], None)
         used_by[NIDM['NoiseModel']] = [NIDM['ModelParametersEstimation']]
         # No "InferenceMaskMap"
+        # "ExcursionSetMap" was called "ExcursionSet"
         components["Inference"] = [NIDM['Inference'], NIDM['HeightThreshold'], NIDM['ExtentThreshold'], 
-             NIDM['ExcursionSetMap'], NIDM['ClusterLabelsMap'], NIDM['SearchSpaceMap'], 
+             NIDM['ExcursionSet'], NIDM['ClusterLabelsMap'], NIDM['SearchSpaceMap'], 
              NIDM['Cluster'], NIDM['Peak'],
              NIDM['Coordinate']]
         # In version 0.2.0 "SignificantCluster" was called "Cluster"

--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -759,9 +759,9 @@ http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#P-Value""" ;
             
             rdfs:range [ rdf:type rdfs:Datatype ;
                          owl:onDatatype xsd:float ;
-                         owl:withRestrictions ( [ xsd:minInclusive "0.0"^^xsd:float
+                         owl:withRestrictions ( [ xsd:maxInclusive "1.0"^^xsd:float
                                                 ]
-                                                [ xsd:maxInclusive "1.0"^^xsd:float
+                                                [ xsd:minInclusive "0.0"^^xsd:float
                                                 ]
                                               )
                        ] .
@@ -789,9 +789,9 @@ nidm:pValueFWER rdf:type owl:DatatypeProperty ;
                 
                 rdfs:range [ rdf:type rdfs:Datatype ;
                              owl:onDatatype xsd:float ;
-                             owl:withRestrictions ( [ xsd:minInclusive "0.0"^^xsd:float
+                             owl:withRestrictions ( [ xsd:maxInclusive "1.0"^^xsd:float
                                                     ]
-                                                    [ xsd:maxInclusive "1.0"^^xsd:float
+                                                    [ xsd:minInclusive "0.0"^^xsd:float
                                                     ]
                                                   )
                            ] .
@@ -817,9 +817,9 @@ nidm:pValueUncorrected rdf:type owl:DatatypeProperty ;
                        
                        rdfs:range [ rdf:type rdfs:Datatype ;
                                     owl:onDatatype xsd:float ;
-                                    owl:withRestrictions ( [ xsd:minInclusive "0.0"^^xsd:float
+                                    owl:withRestrictions ( [ xsd:maxInclusive "1.0"^^xsd:float
                                                            ]
-                                                           [ xsd:maxInclusive "1.0"^^xsd:float
+                                                           [ xsd:minInclusive "0.0"^^xsd:float
                                                            ]
                                                          )
                                   ] .
@@ -845,9 +845,9 @@ nidm:qValueFDR rdf:type owl:DatatypeProperty ;
                
                rdfs:range [ rdf:type rdfs:Datatype ;
                             owl:onDatatype xsd:float ;
-                            owl:withRestrictions ( [ xsd:minInclusive "0.0"^^xsd:float
+                            owl:withRestrictions ( [ xsd:maxInclusive "1.0"^^xsd:float
                                                    ]
-                                                   [ xsd:maxInclusive "1.0"^^xsd:float
+                                                   [ xsd:minInclusive "0.0"^^xsd:float
                                                    ]
                                                  )
                           ] .
@@ -1429,20 +1429,6 @@ dctype:Image rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/fsl#BinomialDistribution
-
-fsl:BinomialDistribution rdf:type owl:Class ;
-                         
-                         rdfs:subClassOf nidm:ErrorDistribution ;
-                         
-                         owl:sameAs "http://purl.obolibrary.org/obo/STATO_0000276"^^xsd:anyURI ;
-                         
-                         obo:IAO_0000115 "The binomial distribution is a discrete probability distribution which describes the probability of k successes in n draws with replacement from a finite population of size N. The binomial distribution is frequently used to model the number of successes in a sample of size n drawn with replacement from a population of size N. The binomial distribution gives the discrete probability distribution of obtaining exactly n successes out of N Bernoulli trials (where the result of each Bernoulli trial is true with probability p and false with probability q=1-p ) notation: B(n,p) The mean is N*p The variance is N*p*q. (Definition from STATO)." ;
-                         
-                         obo:IAO_0000114 obo:IAO_0000122 .
-
-
-
 ###  http://www.incf.org/ns/nidash/fsl#CenterOfGravity
 
 fsl:CenterOfGravity rdf:type owl:Class ;
@@ -1481,18 +1467,6 @@ fsl:ContrastVarianceMap rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/fsl#NonParametricSymmetricDistribution
-
-fsl:NonParametricSymmetricDistribution rdf:type owl:Class ;
-                                       
-                                       rdfs:subClassOf nidm:ErrorDistribution ;
-                                       
-                                       obo:IAO_0000115 "Probability distribution estimated empirically on the data assuming only symmetry of the probability distribution." ;
-                                       
-                                       obo:IAO_0000114 obo:IAO_0000122 .
-
-
-
 ###  http://www.incf.org/ns/nidash/nidm#ArbitrarilyCorrelatedError
 
 nidm:ArbitrarilyCorrelatedError rdf:type owl:Class ;
@@ -1505,12 +1479,26 @@ nidm:ArbitrarilyCorrelatedError rdf:type owl:Class ;
 
 
 
+###  http://www.incf.org/ns/nidash/nidm#BinomialDistribution
+
+nidm:BinomialDistribution rdf:type owl:Class ;
+                          
+                          rdfs:subClassOf nidm:ErrorDistribution ;
+                          
+                          owl:sameAs "http://purl.obolibrary.org/obo/STATO_0000276"^^xsd:anyURI ;
+                          
+                          obo:IAO_0000115 "The binomial distribution is a discrete probability distribution which describes the probability of k successes in n draws with replacement from a finite population of size N. The binomial distribution is frequently used to model the number of successes in a sample of size n drawn with replacement from a population of size N. The binomial distribution gives the discrete probability distribution of obtaining exactly n successes out of N Bernoulli trials (where the result of each Bernoulli trial is true with probability p and false with probability q=1-p ) notation: B(n,p) The mean is N*p The variance is N*p*q. (Definition from STATO)." ;
+                          
+                          obo:IAO_0000114 obo:IAO_0000122 .
+
+
+
 ###  http://www.incf.org/ns/nidash/nidm#Cluster
 
 nidm:Cluster rdf:type owl:Class ;
              
              rdfs:subClassOf prov:Entity ;
-                          
+             
              obo:IAO_0000115 "A collection of elements related by one or more criteria."^^xsd:string ;
              
              prov:editorialNote "Discussed in https://github.com/incf-nidash/nidm/issues/71."^^xsd:string ;
@@ -1734,12 +1722,12 @@ nidm:DesignMatrix rdf:type owl:Class ;
                   
                   rdfs:subClassOf prov:Entity ,
                                   [ rdf:type owl:Restriction ;
-                                    owl:onProperty nfo:fileName ;
+                                    owl:onProperty dct:format ;
                                     owl:minQualifiedCardinality "0"^^xsd:nonNegativeInteger ;
                                     owl:onDataRange xsd:string
                                   ] ,
                                   [ rdf:type owl:Restriction ;
-                                    owl:onProperty dct:format ;
+                                    owl:onProperty nfo:fileName ;
                                     owl:minQualifiedCardinality "0"^^xsd:nonNegativeInteger ;
                                     owl:onDataRange xsd:string
                                   ] ,
@@ -2094,6 +2082,18 @@ nidm:NonParametricDistribution rdf:type owl:Class ;
                                obo:IAO_0000115 "Probability distribution estimated empirically on the data without assumptions on the shape of the probability distribution." ;
                                
                                obo:IAO_0000114 obo:IAO_0000122 .
+
+
+
+###  http://www.incf.org/ns/nidash/nidm#NonParametricSymmetricDistribution
+
+nidm:NonParametricSymmetricDistribution rdf:type owl:Class ;
+                                        
+                                        rdfs:subClassOf nidm:ErrorDistribution ;
+                                        
+                                        obo:IAO_0000115 "Probability distribution estimated empirically on the data assuming only symmetry of the probability distribution." ;
+                                        
+                                        obo:IAO_0000114 obo:IAO_0000122 .
 
 
 

--- a/nidm/nidm-results/terms/releases/nidm-results_020.owl
+++ b/nidm/nidm-results/terms/releases/nidm-results_020.owl
@@ -1,7 +1,7 @@
 @prefix : <http://www.semanticweb.org/owl/owlapi/turtle#> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix fsl: <http://www.incf.org/ns/nidash/fsl#> .
-@prefix iao: <http://purl.obolibrary.org/obo/iao.owl#> .
+@prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix spm: <http://www.incf.org/ns/nidash/spm#> .
@@ -21,22 +21,71 @@
 #
 #################################################################
 
+###  http://purl.obolibrary.org/obo/IAO_0000112
 
-###  http://purl.obolibrary.org/obo/iao.owl#IAO_0000112
+obo:IAO_0000112 rdf:type owl:AnnotationProperty ;
+                
+                rdfs:label "example of usage"@en ;
+                
+                obo:IAO_0000115 "A phrase describing how a class name should be used. May also include other kinds of examples that facilitate immediate understanding of a class semantics, such as widely known prototypical subclasses or instances of the class. Although essential for high level terms, examples for low level terms (e.g., Affymetrix HU133 array) are not"@en ;
+                
+                obo:IAO_0000119 "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"@en ;
+                
+                obo:IAO_0000117 "PERSON:Daniel Schober"@en ;
+                
+                obo:IAO_0000111 "example"@en ;
+                
+                obo:IAO_0000114 obo:IAO_0000122 .
 
-iao:IAO_0000112 rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.obolibrary.org/obo/IAO_0000114
+
+obo:IAO_0000114 rdf:type owl:AnnotationProperty ;
+                
+                rdfs:label "has curation status"@en ;
+                
+                obo:IAO_0000119 "OBI_0000281"@en ;
+                
+                obo:IAO_0000117 "PERSON:Alan Ruttenberg"@en ,
+                                "PERSON:Bill Bug"@en ,
+                                "PERSON:Melanie Courtot"@en ;
+                
+                obo:IAO_0000111 "has curation status"@en .
 
 
 
-###  http://purl.obolibrary.org/obo/iao.owl#IAO_0000116
+###  http://purl.obolibrary.org/obo/IAO_0000115
 
-iao:IAO_0000116 rdf:type owl:AnnotationProperty .
+obo:IAO_0000115 rdf:type owl:AnnotationProperty ;
+                
+                rdfs:label "definition"@en ;
+                
+                obo:IAO_0000119 "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"@en ;
+                
+                obo:IAO_0000117 "PERSON:Daniel Schober"@en ;
+                
+                obo:IAO_0000115 "The official definition, explaining the meaning of a class or property. Shall be Aristotelian, formalized and normalized. Can be augmented with colloquial definitions."@en ;
+                
+                obo:IAO_0000111 "definition"@en ;
+                
+                obo:IAO_0000114 obo:IAO_0000122 .
 
+###  http://purl.obolibrary.org/obo/IAO_0000116
 
-
-###  http://www.w3.org/2000/01/rdf-schema#isDefinedBy
-
-rdfs:isDefinedBy rdf:type owl:AnnotationProperty .
+obo:IAO_0000116 rdf:type owl:AnnotationProperty ;
+                
+                rdfs:label "editor note"@en ;
+                
+                obo:IAO_0000115 "An administrative note intended for its editor. It may not be included in the publication version of the ontology, so it should contain nothing necessary for end users to understand the ontology."@en ;
+                
+                obo:IAO_0000119 "GROUP:OBI:<http://purl.obfoundry.org/obo/obi>"@en ;
+                
+                obo:IAO_0000117 "PERSON:Daniel Schober"@en ;
+                
+                obo:IAO_0000111 "editor note"@en ;
+                
+                obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -69,7 +118,7 @@ dct:format rdf:type owl:ObjectProperty ;
 
 nidm:alternativeHypothesis rdf:type owl:ObjectProperty ;
                            
-                           rdfs:isDefinedBy "FIXME" ;
+                           obo:IAO_0000115 "FIXME" ;
                            
                            rdfs:domain nidm:Inference .
 
@@ -79,7 +128,7 @@ nidm:alternativeHypothesis rdf:type owl:ObjectProperty ;
 
 nidm:atCoordinateSpace rdf:type owl:ObjectProperty ;
                        
-                       rdfs:isDefinedBy "Property of a DataArray to associate a CoordinateSpace with a physical file." ;
+                       obo:IAO_0000115 "Property of a DataArray to associate a CoordinateSpace with a physical file." ;
                        
                        rdfs:range nidm:CoordinateSpace ;
                        
@@ -91,7 +140,7 @@ nidm:atCoordinateSpace rdf:type owl:ObjectProperty ;
 
 nidm:dependenceSpatialModel rdf:type owl:ObjectProperty ;
                             
-                            rdfs:isDefinedBy "FIXME" ;
+                            obo:IAO_0000115 "FIXME" ;
                             
                             rdfs:domain nidm:NoiseModel ;
                             
@@ -103,7 +152,7 @@ nidm:dependenceSpatialModel rdf:type owl:ObjectProperty ;
 
 nidm:hasAlternativeHypothesis rdf:type owl:ObjectProperty ;
                               
-                              rdfs:isDefinedBy "FIXME" ;
+                              obo:IAO_0000115 "FIXME" ;
                               
                               rdfs:domain nidm:Inference ;
                               
@@ -116,11 +165,11 @@ nidm:hasAlternativeHypothesis rdf:type owl:ObjectProperty ;
 
 nidm:hasClusterLabelsMap rdf:type owl:ObjectProperty ;
                          
-                         iao:IAO_0000112 "file:///path/to/cluster_labels.img" ;
+                         obo:IAO_0000112 "file:///path/to/cluster_labels.img" ;
                          
-                         rdfs:isDefinedBy "A map whose value at each location denotes cluster membership. Each cluster is denoted by a different integer." ;
+                         obo:IAO_0000115 "A map whose value at each location denotes cluster membership. Each cluster is denoted by a different integer." ;
                          
-                         iao:IAO_0000116 """Range: Pathtoaniftiimage not found. BIRNLex or 
+                         obo:IAO_0000116 """Range: Pathtoaniftiimage not found. BIRNLex or 
 NIDM Concept ID: nidm_4. """ ;
                          
                          rdfs:range nidm:ClusterLabelsMap ;
@@ -133,7 +182,7 @@ NIDM Concept ID: nidm_4. """ ;
 
 nidm:hasMapHeader rdf:type owl:ObjectProperty ;
                   
-                  rdfs:isDefinedBy "FIXME" ;
+                  obo:IAO_0000115 "FIXME" ;
                   
                   rdfs:domain nidm:Map ;
                   
@@ -145,7 +194,7 @@ nidm:hasMapHeader rdf:type owl:ObjectProperty ;
 
 nidm:hasNoiseDependence rdf:type owl:ObjectProperty ;
                         
-                        rdfs:isDefinedBy "FIXME" ;
+                        obo:IAO_0000115 "FIXME" ;
                         
                         rdfs:range nidm:NoiseDependence ;
                         
@@ -157,7 +206,7 @@ nidm:hasNoiseDependence rdf:type owl:ObjectProperty ;
 
 nidm:hasNoiseDistribution rdf:type owl:ObjectProperty ;
                           
-                          rdfs:isDefinedBy "FIXME" ;
+                          obo:IAO_0000115 "FIXME" ;
                           
                           rdfs:range nidm:NoiseDistribution ;
                           
@@ -169,12 +218,12 @@ nidm:hasNoiseDistribution rdf:type owl:ObjectProperty ;
 
 nidm:inWorldCoordinateSystem rdf:type owl:ObjectProperty ;
                              
-                             iao:IAO_0000116 """BIRNLex or 
+                             obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_22. """ ;
                              
-                             rdfs:isDefinedBy "Type of coordinate system." ;
+                             obo:IAO_0000115 "Type of coordinate system." ;
                              
-                             iao:IAO_0000112 "nidm:MNICoordinateSystem" ;
+                             obo:IAO_0000112 "nidm:MNICoordinateSystem" ;
                              
                              rdfs:domain nidm:CoordinateSpace ;
                              
@@ -186,7 +235,7 @@ NIDM Concept ID: nidm_22. """ ;
 
 nidm:objectModel rdf:type owl:ObjectProperty ;
                  
-                 rdfs:isDefinedBy "FIXME" ;
+                 obo:IAO_0000115 "FIXME" ;
                  
                  rdfs:range nidm:NIDMObjectModel ;
                  
@@ -198,7 +247,7 @@ nidm:objectModel rdf:type owl:ObjectProperty ;
 
 nidm:statisticType rdf:type owl:ObjectProperty ;
                    
-                   rdfs:isDefinedBy "FIXME" ;
+                   obo:IAO_0000115 "FIXME" ;
                    
                    rdfs:domain nidm:ContrastWeights ;
                    
@@ -212,7 +261,7 @@ nidm:statisticType rdf:type owl:ObjectProperty ;
 
 nidm:varianceSpatialModel rdf:type owl:ObjectProperty ;
                           
-                          rdfs:isDefinedBy "FIXME" ;
+                          obo:IAO_0000115 "FIXME" ;
                           
                           rdfs:domain nidm:NoiseModel ;
                           
@@ -224,12 +273,12 @@ nidm:varianceSpatialModel rdf:type owl:ObjectProperty ;
 
 nidm:visualisation rdf:type owl:ObjectProperty ;
                    
-                   iao:IAO_0000112 "file:///path/to/design_matrix.png" ;
+                   obo:IAO_0000112 "file:///path/to/design_matrix.png" ;
                    
-                   iao:IAO_0000116 """Range: Pathtoanimage(e.g.png) not found. BIRNLex or 
+                   obo:IAO_0000116 """Range: Pathtoanimage(e.g.png) not found. BIRNLex or 
 NIDM Concept ID: nidm_66. """ ;
                    
-                   rdfs:isDefinedBy "Graphical representation of an entity." ;
+                   obo:IAO_0000115 "Graphical representation of an entity." ;
                    
                    rdfs:domain nidm:DesignMatrix ,
                                nidm:ExcursionSet ;
@@ -242,7 +291,7 @@ NIDM Concept ID: nidm_66. """ ;
 
 nidm:withEstimationMethod rdf:type owl:ObjectProperty ;
                           
-                          rdfs:isDefinedBy "FIXME" ;
+                          obo:IAO_0000115 "FIXME" ;
                           
                           rdfs:range nidm:EstimationMethod ;
                           
@@ -254,11 +303,11 @@ nidm:withEstimationMethod rdf:type owl:ObjectProperty ;
 
 spm:hasMaximumIntensityProjection rdf:type owl:ObjectProperty ;
                                   
-                                  rdfs:isDefinedBy "Maximum intensity projection of a map." ;
+                                  obo:IAO_0000115 "Maximum intensity projection of a map." ;
                                   
-                                  iao:IAO_0000112 "file:///path/to/MIP.png" ;
+                                  obo:IAO_0000112 "file:///path/to/MIP.png" ;
                                   
-                                  iao:IAO_0000116 """Range: Pathtoanimage(e.g.png) not found. BIRNLex or 
+                                  obo:IAO_0000116 """Range: Pathtoanimage(e.g.png) not found. BIRNLex or 
 NIDM Concept ID: spm_77. """ ;
                                   
                                   rdfs:domain nidm:ExcursionSet ;
@@ -350,12 +399,12 @@ dct:format rdf:type owl:DatatypeProperty ;
 
 fsl:coordinate1InVoxels rdf:type owl:DatatypeProperty ;
                         
-                        iao:IAO_0000112 "-60" ;
+                        obo:IAO_0000112 "-60" ;
                         
-                        iao:IAO_0000116 """BIRNLex or 
+                        obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_16. """ ;
                         
-                        rdfs:isDefinedBy "Coordinate along the first dimension in voxels." ;
+                        obo:IAO_0000115 "Coordinate along the first dimension in voxels." ;
                         
                         rdfs:domain nidm:Coordinate ;
                         
@@ -367,12 +416,12 @@ NIDM Concept ID: nidm_16. """ ;
 
 fsl:coordinate2InVoxels rdf:type owl:DatatypeProperty ;
                         
-                        rdfs:isDefinedBy "Coordinate along the second dimension in voxels." ;
+                        obo:IAO_0000115 "Coordinate along the second dimension in voxels." ;
                         
-                        iao:IAO_0000116 """BIRNLex or 
+                        obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_18. """ ;
                         
-                        iao:IAO_0000112 "-28" ;
+                        obo:IAO_0000112 "-28" ;
                         
                         rdfs:domain nidm:Coordinate ;
                         
@@ -384,12 +433,12 @@ NIDM Concept ID: nidm_18. """ ;
 
 fsl:coordinate3InVoxels rdf:type owl:DatatypeProperty ;
                         
-                        iao:IAO_0000116 """BIRNLex or 
+                        obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_20. """ ;
                         
-                        rdfs:isDefinedBy "Coordinate along the third dimension in voxels" ;
+                        obo:IAO_0000115 "Coordinate along the third dimension in voxels" ;
                         
-                        iao:IAO_0000112 "13" ;
+                        obo:IAO_0000112 "13" ;
                         
                         rdfs:domain nidm:Coordinate ;
                         
@@ -403,7 +452,7 @@ fsl:dlh rdf:type owl:DatatypeProperty ;
         
         rdfs:comment "To be renamed" ;
         
-        rdfs:isDefinedBy "FIXME" ;
+        obo:IAO_0000115 "FIXME" ;
         
         rdfs:domain nidm:SearchSpaceMap ;
         
@@ -425,7 +474,7 @@ fsl:featVersion rdf:type owl:DatatypeProperty ;
 
 fsl:reselSizeInVoxels rdf:type owl:DatatypeProperty ;
                       
-                      rdfs:isDefinedBy "FIXME" ;
+                      obo:IAO_0000115 "FIXME" ;
                       
                       rdfs:domain nidm:SearchSpaceMap ;
                       
@@ -439,7 +488,7 @@ fsl:reselSizeInVoxels rdf:type owl:DatatypeProperty ;
 
 fsl:searchVolumeInVoxels rdf:type owl:DatatypeProperty ;
                          
-                         rdfs:isDefinedBy "FIXME" ;
+                         obo:IAO_0000115 "FIXME" ;
                          
                          rdfs:comment "Check if this can be merged with spm:searchVolumeInVoxels" ;
                          
@@ -455,11 +504,11 @@ fsl:searchVolumeInVoxels rdf:type owl:DatatypeProperty ;
 
 nidm:clusterLabelId rdf:type owl:DatatypeProperty ;
                     
-                    iao:IAO_0000112 "5" ;
+                    obo:IAO_0000112 "5" ;
                     
-                    rdfs:isDefinedBy "Integer associated with a particular cluster as specified in the clusterLabelsMap." ;
+                    obo:IAO_0000115 "Integer associated with a particular cluster as specified in the clusterLabelsMap." ;
                     
-                    iao:IAO_0000116 """BIRNLex or 
+                    obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_3. """ ;
                     
                     rdfs:domain nidm:Cluster ;
@@ -472,12 +521,12 @@ NIDM Concept ID: nidm_3. """ ;
 
 nidm:clusterSizeInVertices rdf:type owl:DatatypeProperty ;
                            
-                           iao:IAO_0000112 "10" ;
+                           obo:IAO_0000112 "10" ;
                            
-                           iao:IAO_0000116 """BIRNLex or 
+                           obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_5. """ ;
                            
-                           rdfs:isDefinedBy "Number of vertices that make up the cluster." ;
+                           obo:IAO_0000115 "Number of vertices that make up the cluster." ;
                            
                            rdfs:domain nidm:Cluster ,
                                        nidm:ExtentThreshold ;
@@ -490,12 +539,12 @@ NIDM Concept ID: nidm_5. """ ;
 
 nidm:clusterSizeInVoxels rdf:type owl:DatatypeProperty ;
                          
-                         iao:IAO_0000112 "18" ;
+                         obo:IAO_0000112 "18" ;
                          
-                         iao:IAO_0000116 """BIRNLex or 
+                         obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_6. """ ;
                          
-                         rdfs:isDefinedBy "Number of voxels that make up the cluster." ;
+                         obo:IAO_0000115 "Number of voxels that make up the cluster." ;
                          
                          rdfs:domain nidm:Cluster ,
                                      nidm:ExtentThreshold ;
@@ -508,12 +557,12 @@ NIDM Concept ID: nidm_6. """ ;
 
 nidm:contrastName rdf:type owl:DatatypeProperty ;
                   
-                  iao:IAO_0000116 """BIRNLex or 
+                  obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_11. """ ;
                   
-                  rdfs:isDefinedBy "Name of the contrast." ;
+                  obo:IAO_0000115 "Name of the contrast." ;
                   
-                  iao:IAO_0000112 "\"Listening > Rest\"" ;
+                  obo:IAO_0000112 "\"Listening > Rest\"" ;
                   
                   rdfs:domain nidm:ContrastMap ,
                               nidm:ContrastWeights ,
@@ -527,12 +576,12 @@ NIDM Concept ID: nidm_11. """ ;
 
 nidm:coordinate1 rdf:type owl:DatatypeProperty ;
                  
-                 iao:IAO_0000116 """BIRNLex or 
+                 obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_15. """ ;
                  
-                 rdfs:isDefinedBy "Coordinate along the first dimension in voxel units." ;
+                 obo:IAO_0000115 "Coordinate along the first dimension in voxel units." ;
                  
-                 iao:IAO_0000112 "-60" ;
+                 obo:IAO_0000112 "-60" ;
                  
                  rdfs:domain nidm:Coordinate ;
                  
@@ -544,12 +593,12 @@ NIDM Concept ID: nidm_15. """ ;
 
 nidm:coordinate2 rdf:type owl:DatatypeProperty ;
                  
-                 rdfs:isDefinedBy "Coordinate along the second dimension in voxel units." ;
+                 obo:IAO_0000115 "Coordinate along the second dimension in voxel units." ;
                  
-                 iao:IAO_0000116 """BIRNLex or 
+                 obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_17. """ ;
                  
-                 iao:IAO_0000112 "-28" ;
+                 obo:IAO_0000112 "-28" ;
                  
                  rdfs:domain nidm:Coordinate ;
                  
@@ -561,11 +610,11 @@ NIDM Concept ID: nidm_17. """ ;
 
 nidm:coordinate3 rdf:type owl:DatatypeProperty ;
                  
-                 iao:IAO_0000112 "13" ;
+                 obo:IAO_0000112 "13" ;
                  
-                 rdfs:isDefinedBy "Coordinate along the third dimension in voxel units." ;
+                 obo:IAO_0000115 "Coordinate along the third dimension in voxel units." ;
                  
-                 iao:IAO_0000116 """BIRNLex or 
+                 obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_19. """ ;
                  
                  rdfs:domain nidm:Coordinate ;
@@ -578,12 +627,12 @@ NIDM Concept ID: nidm_19. """ ;
 
 nidm:dimensionsInVoxels rdf:type owl:DatatypeProperty ;
                         
-                        iao:IAO_0000116 """Range: Vectorofintegers not found. BIRNLex or 
+                        obo:IAO_0000116 """Range: Vectorofintegers not found. BIRNLex or 
 NIDM Concept ID: nidm_25. """ ;
                         
-                        rdfs:isDefinedBy "Dimensions of some N-dimensional data." ;
+                        obo:IAO_0000115 "Dimensions of some N-dimensional data." ;
                         
-                        iao:IAO_0000112 "[64 64 20]" ;
+                        obo:IAO_0000112 "[64 64 20]" ;
                         
                         rdfs:domain nidm:CoordinateSpace ;
                         
@@ -595,12 +644,12 @@ NIDM Concept ID: nidm_25. """ ;
 
 nidm:effectDegreesOfFreedom rdf:type owl:DatatypeProperty ;
                             
-                            iao:IAO_0000112 "1" ;
+                            obo:IAO_0000112 "1" ;
                             
-                            iao:IAO_0000116 """Range: Positivefloat not found. BIRNLex or 
+                            obo:IAO_0000116 """Range: Positivefloat not found. BIRNLex or 
 NIDM Concept ID: nidm_26. """ ;
                             
-                            rdfs:isDefinedBy "Degrees of freedom of the effect." ;
+                            obo:IAO_0000115 "Degrees of freedom of the effect." ;
                             
                             rdfs:domain nidm:StatisticMap ;
                             
@@ -612,11 +661,11 @@ NIDM Concept ID: nidm_26. """ ;
 
 nidm:equivalentZStatistic rdf:type owl:DatatypeProperty ;
                           
-                          iao:IAO_0000112 "3.5" ;
+                          obo:IAO_0000112 "3.5" ;
                           
-                          rdfs:isDefinedBy "Statistic value transformed into Z units; the output of a process which takes a non-normal statistic and transforms it to an equivalent z score." ;
+                          obo:IAO_0000115 "Statistic value transformed into Z units; the output of a process which takes a non-normal statistic and transforms it to an equivalent z score." ;
                           
-                          iao:IAO_0000116 """Context: Functional. Parent: Data transformation;  http://purl.obolibrary.org/obo/OBI_0200000 not found. BIRNLex or 
+                          obo:IAO_0000116 """Context: Functional. Parent: Data transformation;  http://purl.obolibrary.org/obo/OBI_0200000 not found. BIRNLex or 
 NIDM Concept ID: nidm_27. new parent: Peak. """ ;
                           
                           rdfs:domain nidm:Peak ;
@@ -629,9 +678,9 @@ NIDM Concept ID: nidm_27. new parent: Peak. """ ;
 
 nidm:errorDegreesOfFreedom rdf:type owl:DatatypeProperty ;
                            
-                           iao:IAO_0000112 "72.999999" ;
+                           obo:IAO_0000112 "72.999999" ;
                            
-                           rdfs:isDefinedBy "Degrees of freedom of the error." ;
+                           obo:IAO_0000115 "Degrees of freedom of the error." ;
                            
                            rdfs:domain nidm:StatisticMap ;
                            
@@ -648,10 +697,10 @@ nidm:errorDegreesOfFreedom rdf:type owl:DatatypeProperty ;
 
 nidm:f-statistic rdf:type owl:DatatypeProperty ;
                  
-                 iao:IAO_0000116 """Context: io terms. Domain or Attributes: <notdirectlyinuse> not found. BIRNLex or 
+                 obo:IAO_0000116 """Context: io terms. Domain or Attributes: <notdirectlyinuse> not found. BIRNLex or 
 NIDM Concept ID: nidm_31. """ ;
                  
-                 rdfs:isDefinedBy "The statistic from the F-test, a test of the hypothesis that the standard deviations of two normally distributed populations are equal, and thus that they are of comparable origin." ;
+                 obo:IAO_0000115 "The statistic from the F-test, a test of the hypothesis that the standard deviations of two normally distributed populations are equal, and thus that they are of comparable origin." ;
                  
                  rdfs:seeAlso "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#F-Test" .
 
@@ -663,7 +712,7 @@ nidm:filename rdf:type owl:DatatypeProperty ;
               
               owl:sameAs "http://purl.obolibrary.org/obo/OBIws_0000001"^^xsd:anyURI ;
               
-              iao:IAO_0000112 "con_0001.img" ;
+              obo:IAO_0000112 "con_0001.img" ;
               
               rdfs:domain nidm:DesignMatrix ,
                           nidm:ExcursionSet ,
@@ -679,7 +728,7 @@ nidm:filename rdf:type owl:DatatypeProperty ;
 
 nidm:globalNullDegree rdf:type owl:DatatypeProperty ;
                       
-                      rdfs:isDefinedBy "FIXME" ;
+                      obo:IAO_0000115 "FIXME" ;
                       
                       rdfs:domain spm:KConjunctionInference ;
                       
@@ -691,11 +740,11 @@ nidm:globalNullDegree rdf:type owl:DatatypeProperty ;
 
 nidm:grandMeanScaling rdf:type owl:DatatypeProperty ;
                       
-                      iao:IAO_0000112 "TRUE" ;
+                      obo:IAO_0000112 "TRUE" ;
                       
-                      rdfs:isDefinedBy "Binary flag defining whether the data was scaled. Specifically, \"grand mean scaling\" refers to multipliciation of every voxel in every scan by a common value.  Grand mean scaling is essential for first-level fMRI, to transform the arbitrary MRI units, but is generally not used with second level analyses." ;
+                      obo:IAO_0000115 "Binary flag defining whether the data was scaled. Specifically, \"grand mean scaling\" refers to multipliciation of every voxel in every scan by a common value.  Grand mean scaling is essential for first-level fMRI, to transform the arbitrary MRI units, but is generally not used with second level analyses." ;
                       
-                      iao:IAO_0000116 """BIRNLex or 
+                      obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_96. """ ;
                       
                       rdfs:domain nidm:Data ;
@@ -708,12 +757,12 @@ NIDM Concept ID: nidm_96. """ ;
 
 nidm:inWorldCoordinateSystem rdf:type owl:DatatypeProperty ;
                              
-                             iao:IAO_0000116 """BIRNLex or 
+                             obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_22. """ ;
                              
-                             rdfs:isDefinedBy "Type of coordinate system." ;
+                             obo:IAO_0000115 "Type of coordinate system." ;
                              
-                             iao:IAO_0000112 "nidm:MNICoordinateSystem" .
+                             obo:IAO_0000112 "nidm:MNICoordinateSystem" .
 
 
 
@@ -721,14 +770,14 @@ NIDM Concept ID: nidm_22. """ ;
 
 nidm:maskedMedian rdf:type owl:DatatypeProperty ;
                   
-                  rdfs:isDefinedBy "Median value considering only in-mask voxels. Useful diagnostic when computed on grand mean image when grandMeanScaling is TRUE, as the median should be close to targetIntensity." ;
+                  obo:IAO_0000115 "Median value considering only in-mask voxels. Useful diagnostic when computed on grand mean image when grandMeanScaling is TRUE, as the median should be close to targetIntensity." ;
                   
-                  iao:IAO_0000116 """BIRNLex or 
+                  obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_98. """ ;
                   
                   rdfs:seeAlso "http://purl.obolibrary.org/obo/OBI_0200119" ;
                   
-                  iao:IAO_0000112 "155.23" ;
+                  obo:IAO_0000112 "155.23" ;
                   
                   rdfs:domain nidm:GrandMeanMap ;
                   
@@ -740,12 +789,12 @@ NIDM Concept ID: nidm_98. """ ;
 
 nidm:noiseFWHM rdf:type owl:DatatypeProperty ;
                
-               iao:IAO_0000116 """Context: Functional. Domain or Attributes: <onlychildofareusedinthedatamodel> not found. BIRNLex or 
+               obo:IAO_0000116 """Context: Functional. Domain or Attributes: <onlychildofareusedinthedatamodel> not found. BIRNLex or 
 NIDM Concept ID: nidm_42. \"type\": SearchVol. """ ;
                
-               iao:IAO_0000112 "2.35" ;
+               obo:IAO_0000112 "2.35" ;
                
-               rdfs:isDefinedBy "Estimated Full Width at Half Maximum of the noise distribution." ;
+               obo:IAO_0000115 "Estimated Full Width at Half Maximum of the noise distribution." ;
                
                rdfs:seeAlso "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#Full_Width_at_Half_Maximum" .
 
@@ -755,7 +804,7 @@ NIDM Concept ID: nidm_42. \"type\": SearchVol. """ ;
 
 nidm:noiseVarianceHomogeneous rdf:type owl:DatatypeProperty ;
                               
-                              rdfs:isDefinedBy "FIXME" ;
+                              obo:IAO_0000115 "FIXME" ;
                               
                               rdfs:domain nidm:NoiseModel ;
                               
@@ -767,7 +816,7 @@ nidm:noiseVarianceHomogeneous rdf:type owl:DatatypeProperty ;
 
 nidm:numberOfClusters rdf:type owl:DatatypeProperty ;
                       
-                      rdfs:isDefinedBy "FIXME" ;
+                      obo:IAO_0000115 "FIXME" ;
                       
                       rdfs:domain nidm:ExcursionSet ;
                       
@@ -781,12 +830,12 @@ nidm:numberOfClusters rdf:type owl:DatatypeProperty ;
 
 nidm:numberOfDimensions rdf:type owl:DatatypeProperty ;
                         
-                        rdfs:isDefinedBy "Number of dimensions of a data matrix." ;
+                        obo:IAO_0000115 "Number of dimensions of a data matrix." ;
                         
-                        iao:IAO_0000116 """BIRNLex or 
+                        obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_43. """ ;
                         
-                        iao:IAO_0000112 "3" ;
+                        obo:IAO_0000112 "3" ;
                         
                         rdfs:domain nidm:CoordinateSpace ;
                         
@@ -800,14 +849,14 @@ nidm:pValue rdf:type owl:DatatypeProperty ;
             
             owl:sameAs "http://purl.obolibrary.org/obo/OBI_0000175"^^xsd:anyURI ;
             
-            iao:IAO_0000116 """Range: Floatbetween0and1 not found. BIRNLex or 
+            obo:IAO_0000116 """Range: Floatbetween0and1 not found. BIRNLex or 
 NIDM Concept ID: nidm_47. """ ;
             
             rdfs:seeAlso """http://purl.obolibrary.org/obo/IAO_0000121
 http://purl.obolibrary.org/obo/OBI_0000175
 http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#P-Value""" ;
             
-            iao:IAO_0000112 "8.95E-14" ;
+            obo:IAO_0000112 "8.95E-14" ;
             
             owl:sameAs "This definition is from OBI. Please update this note if the definition is modified." ;
             
@@ -821,16 +870,16 @@ http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#P-Value""" ;
 
 nidm:pValueFWER rdf:type owl:DatatypeProperty ;
                 
-                iao:IAO_0000112 "0.05" ;
+                obo:IAO_0000112 "0.05" ;
                 
-                iao:IAO_0000116 """Range: Floatbetween0and1 not found. BIRNLex or 
+                obo:IAO_0000116 """Range: Floatbetween0and1 not found. BIRNLex or 
 NIDM Concept ID: nidm_48. """ ;
                 
                 owl:sameAs "This definition is from OBI. Please update this note if the definition is modified." ;
                 
                 rdfs:seeAlso "Synonym of \"nidm:pFWE\"" ;
                 
-                rdfs:isDefinedBy "\"A quantitative confidence value resulting from a multiple testing error correction method which adjusts the p-value used as input to control for Type I error in the context of multiple pairwise tests\"" ;
+                obo:IAO_0000115 "\"A quantitative confidence value resulting from a multiple testing error correction method which adjusts the p-value used as input to control for Type I error in the context of multiple pairwise tests\"" ;
                 
                 rdfs:domain nidm:Cluster ,
                             nidm:ExtentThreshold ,
@@ -845,13 +894,13 @@ NIDM Concept ID: nidm_48. """ ;
 
 nidm:pValueUncorrected rdf:type owl:DatatypeProperty ;
                        
-                       rdfs:isDefinedBy "A p-value reported without correction for multiple testing.        " ;
+                       obo:IAO_0000115 "A p-value reported without correction for multiple testing.        " ;
                        
-                       iao:IAO_0000112 "0.0542" ;
+                       obo:IAO_0000112 "0.0542" ;
                        
                        rdfs:seeAlso "http://purl.obolibrary.org/obo/IAO_0000121" ;
                        
-                       iao:IAO_0000116 """Parent: p-value i.e. nidm:nidm_0011 not found. Range: Floatbetween0and1 not found. BIRNLex or 
+                       obo:IAO_0000116 """Parent: p-value i.e. nidm:nidm_0011 not found. Range: Floatbetween0and1 not found. BIRNLex or 
 NIDM Concept ID: nidm_49. """ ;
                        
                        rdfs:domain nidm:Cluster ,
@@ -867,12 +916,12 @@ NIDM Concept ID: nidm_49. """ ;
 
 nidm:qValueFDR rdf:type owl:DatatypeProperty ;
                
-               iao:IAO_0000112 "0.000154" ;
+               obo:IAO_0000112 "0.000154" ;
                
-               iao:IAO_0000116 """Parent: p-value i.e. nidm:nidm_0011 not found. Range: Floatbetween0and1 not found. BIRNLex or 
+               obo:IAO_0000116 """Parent: p-value i.e. nidm:nidm_0011 not found. Range: Floatbetween0and1 not found. BIRNLex or 
 NIDM Concept ID: nidm_50. """ ;
                
-               rdfs:isDefinedBy "P-value adjusted for the multiple testing, controlling for the False Discovery Rate" ;
+               obo:IAO_0000115 "P-value adjusted for the multiple testing, controlling for the False Discovery Rate" ;
                
                rdfs:seeAlso "http://purl.obolibrary.org/obo/OBI_0001442" ;
                
@@ -889,12 +938,12 @@ NIDM Concept ID: nidm_50. """ ;
 
 nidm:randomFieldStationarity rdf:type owl:DatatypeProperty ;
                              
-                             iao:IAO_0000112 "stationaryRandomField" ;
+                             obo:IAO_0000112 "stationaryRandomField" ;
                              
-                             iao:IAO_0000116 """Range: {nonStationaryRandomField not foundstationaryRandomField} not found. BIRNLex or 
+                             obo:IAO_0000116 """Range: {nonStationaryRandomField not foundstationaryRandomField} not found. BIRNLex or 
 NIDM Concept ID: nidm_51. """ ;
                              
-                             rdfs:isDefinedBy "Is the random field assumed to be stationary across the entire search volume?" ;
+                             obo:IAO_0000115 "Is the random field assumed to be stationary across the entire search volume?" ;
                              
                              rdfs:domain nidm:SearchSpaceMap ;
                              
@@ -906,12 +955,12 @@ NIDM Concept ID: nidm_51. """ ;
 
 nidm:smoothingFWHM rdf:type owl:DatatypeProperty ;
                    
-                   iao:IAO_0000116 """Domain or Attributes: <notinuse> not found. BIRNLex or 
+                   obo:IAO_0000116 """Domain or Attributes: <notinuse> not found. BIRNLex or 
 NIDM Concept ID: nidm_54. """ ;
                    
-                   rdfs:isDefinedBy "Full width at half maximum of a Gaussian smoothing kernel in real world units (e.g. mm mm mm)." ;
+                   obo:IAO_0000115 "Full width at half maximum of a Gaussian smoothing kernel in real world units (e.g. mm mm mm)." ;
                    
-                   iao:IAO_0000112 "[6 6 6]" .
+                   obo:IAO_0000112 "[6 6 6]" .
 
 
 
@@ -919,12 +968,12 @@ NIDM Concept ID: nidm_54. """ ;
 
 nidm:softwareVersion rdf:type owl:DatatypeProperty ;
                      
-                     iao:IAO_0000116 """BIRNLex or 
+                     obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_55. """ ;
                      
-                     iao:IAO_0000112 "SPM99, SPM2, SPM5, SPM8, SPM12b, FSL5.0.0" ;
+                     obo:IAO_0000112 "SPM99, SPM2, SPM5, SPM8, SPM12b, FSL5.0.0" ;
                      
-                     rdfs:isDefinedBy "Name and number that specifies the software version." ;
+                     obo:IAO_0000115 "Name and number that specifies the software version." ;
                      
                      rdfs:range xsd:string ;
                      
@@ -938,10 +987,10 @@ nidm:standardError rdf:type owl:DatatypeProperty ;
                    
                    owl:sameAs "This definition is from OBI. Please update this note if the definition is modified." ;
                    
-                   iao:IAO_0000116 """Domain or Attributes: <notinuse> not found. BIRNLex or 
+                   obo:IAO_0000116 """Domain or Attributes: <notinuse> not found. BIRNLex or 
 NIDM Concept ID: nidm_58. """ ;
                    
-                   rdfs:isDefinedBy "\"A quantitative confidence value which is the standard deviations of the sample in a frequency distribution, obtained by dividing the standard deviation by the total number of cases in the frequency distribution.\"" .
+                   obo:IAO_0000115 "\"A quantitative confidence value which is the standard deviations of the sample in a frequency distribution, obtained by dividing the standard deviation by the total number of cases in the frequency distribution.\"" .
 
 
 
@@ -949,11 +998,11 @@ NIDM Concept ID: nidm_58. """ ;
 
 nidm:targetIntensity rdf:type owl:DatatypeProperty ;
                      
-                     rdfs:isDefinedBy "Value to which the grand mean of the Data was scaled (applies only if grandMeanScaling is true)." ;
+                     obo:IAO_0000115 "Value to which the grand mean of the Data was scaled (applies only if grandMeanScaling is true)." ;
                      
-                     iao:IAO_0000112 "100" ;
+                     obo:IAO_0000112 "100" ;
                      
-                     iao:IAO_0000116 """Range: positivefloat not found. BIRNLex or 
+                     obo:IAO_0000116 """Range: positivefloat not found. BIRNLex or 
 NIDM Concept ID: nidm_97. """ ;
                      
                      rdfs:domain nidm:Data ;
@@ -966,14 +1015,14 @@ NIDM Concept ID: nidm_97. """ ;
 
 nidm:underlayFile rdf:type owl:DatatypeProperty ;
                   
-                  rdfs:isDefinedBy "Map or surface on which the associated results are displayed. " ;
+                  obo:IAO_0000115 "Map or surface on which the associated results are displayed. " ;
                   
-                  iao:IAO_0000116 """Parent: nidm:map not found. Range: Pathtoaniftiimage not found. BIRNLex or 
+                  obo:IAO_0000116 """Parent: nidm:map not found. Range: Pathtoaniftiimage not found. BIRNLex or 
 NIDM Concept ID: nidm_64. """ ;
                   
-                  iao:IAO_0000112 "MNI152.nii.gz or cortex.surf.gii" ;
+                  obo:IAO_0000112 "MNI152.nii.gz or cortex.surf.gii" ;
                   
-                  iao:IAO_0000116 """Parent: nidm:map not found. Range: PathtoaNIfTIimage not found. BIRNLex or 
+                  obo:IAO_0000116 """Parent: nidm:map not found. Range: PathtoaNIfTIimage not found. BIRNLex or 
 NIDM Concept ID: nidm_64. """ ;
                   
                   rdfs:domain nidm:ExcursionSet .
@@ -984,12 +1033,12 @@ NIDM Concept ID: nidm_64. """ ;
 
 nidm:userSpecifiedThresholdType rdf:type owl:DatatypeProperty ;
                                 
-                                iao:IAO_0000116 """Range: {'nidm:pValueFWER' not found'nidm:pValueFDR' not found'nidm:pValueUncorrected';'nidm:statistic'} not found. BIRNLex or 
+                                obo:IAO_0000116 """Range: {'nidm:pValueFWER' not found'nidm:pValueFDR' not found'nidm:pValueUncorrected';'nidm:statistic'} not found. BIRNLex or 
 NIDM Concept ID: nidm_65. """ ;
                                 
-                                rdfs:isDefinedBy "Type of method used to define a threshold (e.g. statistic value, uncorrected P-value or corrected P-value)." ;
+                                obo:IAO_0000115 "Type of method used to define a threshold (e.g. statistic value, uncorrected P-value or corrected P-value)." ;
                                 
-                                iao:IAO_0000112 "nidm:pValueFWER" ;
+                                obo:IAO_0000112 "nidm:pValueFWER" ;
                                 
                                 rdfs:domain nidm:ExtentThreshold ,
                                             nidm:HeightThreshold ;
@@ -1002,7 +1051,7 @@ NIDM Concept ID: nidm_65. """ ;
 
 nidm:version rdf:type owl:DatatypeProperty ;
              
-             rdfs:isDefinedBy "FIXME" ;
+             obo:IAO_0000115 "FIXME" ;
              
              rdfs:range xsd:string ;
              
@@ -1014,14 +1063,14 @@ nidm:version rdf:type owl:DatatypeProperty ;
 
 nidm:voxelSize rdf:type owl:DatatypeProperty ;
                
-               iao:IAO_0000112 "[2 2 4]" ;
+               obo:IAO_0000112 "[2 2 4]" ;
                
-               rdfs:isDefinedBy "3D size of a voxel measured in voxelUnits." ;
+               obo:IAO_0000115 "3D size of a voxel measured in voxelUnits." ;
                
                rdfs:seeAlso """http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C95003 
 """ ;
                
-               iao:IAO_0000116 """Parent: size  not found. Range: Vectoroffloats not found. BIRNLex or 
+               obo:IAO_0000116 """Parent: size  not found. Range: Vectoroffloats not found. BIRNLex or 
 NIDM Concept ID: nidm_67. """ ;
                
                rdfs:domain nidm:CoordinateSpace ;
@@ -1034,11 +1083,11 @@ NIDM Concept ID: nidm_67. """ ;
 
 nidm:voxelToWorldMapping rdf:type owl:DatatypeProperty ;
                          
-                         iao:IAO_0000112 "[3 0 0 0;0 3 0 0;0 0 3 0; 0 0 0 1] " ;
+                         obo:IAO_0000112 "[3 0 0 0;0 3 0 0;0 0 3 0; 0 0 0 1] " ;
                          
-                         rdfs:isDefinedBy "Homogeneous transformation matrix to map from voxel coordinate system to world coordinate system." ;
+                         obo:IAO_0000115 "Homogeneous transformation matrix to map from voxel coordinate system to world coordinate system." ;
                          
-                         iao:IAO_0000116 """Range: Matrixoffloat not found. BIRNLex or 
+                         obo:IAO_0000116 """Range: Matrixoffloat not found. BIRNLex or 
 NIDM Concept ID: nidm_68. """ ;
                          
                          rdfs:domain nidm:CoordinateSpace ;
@@ -1051,12 +1100,12 @@ NIDM Concept ID: nidm_68. """ ;
 
 nidm:voxelUnits rdf:type owl:DatatypeProperty ;
                 
-                rdfs:isDefinedBy "Units associated with each dimensions of some N-dimensional data." ;
+                obo:IAO_0000115 "Units associated with each dimensions of some N-dimensional data." ;
                 
-                iao:IAO_0000116 """Range: Vectorofstrings not found. BIRNLex or 
+                obo:IAO_0000116 """Range: Vectorofstrings not found. BIRNLex or 
 NIDM Concept ID: nidm_69. """ ;
                 
-                iao:IAO_0000112 "{'mm' 'mm' 's'}" ;
+                obo:IAO_0000112 "{'mm' 'mm' 's'}" ;
                 
                 rdfs:domain nidm:CoordinateSpace ;
                 
@@ -1068,9 +1117,9 @@ NIDM Concept ID: nidm_69. """ ;
 
 spm:clusterSizeInResels rdf:type owl:DatatypeProperty ;
                         
-                        rdfs:isDefinedBy "Number of resels that make up a cluster." ;
+                        obo:IAO_0000115 "Number of resels that make up a cluster." ;
                         
-                        iao:IAO_0000112 "13" ;
+                        obo:IAO_0000112 "13" ;
                         
                         rdfs:domain nidm:Cluster ,
                                     nidm:ExtentThreshold ;
@@ -1088,9 +1137,9 @@ spm:clusterSizeInResels rdf:type owl:DatatypeProperty ;
 
 spm:expectedNumberOfClusters rdf:type owl:DatatypeProperty ;
                              
-                             rdfs:isDefinedBy "Expected number of clusters in an excursion set." ;
+                             obo:IAO_0000115 "Expected number of clusters in an excursion set." ;
                              
-                             iao:IAO_0000112 "9.51" ;
+                             obo:IAO_0000112 "9.51" ;
                              
                              rdfs:domain nidm:SearchSpaceMap ;
                              
@@ -1107,11 +1156,11 @@ spm:expectedNumberOfClusters rdf:type owl:DatatypeProperty ;
 
 spm:expectedNumberOfVerticesPerCluster rdf:type owl:DatatypeProperty ;
                                        
-                                       iao:IAO_0000112 "60.632" ;
+                                       obo:IAO_0000112 "60.632" ;
                                        
-                                       rdfs:isDefinedBy "Expected number of vertices in a cluster." ;
+                                       obo:IAO_0000115 "Expected number of vertices in a cluster." ;
                                        
-                                       iao:IAO_0000116 """Range: Positivefloat not found. BIRNLex or 
+                                       obo:IAO_0000116 """Range: Positivefloat not found. BIRNLex or 
 NIDM Concept ID: spm_72. """ ;
                                        
                                        rdfs:domain nidm:SearchSpaceMap ;
@@ -1129,12 +1178,12 @@ NIDM Concept ID: spm_72. """ ;
 
 spm:expectedNumberOfVoxelsPerCluster rdf:type owl:DatatypeProperty ;
                                      
-                                     iao:IAO_0000116 """Range: Positivefloat not found. BIRNLex or 
+                                     obo:IAO_0000116 """Range: Positivefloat not found. BIRNLex or 
 NIDM Concept ID: spm_73. """ ;
                                      
-                                     iao:IAO_0000112 "60.632" ;
+                                     obo:IAO_0000112 "60.632" ;
                                      
-                                     rdfs:isDefinedBy "Expected number of voxels in a cluster." ;
+                                     obo:IAO_0000115 "Expected number of voxels in a cluster." ;
                                      
                                      rdfs:domain nidm:SearchSpaceMap ;
                                      
@@ -1151,12 +1200,12 @@ NIDM Concept ID: spm_73. """ ;
 
 spm:heightCriticalThresholdFDR05 rdf:type owl:DatatypeProperty ;
                                  
-                                 rdfs:isDefinedBy "Peak statistic threshold corrected for false discovery rate at a level of alpha = 0.05. " ;
+                                 obo:IAO_0000115 "Peak statistic threshold corrected for false discovery rate at a level of alpha = 0.05. " ;
                                  
-                                 iao:IAO_0000116 """BIRNLex or 
+                                 obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: spm_74. """ ;
                                  
-                                 iao:IAO_0000112 "5.896" ;
+                                 obo:IAO_0000112 "5.896" ;
                                  
                                  rdfs:domain nidm:SearchSpaceMap ;
                                  
@@ -1168,12 +1217,12 @@ NIDM Concept ID: spm_74. """ ;
 
 spm:heightCriticalThresholdFWE05 rdf:type owl:DatatypeProperty ;
                                  
-                                 rdfs:isDefinedBy "Peak statistic threshold corrected for family-wise error at a level of alpha = 0.05. " ;
+                                 obo:IAO_0000115 "Peak statistic threshold corrected for family-wise error at a level of alpha = 0.05. " ;
                                  
-                                 iao:IAO_0000116 """BIRNLex or 
+                                 obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: spm_75. """ ;
                                  
-                                 iao:IAO_0000112 "4.913" ;
+                                 obo:IAO_0000112 "4.913" ;
                                  
                                  rdfs:domain nidm:SearchSpaceMap ;
                                  
@@ -1185,11 +1234,11 @@ NIDM Concept ID: spm_75. """ ;
 
 spm:noiseFWHMInUnits rdf:type owl:DatatypeProperty ;
                      
-                     iao:IAO_0000112 "[8.87, 8.89, 7.83]" ;
+                     obo:IAO_0000112 "[8.87, 8.89, 7.83]" ;
                      
-                     rdfs:isDefinedBy "Estimated Full Width at Half Maximum of the noise distribution in world units." ;
+                     obo:IAO_0000115 "Estimated Full Width at Half Maximum of the noise distribution in world units." ;
                      
-                     iao:IAO_0000116 """Range: Vectorofpositivefloats not found. BIRNLex or 
+                     obo:IAO_0000116 """Range: Vectorofpositivefloats not found. BIRNLex or 
 NIDM Concept ID: spm_78. """ ;
                      
                      rdfs:domain nidm:SearchSpaceMap ;
@@ -1204,12 +1253,12 @@ NIDM Concept ID: spm_78. """ ;
 
 spm:noiseFWHMInVertices rdf:type owl:DatatypeProperty ;
                         
-                        iao:IAO_0000116 """Range: Vectorofpositivefloats not found. BIRNLex or 
+                        obo:IAO_0000116 """Range: Vectorofpositivefloats not found. BIRNLex or 
 NIDM Concept ID: spm_79. """ ;
                         
-                        rdfs:isDefinedBy "Estimated Full Width at Half Maximum of the noise distribution in world vertices." ;
+                        obo:IAO_0000115 "Estimated Full Width at Half Maximum of the noise distribution in world vertices." ;
                         
-                        iao:IAO_0000112 "[2.95, 2.96, 2.61]" ;
+                        obo:IAO_0000112 "[2.95, 2.96, 2.61]" ;
                         
                         rdfs:domain nidm:MaskMap ;
                         
@@ -1221,12 +1270,12 @@ NIDM Concept ID: spm_79. """ ;
 
 spm:noiseFWHMInVoxels rdf:type owl:DatatypeProperty ;
                       
-                      rdfs:isDefinedBy "Estimated Full Width at Half Maximum of the noise distribution in voxels." ;
+                      obo:IAO_0000115 "Estimated Full Width at Half Maximum of the noise distribution in voxels." ;
                       
-                      iao:IAO_0000116 """Context: NoiseFWHM nidm_0009. Range: Vectorofpositivefloats not found. BIRNLex or 
+                      obo:IAO_0000116 """Context: NoiseFWHM nidm_0009. Range: Vectorofpositivefloats not found. BIRNLex or 
 NIDM Concept ID: spm_80. """ ;
                       
-                      iao:IAO_0000112 "[3.7 3.7 3.1]" ;
+                      obo:IAO_0000112 "[3.7 3.7 3.1]" ;
                       
                       rdfs:seeAlso "Synonyms of or close match with nidm:NoiseFWHM" ;
                       
@@ -1242,9 +1291,9 @@ NIDM Concept ID: spm_80. """ ;
 
 spm:reselSize rdf:type owl:DatatypeProperty ;
               
-              iao:IAO_0000112 "22.325" ;
+              obo:IAO_0000112 "22.325" ;
               
-              rdfs:isDefinedBy "Size of one resel in voxels or vertices." ;
+              obo:IAO_0000115 "Size of one resel in voxels or vertices." ;
               
               rdfs:domain nidm:SearchSpaceMap ;
               
@@ -1261,11 +1310,11 @@ spm:reselSize rdf:type owl:DatatypeProperty ;
 
 spm:searchVolumeInResels rdf:type owl:DatatypeProperty ;
                          
-                         rdfs:isDefinedBy "Total number of resels within the search volume." ;
+                         obo:IAO_0000115 "Total number of resels within the search volume." ;
                          
                          rdfs:seeAlso "Synonyms of nidm:volumeInResels" ;
                          
-                         iao:IAO_0000112 "151.3" ;
+                         obo:IAO_0000112 "151.3" ;
                          
                          rdfs:domain nidm:SearchSpaceMap ;
                          
@@ -1282,14 +1331,14 @@ spm:searchVolumeInResels rdf:type owl:DatatypeProperty ;
 
 spm:searchVolumeInUnits rdf:type owl:DatatypeProperty ;
                         
-                        iao:IAO_0000112 "1771011" ;
+                        obo:IAO_0000112 "1771011" ;
                         
-                        rdfs:isDefinedBy "Total number of product of coordinate units within the search volume." ;
+                        obo:IAO_0000115 "Total number of product of coordinate units within the search volume." ;
                         
-                        iao:IAO_0000116 """Context: volumeInVoxels nidm_0025. Range: Positivefloat not found. BIRNLex or 
+                        obo:IAO_0000116 """Context: volumeInVoxels nidm_0025. Range: Positivefloat not found. BIRNLex or 
 NIDM Concept ID: spm_84. """ ;
                         
-                        rdfs:isDefinedBy "The volume of the searched region in units determined by the current coordinate space units (e.g., mm^3 for axis units of mm in a three dimensional image, sec.Hz for a time by frequency two dimensional image)." ;
+                        obo:IAO_0000115 "The volume of the searched region in units determined by the current coordinate space units (e.g., mm^3 for axis units of mm in a three dimensional image, sec.Hz for a time by frequency two dimensional image)." ;
                         
                         rdfs:domain nidm:SearchSpaceMap ;
                         
@@ -1306,9 +1355,9 @@ NIDM Concept ID: spm_84. """ ;
 
 spm:searchVolumeInVertices rdf:type owl:DatatypeProperty ;
                            
-                           iao:IAO_0000112 "151.3" ;
+                           obo:IAO_0000112 "151.3" ;
                            
-                           rdfs:isDefinedBy "Total number of vertices within the search volume." ;
+                           obo:IAO_0000115 "Total number of vertices within the search volume." ;
                            
                            rdfs:domain nidm:SearchSpaceMap ;
                            
@@ -1327,12 +1376,12 @@ spm:searchVolumeInVoxels rdf:type owl:DatatypeProperty ;
                          
                          rdfs:seeAlso "Synonyms of nidm:volumeInVoxels" ;
                          
-                         iao:IAO_0000116 """Context: volumeInVoxels nidm_0025. BIRNLex or 
+                         obo:IAO_0000116 """Context: volumeInVoxels nidm_0025. BIRNLex or 
 NIDM Concept ID: spm_87. """ ;
                          
-                         rdfs:isDefinedBy "Total number of voxels within the search volume." ;
+                         obo:IAO_0000115 "Total number of voxels within the search volume." ;
                          
-                         iao:IAO_0000112 "68656" ;
+                         obo:IAO_0000112 "68656" ;
                          
                          rdfs:domain nidm:SearchSpaceMap ;
                          
@@ -1344,14 +1393,14 @@ NIDM Concept ID: spm_87. """ ;
 
 spm:searchVolumeReselsGeometry rdf:type owl:DatatypeProperty ;
                                
-                               iao:IAO_0000116 """Context: volumeInResels nidm_0024. Range: Vectorof1positiveintegerand3positivefloats not found. BIRNLex or 
+                               obo:IAO_0000116 """Context: volumeInResels nidm_0024. Range: Vectorof1positiveintegerand3positivefloats not found. BIRNLex or 
 NIDM Concept ID: spm_88. """ ;
                                
-                               iao:IAO_0000112 "[6 68.8 589.1 1475.5]" ;
+                               obo:IAO_0000112 "[6 68.8 589.1 1475.5]" ;
                                
                                rdfs:seeAlso "http://www.ncbi.nlm.nih.gov/pubmed/20408186" ;
                                
-                               rdfs:isDefinedBy "Description of geometry of search volume.  As per Worsley et al. [ http://www.ncbi.nlm.nih.gov/pubmed/20408186 ], the first element is the Euler Characteristic of the search volume, the second element is twice the average caliper diameter, the third element is half the surface area, and the fourth element is the volume.  With the exception of the first element (which is a unitless integer) all quantities are in units of Resels." ;
+                               obo:IAO_0000115 "Description of geometry of search volume.  As per Worsley et al. [ http://www.ncbi.nlm.nih.gov/pubmed/20408186 ], the first element is the Euler Characteristic of the search volume, the second element is twice the average caliper diameter, the third element is half the surface area, and the fourth element is the volume.  With the exception of the first element (which is a unitless integer) all quantities are in units of Resels." ;
                                
                                rdfs:domain nidm:SearchSpaceMap ;
                                
@@ -1365,11 +1414,11 @@ NIDM Concept ID: spm_88. """ ;
 
 spm:smallestSignifClusterSizeInVerticesFDR05 rdf:type owl:DatatypeProperty ;
                                              
-                                             iao:IAO_0000112 "5" ;
+                                             obo:IAO_0000112 "5" ;
                                              
-                                             rdfs:isDefinedBy "Smallest cluster size in vertices that are significant at a false discovery rate corrected alpha value of 0.05.  " ;
+                                             obo:IAO_0000115 "Smallest cluster size in vertices that are significant at a false discovery rate corrected alpha value of 0.05.  " ;
                                              
-                                             iao:IAO_0000116 """BIRNLex or 
+                                             obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: spm_90. """ ;
                                              
                                              rdfs:domain nidm:SearchSpaceMap ;
@@ -1382,12 +1431,12 @@ NIDM Concept ID: spm_90. """ ;
 
 spm:smallestSignifClusterSizeInVerticesFWE05 rdf:type owl:DatatypeProperty ;
                                              
-                                             rdfs:isDefinedBy """Smallest cluster size in vertices significant at family-wise error rate corrected alpha value of 0.05. 
+                                             obo:IAO_0000115 """Smallest cluster size in vertices significant at family-wise error rate corrected alpha value of 0.05. 
 """ ;
                                              
-                                             iao:IAO_0000112 "2" ;
+                                             obo:IAO_0000112 "2" ;
                                              
-                                             iao:IAO_0000116 """BIRNLex or 
+                                             obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: spm_91. """ ;
                                              
                                              rdfs:domain nidm:SearchSpaceMap ;
@@ -1400,12 +1449,12 @@ NIDM Concept ID: spm_91. """ ;
 
 spm:smallestSignifClusterSizeInVoxelsFDR05 rdf:type owl:DatatypeProperty ;
                                            
-                                           iao:IAO_0000112 "3" ;
+                                           obo:IAO_0000112 "3" ;
                                            
-                                           iao:IAO_0000116 """BIRNLex or 
+                                           obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: spm_92. """ ;
                                            
-                                           rdfs:isDefinedBy "Smallest cluster size in voxels significant at false discovery rate corrected alpha value of 0.05.  " ;
+                                           obo:IAO_0000115 "Smallest cluster size in voxels significant at false discovery rate corrected alpha value of 0.05.  " ;
                                            
                                            rdfs:domain nidm:SearchSpaceMap ;
                                            
@@ -1417,13 +1466,13 @@ NIDM Concept ID: spm_92. """ ;
 
 spm:smallestSignifClusterSizeInVoxelsFWE05 rdf:type owl:DatatypeProperty ;
                                            
-                                           rdfs:isDefinedBy """Smallest cluster size in voxels significant at family-wise error corrected alpha value of 0.05. 
+                                           obo:IAO_0000115 """Smallest cluster size in voxels significant at family-wise error corrected alpha value of 0.05. 
 """ ;
                                            
-                                           iao:IAO_0000116 """BIRNLex or 
+                                           obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: spm_93. """ ;
                                            
-                                           iao:IAO_0000112 "1" ;
+                                           obo:IAO_0000112 "1" ;
                                            
                                            rdfs:domain nidm:SearchSpaceMap ;
                                            
@@ -1435,12 +1484,12 @@ NIDM Concept ID: spm_93. """ ;
 
 spm:softwareRevision rdf:type owl:DatatypeProperty ;
                      
-                     iao:IAO_0000116 """BIRNLex or 
+                     obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: spm_94. """ ;
                      
-                     rdfs:isDefinedBy "revision number of a piece of software." ;
+                     obo:IAO_0000115 "revision number of a piece of software." ;
                      
-                     iao:IAO_0000112 "5417" ;
+                     obo:IAO_0000112 "5417" ;
                      
                      rdfs:range xsd:string ;
                      
@@ -1473,12 +1522,12 @@ fsl:CenterOfGravity rdf:type owl:Class ;
                     
                     rdfs:subClassOf prov:Entity ;
                     
-                    rdfs:isDefinedBy "Centre Of Gravity for the cluster, equivalent to the concept of Centre Of Gravity for a object with distributed mass, where intensity substitutes for mass in this case (definition from http://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Cluster)" ;
+                    obo:IAO_0000115 "Centre Of Gravity for the cluster, equivalent to the concept of Centre Of Gravity for a object with distributed mass, where intensity substitutes for mass in this case (definition from http://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Cluster)" ;
                     
-                    iao:IAO_0000116 """BIRNLex or 
+                    obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: fsl_102. """ ;
                     
-                    iao:IAO_0000112 """entity(niiri:center_of_gravity_1,
+                    obo:IAO_0000112 """entity(niiri:center_of_gravity_1,
         [prov:type = 'fsl:CenterOfGravity',
         prov:label = \"Center of gravity 1\",
         prov:location = 'niiri:COG_coordinate_0001'])""" ;
@@ -1493,14 +1542,14 @@ fsl:ClusterMaximumStatistic rdf:type owl:Class ;
                             
                             rdfs:subClassOf prov:Entity ;
                             
-                            iao:IAO_0000112 """entity(niiri:peak_0001,
+                            obo:IAO_0000112 """entity(niiri:peak_0001,
         [prov:type = 'fsl:ClusterMaximumStatistic',
         prov:type = 'nidm:Peak',
         prov:label = \"Peak 1\" %% xsd:string,
         prov:location = 'niiri:coordinate_0001',
         nidm:equivalentZStatistic = \"6.14\" %% xsd:float])""" ;
                             
-                            rdfs:isDefinedBy "FIXME" .
+                            obo:IAO_0000115 "FIXME" .
 
 
 
@@ -1510,7 +1559,7 @@ fsl:NonParametricSymmetricDistribution rdf:type owl:Class ;
                                        
                                        rdfs:subClassOf nidm:NoiseDistribution ;
                                        
-                                       rdfs:isDefinedBy "FIXME" .
+                                       obo:IAO_0000115 "FIXME" .
 
 
 
@@ -1520,7 +1569,7 @@ fsl:VarCope rdf:type owl:Class ;
             
             rdfs:subClassOf nidm:Map ;
             
-            rdfs:isDefinedBy "FIXME" .
+            obo:IAO_0000115 "FIXME" .
 
 
 
@@ -1530,9 +1579,9 @@ fsl:ZStatisticMap rdf:type owl:Class ;
                   
                   rdfs:subClassOf prov:Entity ;
                   
-                  rdfs:isDefinedBy "A map whose value at each location is a Z-statistic value. " ;
+                  obo:IAO_0000115 "A map whose value at each location is a Z-statistic value. " ;
                   
-                  iao:IAO_0000112 """entity(niiri:z_statistical_map_id,
+                  obo:IAO_0000112 """entity(niiri:z_statistical_map_id,
         [prov:type = 'nidm:StatisticMap',
         prov:type = 'fsl:ZStatisticalMap',
         prov:location = \"file:///path/to/tstat1.nii.gz\" %% xsd:anyURI,
@@ -1551,7 +1600,7 @@ nidm:ArbitrarilyCorrelatedNoise rdf:type owl:Class ;
                                 
                                 rdfs:subClassOf nidm:NoiseDependence ;
                                 
-                                rdfs:isDefinedBy "FIXME" .
+                                obo:IAO_0000115 "FIXME" .
 
 
 
@@ -1563,7 +1612,7 @@ nidm:Cluster rdf:type owl:Class ;
              
              rdfs:seeAlso "Child of \"nidm:Statistic\"" ;
              
-             iao:IAO_0000112 """entity(niiri:cluster_0001,
+             obo:IAO_0000112 """entity(niiri:cluster_0001,
       [prov:type = 'nidm:Cluster',
       prov:label = \"Cluster 0001\" %% xsd:string,
       nidm:clusterSizeInVoxels = \"530\" %% xsd:int,
@@ -1573,9 +1622,9 @@ nidm:Cluster rdf:type owl:Class ;
       nidm:pValueFWER = \"0\" %% xsd:float,
       nidm:qValueFDR = \"7.65021389184909e-51\" %% xsd:float])""" ;
              
-             rdfs:isDefinedBy "Statistic defined at the cluster-level in an excusion set. In SPM it is defined as the cluster size. FIXME (now Cluster instead of ClusterStatistic)" ;
+             obo:IAO_0000115 "Statistic defined at the cluster-level in an excusion set. In SPM it is defined as the cluster size. FIXME (now Cluster instead of ClusterStatistic)" ;
              
-             iao:IAO_0000116 """Range: - not found. BIRNLex or 
+             obo:IAO_0000116 """Range: - not found. BIRNLex or 
 NIDM Concept ID: nidm_7. """ .
 
 
@@ -1586,9 +1635,9 @@ nidm:ClusterLabelsMap rdf:type owl:Class ;
                       
                       rdfs:subClassOf nidm:Map ;
                       
-                      rdfs:isDefinedBy "FIXME" ;
+                      obo:IAO_0000115 "FIXME" ;
                       
-                      iao:IAO_0000112 """entity(niiri:cluster_label_map_id,
+                      obo:IAO_0000112 """entity(niiri:cluster_label_map_id,
       [prov:type = 'nidm:ClusterLabelsMap',
       prov:location = \"file:///path/to/ClusterLabels.nii.gz\" %% xsd:anyURI,
       nidm:filename = \"ClusterLabels.nii.gz\" %% xsd:string,
@@ -1606,7 +1655,7 @@ nidm:Colin27CoordinateSystem rdf:type owl:Class ;
                              
                              rdfs:comment "used in SPM96 (cf. http://imaging.mrc-cbu.cam.ac.uk/imaging/MniTalairach)" ;
                              
-                             rdfs:isDefinedBy "Coordinate system defined by the \"stereotaxic average of 27 T1-weighted MRI scans of the same individual\"." ;
+                             obo:IAO_0000115 "Coordinate system defined by the \"stereotaxic average of 27 T1-weighted MRI scans of the same individual\"." ;
                              
                              rdfs:comment "FIXME. This definition needs to be re-worked and reviewed." .
 
@@ -1618,7 +1667,7 @@ nidm:CompoundSymmetricNoise rdf:type owl:Class ;
                             
                             rdfs:subClassOf nidm:NoiseDependence ;
                             
-                            rdfs:isDefinedBy "FIXME" .
+                            obo:IAO_0000115 "FIXME" .
 
 
 
@@ -1629,10 +1678,10 @@ nidm:ConjunctionInference rdf:type owl:Class ;
                           rdfs:subClassOf nidm:Inference ,
                                           prov:Activity ;
                           
-                          iao:IAO_0000116 """Range: - not found. BIRNLex or 
+                          obo:IAO_0000116 """Range: - not found. BIRNLex or 
 NIDM Concept ID: nidm_8. """ ;
                           
-                          rdfs:isDefinedBy "Statistically testing for the joint significance of multiple effects, with emphasis on rejecting all (instead of one or more) of the respective null hypotheses." .
+                          obo:IAO_0000115 "Statistically testing for the joint significance of multiple effects, with emphasis on rejecting all (instead of one or more) of the respective null hypotheses." .
 
 
 
@@ -1642,14 +1691,14 @@ nidm:ContrastEstimation rdf:type owl:Class ;
                         
                         rdfs:subClassOf prov:Activity ;
                         
-                        iao:IAO_0000112 """activity(niiri:contrast_estimation_id,
+                        obo:IAO_0000112 """activity(niiri:contrast_estimation_id,
       [prov:type = 'nidm:ContrastEstimation',
       prov:label = \"Contrast estimation\"])""" ;
                         
-                        iao:IAO_0000116 """Range: - not found. BIRNLex or 
+                        obo:IAO_0000116 """Range: - not found. BIRNLex or 
 NIDM Concept ID: nidm_9. """ ;
                         
-                        rdfs:isDefinedBy "The process of estimating a contrast from the estimated parameters of statistical model." .
+                        obo:IAO_0000115 "The process of estimating a contrast from the estimated parameters of statistical model." .
 
 
 
@@ -1660,20 +1709,20 @@ nidm:ContrastMap rdf:type owl:Class ;
                  rdfs:subClassOf nidm:Map ,
                                  prov:Entity ;
                  
-                 iao:IAO_0000112 """entity(niiri:contrast_map_id,
+                 obo:IAO_0000112 """entity(niiri:contrast_map_id,
       [prov:type = 'nidm:ContrastMap',
       prov:location = \"file:///path/to/Contrast.nii.gz\" %% xsd:anyURI,
-      dct:format = 'nidm:Nifti1Gz',
+      dct:format = \"image/nifti\",
       nidm:filename = \"Contrast.nii.gz\" %% xsd:string,
       prov:label = \"Contrast Map: listening > rest\" %% xsd:string,
       nidm:contrastName = \"listening > rest\" %% xsd:string,
       nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" ;
                  
-                 iao:IAO_0000116 """Context: io terms. Parent: nidm:map, Scan Image  not found. Range: - not found. BIRNLex or 
+                 obo:IAO_0000116 """Context: io terms. Parent: nidm:map, Scan Image  not found. Range: - not found. BIRNLex or 
 NIDM Concept ID: nidm_10. """ ;
                  
-                 rdfs:isDefinedBy "A map whose value at each location is statistical contrast estimate." .
+                 obo:IAO_0000115 "A map whose value at each location is statistical contrast estimate." .
 
 
 
@@ -1683,7 +1732,7 @@ nidm:ContrastStandardErrorMap rdf:type owl:Class ;
                               
                               rdfs:subClassOf nidm:Map ;
                               
-                              iao:IAO_0000112 """entity(niiri:contrast_standard_error_map_id,
+                              obo:IAO_0000112 """entity(niiri:contrast_standard_error_map_id,
       [prov:type = 'nidm:ContrastStandardErrorMap',
       prov:location = \"file:///path/to/ContrastStandardError.nii.gz\" %% xsd:anyURI,
       nidm:filename = \"ContrastStandardError.nii.gz\" %% xsd:string,
@@ -1692,9 +1741,9 @@ nidm:ContrastStandardErrorMap rdf:type owl:Class ;
       nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" ;
                               
-                              rdfs:isDefinedBy "A map whose value at each location is the standard error of a given contrast." ;
+                              obo:IAO_0000115 "A map whose value at each location is the standard error of a given contrast." ;
                               
-                              iao:IAO_0000116 """BIRNLex or 
+                              obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_12. """ .
 
 
@@ -1705,17 +1754,17 @@ nidm:ContrastWeights rdf:type owl:Class ;
                      
                      rdfs:subClassOf prov:Entity ;
                      
-                     iao:IAO_0000112 """entity(niiri:contrast_weights_id,
+                     obo:IAO_0000112 """entity(niiri:contrast_weights_id,
       [prov:type = 'nidm:ContrastWeights',
       nidm:statisticType = 'nidm:TStatistic',
       nidm:contrastName = \"listening > rest\" %% xsd:string,
       prov:label = \"Contrast: Listening > Rest\" %% xsd:string,
       prov:value = \"[1, 0, 0]\" %% xsd:string])""" ;
                      
-                     iao:IAO_0000116 """Range: Vectorofintegers not found. BIRNLex or 
+                     obo:IAO_0000116 """Range: Vectorofintegers not found. BIRNLex or 
 NIDM Concept ID: nidm_13. """ ;
                      
-                     rdfs:isDefinedBy "Vector defining the linear combination associated with a particular contrast. " .
+                     obo:IAO_0000115 "Vector defining the linear combination associated with a particular contrast. " .
 
 
 
@@ -1727,7 +1776,7 @@ nidm:Coordinate rdf:type owl:Class ;
                 
                 owl:sameAs "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C44465"^^xsd:anyURI ;
                 
-                iao:IAO_0000112 """entity(niiri:coordinate_0001,
+                obo:IAO_0000112 """entity(niiri:coordinate_0001,
       [prov:type = 'prov:Location',
       prov:type = 'nidm:Coordinate',
       prov:label = \"Coordinate: 0001\" %% xsd:string,
@@ -1745,7 +1794,7 @@ nidm:Coordinate rdf:type owl:Class ;
         nidm:coordinate2 = \"-73.7\" %% xsd:float,
         nidm:coordinate3 = \"-9.24\" %% xsd:float])""" ;
                 
-                iao:IAO_0000116 """Model: - search for coordinate uri
+                obo:IAO_0000116 """Model: - search for coordinate uri
 - subclasses of coordinate
 - additional properties (e.g. units) 
 . Context: Functional. BIRNLex or 
@@ -1759,10 +1808,10 @@ nidm:CoordinateSpace rdf:type owl:Class ;
                      
                      rdfs:subClassOf prov:Entity ;
                      
-                     iao:IAO_0000116 """BIRNLex or 
+                     obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_21. """ ;
                      
-                     iao:IAO_0000112 """entity(niiri:coordinate_space_id_1,
+                     obo:IAO_0000112 """entity(niiri:coordinate_space_id_1,
       [prov:type = 'nidm:CoordinateSpace',
       prov:label = \"Coordinate space 1\" %% xsd:string,
       nidm:voxelToWorldMapping = \"[[-3, 0, 0, 78],[0, 3, 0, -112],[0, 0, 3, -50],[0, 0, 0, 1]]\" %% xsd:string,
@@ -1772,7 +1821,7 @@ NIDM Concept ID: nidm_21. """ ;
       nidm:numberOfDimensions = \"3\" %% xsd:int,
       nidm:dimensionsInVoxels = \"[53,63,46]\" %% xsd:string])""" ;
                      
-                     rdfs:isDefinedBy "An entity with spatial attributes (e.g., dimensions, units, and voxel-to-world mapping) that provides context to a SpatialImage (e.g., a StatisticMap)." .
+                     obo:IAO_0000115 "An entity with spatial attributes (e.g., dimensions, units, and voxel-to-world mapping) that provides context to a SpatialImage (e.g., a StatisticMap)." .
 
 
 
@@ -1792,7 +1841,7 @@ nidm:CustomMaskMap rdf:type owl:Class ;
                    
                    rdfs:subClassOf nidm:Map ;
                    
-                   iao:IAO_0000112 """entity(niiri:custom_mask_id_1,
+                   obo:IAO_0000112 """entity(niiri:custom_mask_id_1,
       [prov:type = 'nidm:CustomMaskMap',
       prov:location = \"file:///path/to/CustomMask.nii.gz\" %% xsd:anyURI,
       nidm:filename = \"CustomMask.nii.gz\" %% xsd:string,
@@ -1801,10 +1850,10 @@ nidm:CustomMaskMap rdf:type owl:Class ;
       nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" ;
                    
-                   iao:IAO_0000116 """BIRNLex or 
+                   obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_99. """ ;
                    
-                   rdfs:isDefinedBy "mask defined by the user to restrain the space in which model fitting is performed." .
+                   obo:IAO_0000115 "mask defined by the user to restrain the space in which model fitting is performed." .
 
 
 
@@ -1814,14 +1863,14 @@ nidm:Data rdf:type owl:Class ;
           
           rdfs:subClassOf prov:Entity ;
           
-          iao:IAO_0000116 """BIRNLex or 
+          obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_23. """ ;
           
-          rdfs:isDefinedBy "\"A collection or single item of factual information, derived from measurement or research, from which conclusions may be drawn.\"" ;
+          obo:IAO_0000115 "\"A collection or single item of factual information, derived from measurement or research, from which conclusions may be drawn.\"" ;
           
           owl:sameAs "This definition is from NCIT. Please update this note if the definition is modified." ;
           
-          iao:IAO_0000112 """entity(niiri:data_id,
+          obo:IAO_0000112 """entity(niiri:data_id,
       [prov:type = 'nidm:Data',
       prov:type = 'prov:Collection',
       prov:label = \"Data\" %% xsd:string,
@@ -1838,10 +1887,10 @@ nidm:DesignMatrix rdf:type owl:Class ;
                   
                   rdfs:subClassOf prov:Entity ;
                   
-                  iao:IAO_0000116 """BIRNLex or 
+                  obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_24. """ ;
                   
-                  iao:IAO_0000112 """entity(niiri:design_matrix_id,
+                  obo:IAO_0000112 """entity(niiri:design_matrix_id,
       [prov:type = 'nidm:DesignMatrix',
       prov:location = \"file:///path/to/DesignMatrix.csv\" %% xsd:anyURI,
       dct:format = \"text/csv\",
@@ -1851,7 +1900,7 @@ NIDM Concept ID: nidm_24. """ ;
                   
                   rdfs:seeAlso "stato:design matrix" ;
                   
-                  rdfs:isDefinedBy "A matrix of values defining the explanatory variables used in a regression model.  Each column corresponds to one explanatory variable, each row corresponds to one observation." .
+                  obo:IAO_0000115 "A matrix of values defining the explanatory variables used in a regression model.  Each column corresponds to one explanatory variable, each row corresponds to one observation." .
 
 
 
@@ -1871,7 +1920,7 @@ nidm:ExchangeableNoise rdf:type owl:Class ;
                        
                        rdfs:comment "Under gaussianity assumption this is equivalent to compound symmetry but not in general." ;
                        
-                       rdfs:isDefinedBy "FIXME" .
+                       obo:IAO_0000115 "FIXME" .
 
 
 
@@ -1881,7 +1930,7 @@ nidm:ExcursionSet rdf:type owl:Class ;
                   
                   rdfs:subClassOf nidm:Map ;
                   
-                  iao:IAO_0000112 """entity(niiri:excursion_set_id,
+                  obo:IAO_0000112 """entity(niiri:excursion_set_id,
       [prov:type = 'nidm:ExcursionSet',
       prov:location = \"file:///path/to/ExcursionSet.nii.gz\" %% xsd:anyURI,
       dct:format = \"image/nifti\",
@@ -1894,10 +1943,10 @@ nidm:ExcursionSet rdf:type owl:Class ;
       nidm:numberOfClusters = \"8\" %% xsd:int,
       nidm:pValue = \"8.95949980872501e-14\" %% xsd:float])""" ;
                   
-                  iao:IAO_0000116 """BIRNLex or 
+                  obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_29. """ ;
                   
-                  rdfs:isDefinedBy "Set of map elements surviving a thresholding procedure." .
+                  obo:IAO_0000115 "Set of map elements surviving a thresholding procedure." .
 
 
 
@@ -1907,10 +1956,10 @@ nidm:ExtentThreshold rdf:type owl:Class ;
                      
                      rdfs:subClassOf prov:Entity ;
                      
-                     rdfs:isDefinedBy """A numerical value that establishes a bound on a range of cluster-sizes. / [from extentThresh:]        Minimum cluster size used when thresholding a statistic image        5voxels
+                     obo:IAO_0000115 """A numerical value that establishes a bound on a range of cluster-sizes. / [from extentThresh:]        Minimum cluster size used when thresholding a statistic image        5voxels
 """ ;
                      
-                     iao:IAO_0000112 """entity(niiri:extent_threshold_id,
+                     obo:IAO_0000112 """entity(niiri:extent_threshold_id,
       [prov:type = 'nidm:ExtentThreshold',
       prov:label = \"Extent Threshold: k>=0\" %% xsd:string,
       nidm:clusterSizeInVoxels = \"0\" %% xsd:int,
@@ -1918,7 +1967,7 @@ nidm:ExtentThreshold rdf:type owl:Class ;
       nidm:pValueUncorrected = \"1\" %% xsd:float,
       nidm:pValueFWER = \"1\" %% xsd:float])""" ;
                      
-                     iao:IAO_0000116 """Context: Attribute \"prov:value\" 
+                     obo:IAO_0000116 """Context: Attribute \"prov:value\" 
 of \"extentThresh\" nidm_0079. BIRNLex or 
 NIDM Concept ID: nidm_30. new parent: Effect. """ .
 
@@ -1932,9 +1981,9 @@ nidm:FSL rdf:type owl:Class ;
          
          rdfs:seeAlso "http://fsl.fmrib.ox.ac.uk" ;
          
-         rdfs:isDefinedBy "FMRIB Software Library software package for the analysis of neuroimaging data from the FMRIB" ;
+         obo:IAO_0000115 "FMRIB Software Library software package for the analysis of neuroimaging data from the FMRIB" ;
          
-         iao:IAO_0000116 """BIRNLex or 
+         obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_57. """ .
 
 
@@ -1945,9 +1994,9 @@ nidm:FSLResults rdf:type owl:Class ;
                 
                 rdfs:subClassOf nidm:NIDMObjectModel ;
                 
-                rdfs:isDefinedBy "FIXME" ;
+                obo:IAO_0000115 "FIXME" ;
                 
-                iao:IAO_0000112 """entity(niiri:fsl_results_id,
+                obo:IAO_0000112 """entity(niiri:fsl_results_id,
     [prov:type = 'prov:Bundle',
     prov:label = \"FSL Results\",
     nidm:objectModel = 'nidm:FSLResults',
@@ -1981,7 +2030,7 @@ nidm:GeneralizedLeastSquares rdf:type owl:Class ;
                              
                              rdfs:subClassOf nidm:EstimationMethod ;
                              
-                             rdfs:isDefinedBy "FIXME" ;
+                             obo:IAO_0000115 "FIXME" ;
                              
                              rdfs:comment "GLS (both heteroscedasticity and dependence accounted for) OLS is a special case of WLS & GLS; WLS is a special case of GLS." .
 
@@ -1993,7 +2042,7 @@ nidm:GrandMeanMap rdf:type owl:Class ;
                   
                   rdfs:subClassOf nidm:Map ;
                   
-                  iao:IAO_0000112 """entity(niiri:grand_mean_map_id,
+                  obo:IAO_0000112 """entity(niiri:grand_mean_map_id,
       [prov:type = 'nidm:GrandMeanMap',
       prov:location = \"file:///path/to/GrandMean.nii.gz\" %% xsd:anyURI,
       nidm:filename = \"GrandMean.nii.gz\" %% xsd:string,
@@ -2003,7 +2052,7 @@ nidm:GrandMeanMap rdf:type owl:Class ;
       nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" ;
                   
-                  rdfs:isDefinedBy "FIXME" .
+                  obo:IAO_0000115 "FIXME" .
 
 
 
@@ -2013,14 +2062,14 @@ nidm:HeightThreshold rdf:type owl:Class ;
                      
                      rdfs:subClassOf prov:Entity ;
                      
-                     iao:IAO_0000116 """Context: Attribute \"statistic\" nidm_0049
+                     obo:IAO_0000116 """Context: Attribute \"statistic\" nidm_0049
 of \"StatisticThresh\" nidm_0018. BIRNLex or 
 NIDM Concept ID: nidm_34. """ ;
                      
-                     rdfs:isDefinedBy """A numerical value that establishes a bound on a range of voxelwise or vertex-wise defined statistic.
+                     obo:IAO_0000115 """A numerical value that establishes a bound on a range of voxelwise or vertex-wise defined statistic.
 """ ;
                      
-                     iao:IAO_0000112 """entity(niiri:height_threshold_id,
+                     obo:IAO_0000112 """entity(niiri:height_threshold_id,
       [prov:type = 'nidm:HeightThreshold',
       prov:label = \"Height Threshold: p<0.05 (FWE)\" %% xsd:string,
       nidm:userSpecifiedThresholdType = \"p-value FWE\" %% xsd:string,
@@ -2038,7 +2087,7 @@ nidm:Icbm452AirCoordinateSystem rdf:type owl:Class ;
                                 
                                 rdfs:seeAlso "http://www.loni.usc.edu/ICBM/Downloads/Downloads_452T1.shtml" ;
                                 
-                                rdfs:isDefinedBy "Coordinate system defined by the \"average of 452 T1-weighted MRIs of normal young adult brains\" with \"linear transforms of the subjects into the atlas space using a 12-parameter affine transformation\"" ;
+                                obo:IAO_0000115 "Coordinate system defined by the \"average of 452 T1-weighted MRIs of normal young adult brains\" with \"linear transforms of the subjects into the atlas space using a 12-parameter affine transformation\"" ;
                                 
                                 rdfs:comment "FIXME. This definition needs to be re-worked and reviewed." .
 
@@ -2052,7 +2101,7 @@ nidm:Icbm452Warp5CoordinateSystem rdf:type owl:Class ;
                                   
                                   rdfs:seeAlso "http://www.loni.usc.edu/ICBM/Downloads/Downloads_452T1.shtml" ;
                                   
-                                  rdfs:isDefinedBy "Coordinate system defined by the \"average of 452 T1-weighted MRIs of normal young adult brains\" \"based on a 5th order polynomial transformation into the atlas space\"" ;
+                                  obo:IAO_0000115 "Coordinate system defined by the \"average of 452 T1-weighted MRIs of normal young adult brains\" \"based on a 5th order polynomial transformation into the atlas space\"" ;
                                   
                                   rdfs:comment "FIXME. This definition needs to be re-worked and reviewed." .
 
@@ -2069,7 +2118,7 @@ nidm:IcbmMni152LinearCoordinateSystem rdf:type owl:Class ;
                                       
                                       rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152Lin" ;
                                       
-                                      rdfs:isDefinedBy "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, linearly transformed to Talairach space\"." .
+                                      obo:IAO_0000115 "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, linearly transformed to Talairach space\"." .
 
 
 
@@ -2081,7 +2130,7 @@ nidm:IcbmMni152NonLinear2009aAsymmetricCoordinateSystem rdf:type owl:Class ;
                                                         
                                                         rdfs:comment "FIXME. This definition needs to be re-worked and reviewed." ;
                                                         
-                                                        rdfs:isDefinedBy "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." ;
+                                                        obo:IAO_0000115 "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." ;
                                                         
                                                         rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009" .
 
@@ -2095,7 +2144,7 @@ nidm:IcbmMni152NonLinear2009aSymmetricCoordinateSystem rdf:type owl:Class ;
                                                        
                                                        rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009" ;
                                                        
-                                                       rdfs:isDefinedBy "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." ;
+                                                       obo:IAO_0000115 "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." ;
                                                        
                                                        rdfs:comment "FIXME. This definition needs to be re-worked and reviewed." .
 
@@ -2111,7 +2160,7 @@ nidm:IcbmMni152NonLinear2009bAsymmetricCoordinateSystem rdf:type owl:Class ;
                                                         
                                                         rdfs:comment "FIXME. This definition needs to be re-worked and reviewed." ;
                                                         
-                                                        rdfs:isDefinedBy "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." .
+                                                        obo:IAO_0000115 "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." .
 
 
 
@@ -2121,7 +2170,7 @@ nidm:IcbmMni152NonLinear2009bSymmetricCoordinateSystem rdf:type owl:Class ;
                                                        
                                                        rdfs:subClassOf nidm:MNICoordinateSystem ;
                                                        
-                                                       rdfs:isDefinedBy "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." ;
+                                                       obo:IAO_0000115 "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." ;
                                                        
                                                        rdfs:comment "FIXME. This definition needs to be re-worked and reviewed." ;
                                                        
@@ -2139,7 +2188,7 @@ nidm:IcbmMni152NonLinear2009cAsymmetricCoordinateSystem rdf:type owl:Class ;
                                                         
                                                         rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009" ;
                                                         
-                                                        rdfs:isDefinedBy "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." ;
+                                                        obo:IAO_0000115 "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." ;
                                                         
                                                         rdfs:comment "FIXME. This definition needs to be re-worked and reviewed." .
 
@@ -2151,7 +2200,7 @@ nidm:IcbmMni152NonLinear2009cSymmetricCoordinateSystem rdf:type owl:Class ;
                                                        
                                                        rdfs:subClassOf nidm:MNICoordinateSystem ;
                                                        
-                                                       rdfs:isDefinedBy "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." ;
+                                                       obo:IAO_0000115 "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." ;
                                                        
                                                        rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009" ;
                                                        
@@ -2167,7 +2216,7 @@ nidm:IcbmMni152NonLinear6thGenerationCoordinateSystem rdf:type owl:Class ;
                                                       
                                                       rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin6"^^xsd:anyURI ;
                                                       
-                                                      rdfs:isDefinedBy "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, linearly and non-linearly (6 iterations) transformed to form a symmetric model in Talairach space\"" ;
+                                                      obo:IAO_0000115 "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, linearly and non-linearly (6 iterations) transformed to form a symmetric model in Talairach space\"" ;
                                                       
                                                       rdfs:comment "Used in FSL (cf. http://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Atlases)" ,
                                                                    "FIXME. This definition needs to be re-worked and reviewed." .
@@ -2180,7 +2229,7 @@ nidm:Image rdf:type owl:Class ;
            
            rdfs:subClassOf prov:Entity ;
            
-           iao:IAO_0000112 """entity(niiri:design_matrix_png_id,
+           obo:IAO_0000112 """entity(niiri:design_matrix_png_id,
       [prov:type = 'nidm:Image',
       prov:location = \"file:///path/to/DesignMatrix.png\" %% xsd:anyURI,
       nidm:filename = \"DesignMatrix.png\",
@@ -2193,7 +2242,7 @@ nidm:Image rdf:type owl:Class ;
            
            rdfs:comment "Class used to represent png, gif..." ;
            
-           rdfs:isDefinedBy "FIXME" .
+           obo:IAO_0000115 "FIXME" .
 
 
 
@@ -2203,7 +2252,7 @@ nidm:IndependentNoise rdf:type owl:Class ;
                       
                       rdfs:subClassOf nidm:NoiseDependence ;
                       
-                      rdfs:isDefinedBy "FIXME" .
+                      obo:IAO_0000115 "FIXME" .
 
 
 
@@ -2213,12 +2262,12 @@ nidm:Inference rdf:type owl:Class ;
                
                rdfs:subClassOf prov:Activity ;
                
-               iao:IAO_0000116 """BIRNLex or 
+               obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_35. """ ;
                
-               rdfs:isDefinedBy "The process of inferring the excursion set from a statistical map." ;
+               obo:IAO_0000115 "The process of inferring the excursion set from a statistical map." ;
                
-               iao:IAO_0000112 """activity(niiri:inference_id,
+               obo:IAO_0000112 """activity(niiri:inference_id,
       [prov:type = 'nidm:Inference',
       nidm:hasAlternativeHypothesis = 'nidm:OneTailedTest',
       prov:label = \"Inference\"])""" .
@@ -2231,7 +2280,7 @@ nidm:Ixi549Space rdf:type owl:Class ;
                  
                  rdfs:subClassOf nidm:MNICoordinateSystem ;
                  
-                 rdfs:isDefinedBy "Coordinate system defined by the average of the \"549 [...] subjects from the IXI dataset\" linearly transformed to ICBM MNI 452." ;
+                 obo:IAO_0000115 "Coordinate system defined by the average of the \"549 [...] subjects from the IXI dataset\" linearly transformed to ICBM MNI 452." ;
                  
                  rdfs:comment "Used in SPM12b (cf. spm12b/spm_templates.man)" ;
                  
@@ -2249,12 +2298,12 @@ nidm:MNICoordinateSystem rdf:type owl:Class ;
                          
                          rdfs:seeAlso "birnlex_2125" ;
                          
-                         iao:IAO_0000116 """Context: io terms. Parent: reference atlas not found. BIRNLex or 
+                         obo:IAO_0000116 """Context: io terms. Parent: reference atlas not found. BIRNLex or 
 NIDM Concept ID: nidm:nidm_40. """ ;
                          
                          rdfs:comment "FIXME. This definition needs to be re-worked and reviewed." ;
                          
-                         rdfs:isDefinedBy "Coordinate system defined with reference to the MNI atlas." .
+                         obo:IAO_0000115 "Coordinate system defined with reference to the MNI atlas." .
 
 
 
@@ -2264,7 +2313,7 @@ nidm:Map rdf:type owl:Class ;
          
          rdfs:subClassOf prov:Entity ;
          
-         rdfs:isDefinedBy "Ordered set of values corresponding to the discrete sampling of some process (e.g. brain MRI data measured on a regular 3D lattice; or brain cortical surface data measured irregularly over the cortex)." .
+         obo:IAO_0000115 "Ordered set of values corresponding to the discrete sampling of some process (e.g. brain MRI data measured on a regular 3D lattice; or brain cortical surface data measured irregularly over the cortex)." .
 
 
 
@@ -2274,7 +2323,7 @@ nidm:MapHeader rdf:type owl:Class ;
                
                rdfs:subClassOf prov:Entity ;
                
-               rdfs:isDefinedBy "FIXME" .
+               obo:IAO_0000115 "FIXME" .
 
 
 
@@ -2285,9 +2334,9 @@ nidm:MaskMap rdf:type owl:Class ;
              rdfs:subClassOf nidm:Map ,
                              prov:Entity ;
              
-             rdfs:isDefinedBy "map or surface on which the associated results are displayed. " ;
+             obo:IAO_0000115 "map or surface on which the associated results are displayed. " ;
              
-             iao:IAO_0000112 """entity(niiri:mask_id_2,
+             obo:IAO_0000112 """entity(niiri:mask_id_2,
       [prov:type = 'nidm:MaskMap',
       prov:location = \"file:///path/to/Mask.nii.gz\" %% xsd:anyURI,
       nidm:filename = \"Mask.nii.gz\" %% xsd:string,
@@ -2296,7 +2345,7 @@ nidm:MaskMap rdf:type owl:Class ;
       nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" ;
              
-             iao:IAO_0000116 """BIRNLex or 
+             obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_39. """ .
 
 
@@ -2307,7 +2356,7 @@ nidm:Mni305CoordinateSystem rdf:type owl:Class ;
                             
                             rdfs:subClassOf nidm:MNICoordinateSystem ;
                             
-                            rdfs:isDefinedBy "Coordinate system defined by the \"average of 305 T1-weighted MRI scans, linearly transformed to Talairach space\"." ;
+                            obo:IAO_0000115 "Coordinate system defined by the \"average of 305 T1-weighted MRI scans, linearly transformed to Talairach space\"." ;
                             
                             rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/MNI305" ;
                             
@@ -2321,10 +2370,10 @@ nidm:ModelParametersEstimation rdf:type owl:Class ;
                                
                                rdfs:subClassOf prov:Activity ;
                                
-                               iao:IAO_0000116 """BIRNLex or 
+                               obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_41. """ ;
                                
-                               iao:IAO_0000112 """activity(niiri:model_pe_id,
+                               obo:IAO_0000112 """activity(niiri:model_pe_id,
       [prov:type = 'nidm:ModelParametersEstimation',
       prov:label = \"Model parameters estimation\",
       nidm:withEstimationMethod = 'nidm:OrdinaryLeastSquares'
@@ -2332,7 +2381,7 @@ NIDM Concept ID: nidm_41. """ ;
                                
                                rdfs:seeAlso "stato:model parameter estimation" ;
                                
-                               rdfs:isDefinedBy "The process of estimating the parameters of a general linear model from the available data." .
+                               obo:IAO_0000115 "The process of estimating the parameters of a general linear model from the available data." .
 
 
 
@@ -2342,7 +2391,7 @@ nidm:NIDMObjectModel rdf:type owl:Class ;
                      
                      rdfs:subClassOf prov:Entity ;
                      
-                     rdfs:isDefinedBy "FIXME" .
+                     obo:IAO_0000115 "FIXME" .
 
 
 
@@ -2352,7 +2401,7 @@ nidm:NoiseDependence rdf:type owl:Class ;
                      
                      rdfs:subClassOf prov:Entity ;
                      
-                     rdfs:isDefinedBy "FIXME" .
+                     obo:IAO_0000115 "FIXME" .
 
 
 
@@ -2370,9 +2419,9 @@ nidm:NoiseModel rdf:type owl:Class ;
                 
                 rdfs:subClassOf prov:Entity ;
                 
-                rdfs:isDefinedBy "FIXME" ;
+                obo:IAO_0000115 "FIXME" ;
                 
-                iao:IAO_0000112 """entity(niiri:noise_model_id,
+                obo:IAO_0000112 """entity(niiri:noise_model_id,
       [prov:type = 'nidm:NoiseModel',
       nidm:hasNoiseDistribution = 'nidm:GaussianDistribution',
       nidm:noiseVarianceHomogeneous = \"true\" %%xsd:boolean,
@@ -2388,7 +2437,7 @@ nidm:NonParametricDistribution rdf:type owl:Class ;
                                
                                rdfs:subClassOf nidm:NoiseDistribution ;
                                
-                               rdfs:isDefinedBy "FIXME" .
+                               obo:IAO_0000115 "FIXME" .
 
 
 
@@ -2400,7 +2449,7 @@ nidm:OneTailedTest rdf:type owl:Class ;
                    
                    owl:sameAs "http://purl.obolibrary.org/obo/STATO_0000286"^^xsd:anyURI ;
                    
-                   rdfs:isDefinedBy "Re-use \"one tailed test\" from STATO." .
+                   obo:IAO_0000115 "Re-use \"one tailed test\" from STATO." .
 
 
 
@@ -2412,7 +2461,7 @@ nidm:OrdinaryLeastSquares rdf:type owl:Class ;
                           
                           rdfs:comment "OLS (no heteroscedasticity or dependence accounted for)" ;
                           
-                          rdfs:isDefinedBy "FIXME" .
+                          obo:IAO_0000115 "FIXME" .
 
 
 
@@ -2422,12 +2471,12 @@ nidm:ParameterEstimateMap rdf:type owl:Class ;
                           
                           rdfs:subClassOf nidm:Map ;
                           
-                          iao:IAO_0000116 """BIRNLex or 
+                          obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_45. """ ;
                           
-                          rdfs:isDefinedBy "A map whose value at each location is the estimate of a model parameter." ;
+                          obo:IAO_0000115 "A map whose value at each location is the estimate of a model parameter." ;
                           
-                          iao:IAO_0000112 """entity(niiri:parameter_estimate_map_id_1,
+                          obo:IAO_0000112 """entity(niiri:parameter_estimate_map_id_1,
       [prov:type = 'nidm:ParameterEstimateMap',
       prov:location = \"file:///path/to/ParameterEstimate_0001.nii.gz\" %% xsd:anyURI,
       prov:label = \"Beta Map 1\" %% xsd:string,
@@ -2444,10 +2493,10 @@ nidm:Peak rdf:type owl:Class ;
           
           rdfs:subClassOf prov:Entity ;
           
-          iao:IAO_0000116 """BIRNLex or 
+          obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_46. """ ;
           
-          iao:IAO_0000112 """entity(niiri:peak_0001,
+          obo:IAO_0000112 """entity(niiri:peak_0001,
       [prov:type = 'nidm:Peak',
       prov:label = \"Peak 0001\" %% xsd:string,
       prov:location = 'niiri:coordinate_0001',
@@ -2457,7 +2506,7 @@ NIDM Concept ID: nidm_46. """ ;
       nidm:pValueFWER = \"0\" %% xsd:float,
       nidm:qValueFDR = \"6.3705194444993e-11\" %% xsd:float])""" ;
           
-          rdfs:isDefinedBy "Statistic defined at the peak-level in an excursion set. FIXME (now Peak instead of PeakStatistic)" .
+          obo:IAO_0000115 "Statistic defined at the peak-level in an excursion set. FIXME (now Peak instead of PeakStatistic)" .
 
 
 
@@ -2477,13 +2526,13 @@ nidm:ResidualMeanSquaresMap rdf:type owl:Class ;
                             
                             rdfs:subClassOf nidm:Map ;
                             
-                            rdfs:isDefinedBy """A map whose value at each location is the residual of the mean squares fit to the data.
+                            obo:IAO_0000115 """A map whose value at each location is the residual of the mean squares fit to the data.
 """ ;
                             
-                            iao:IAO_0000116 """BIRNLex or 
+                            obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_52. """ ;
                             
-                            iao:IAO_0000112 """entity(niiri:residual_mean_squares_map_id,
+                            obo:IAO_0000112 """entity(niiri:residual_mean_squares_map_id,
       [prov:type = 'nidm:ResidualMeanSquaresMap',
       prov:location = \"file:///path/to/ResidualMeanSquares.nii.gz\" %% xsd:anyURI,
       nidm:filename = \"ResidualMeanSquares.nii.gz\" %% xsd:string,
@@ -2502,7 +2551,7 @@ nidm:RobustIterativelyReweighedLeastSquares rdf:type owl:Class ;
                                             
                                             rdfs:subClassOf nidm:EstimationMethod ;
                                             
-                                            rdfs:isDefinedBy "FIXME" ;
+                                            obo:IAO_0000115 "FIXME" ;
                                             
                                             rdfs:comment "used for automatically down-weighting outliers, using some given influence function (e.g. Huber; see [1] for a neuroimaging application)." .
 
@@ -2514,16 +2563,16 @@ nidm:SPM rdf:type owl:Class ;
          
          rdfs:subClassOf prov:SoftwareAgent ;
          
-         rdfs:isDefinedBy "Statistical Parametric Mapping software package for the analysis of neuroimaging data from the FIL Methods Group." ;
+         obo:IAO_0000115 "Statistical Parametric Mapping software package for the analysis of neuroimaging data from the FIL Methods Group." ;
          
-         iao:IAO_0000112 """agent(niiri:software_id,
+         obo:IAO_0000112 """agent(niiri:software_id,
       [prov:type = 'nidm:SPM',
       prov:type = 'prov:SoftwareAgent',
       prov:label = \"SPM\" %% xsd:string,
       nidm:softwareVersion = \"SPM12b\" %% xsd:string,
       spm:softwareRevision = \"5853\" %% xsd:string])""" ;
          
-         iao:IAO_0000116 """BIRNLex or 
+         obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_56. """ ;
          
          rdfs:seeAlso "http://www.fil.ion.ucl.ac.uk/spm/" .
@@ -2536,13 +2585,13 @@ nidm:SPMResults rdf:type owl:Class ;
                 
                 rdfs:subClassOf nidm:NIDMObjectModel ;
                 
-                iao:IAO_0000112 """entity(niiri:spm_results_id,
+                obo:IAO_0000112 """entity(niiri:spm_results_id,
     [prov:type = 'prov:Bundle',
     prov:label = \"SPM Results\",
     nidm:objectModel = 'nidm:SPMResults',
     nidm:version = \"0.2.0\"])""" ;
                 
-                rdfs:isDefinedBy "FIXME" .
+                obo:IAO_0000115 "FIXME" .
 
 
 
@@ -2553,7 +2602,7 @@ nidm:SearchSpaceMap rdf:type owl:Class ;
                     rdfs:subClassOf nidm:Map ,
                                     prov:Entity ;
                     
-                    iao:IAO_0000112 """entity(niiri:search_space_id,
+                    obo:IAO_0000112 """entity(niiri:search_space_id,
         [prov:type = 'nidm:SearchSpaceMap',
         prov:location = \"file:///path/to/SearchSpace.nii.gz\" %% xsd:anyURI,
         dct:format = \"image/nifti\",
@@ -2574,17 +2623,17 @@ nidm:SearchSpaceMap rdf:type owl:Class ;
       spm:smallestSignifClusterSizeInVoxelsFWE05 = \"1\" %% xsd:float,
       spm:smallestSignifClusterSizeInVoxelsFDR05 = \"3\" %% xsd:float])""" ;
                     
-                    iao:IAO_0000116 """Domain or Attributes: spm:searchVolumeInUnits not found. BIRNLex or 
+                    obo:IAO_0000116 """Domain or Attributes: spm:searchVolumeInUnits not found. BIRNLex or 
 NIDM Concept ID: nidm_100. """ ;
                     
                     rdfs:seeAlso "http://purl.obolibrary.org/obo/OBI_0000235" ;
                     
-                    iao:IAO_0000116 """BIRNLex or 
+                    obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: spm_95. """ ;
                     
-                    rdfs:isDefinedBy "mask in which the inference was performed." ;
+                    obo:IAO_0000115 "mask in which the inference was performed." ;
                     
-                    iao:IAO_0000112 """entity(niiri:search_space_id,
+                    obo:IAO_0000112 """entity(niiri:search_space_id,
       [prov:type = 'nidm:SearchSpaceMap',
       prov:location = \"file:///path/to/SearchSpace.nii.gz\" %% xsd:anyURI,
       nidm:filename = \"SearchSpace.nii.gz\" %% xsd:string,
@@ -2607,7 +2656,7 @@ NIDM Concept ID: spm_95. """ ;
       nidm:randomFieldStationarity = \"false\" %%xsd:boolean,
       crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" ;
                     
-                    rdfs:isDefinedBy "Properties of the underlying statistical process." .
+                    obo:IAO_0000115 "Properties of the underlying statistical process." .
 
 
 
@@ -2617,7 +2666,7 @@ nidm:SeriallyCorrelatedNoise rdf:type owl:Class ;
                              
                              rdfs:subClassOf nidm:NoiseDependence ;
                              
-                             rdfs:isDefinedBy "FIXME" .
+                             obo:IAO_0000115 "FIXME" .
 
 
 
@@ -2627,7 +2676,7 @@ nidm:SpatialModel rdf:type owl:Class ;
                   
                   rdfs:subClassOf prov:Entity ;
                   
-                  rdfs:isDefinedBy "FIXME" .
+                  obo:IAO_0000115 "FIXME" .
 
 
 
@@ -2637,7 +2686,7 @@ nidm:SpatiallyGlobalModel rdf:type owl:Class ;
                           
                           rdfs:subClassOf nidm:SpatialModel ;
                           
-                          rdfs:isDefinedBy "FIXME" .
+                          obo:IAO_0000115 "FIXME" .
 
 
 
@@ -2647,7 +2696,7 @@ nidm:SpatiallyLocalModel rdf:type owl:Class ;
                          
                          rdfs:subClassOf nidm:SpatialModel ;
                          
-                         rdfs:isDefinedBy "FIXME" .
+                         obo:IAO_0000115 "FIXME" .
 
 
 
@@ -2657,7 +2706,7 @@ nidm:SpatiallyRegularizedModel rdf:type owl:Class ;
                                
                                rdfs:subClassOf nidm:SpatialModel ;
                                
-                               rdfs:isDefinedBy "FIXME" .
+                               obo:IAO_0000115 "FIXME" .
 
 
 
@@ -2670,7 +2719,7 @@ nidm:StandardizedCoordinateSystem rdf:type owl:Class ;
                                   rdfs:comment "This is meant to be used for retrospective export when exact template is unknown." ,
                                                "FIXME. This definition needs to be re-worked and reviewed." ;
                                   
-                                  rdfs:isDefinedBy "Parent of all reference spaces except \"Subject\"." .
+                                  obo:IAO_0000115 "Parent of all reference spaces except \"Subject\"." .
 
 
 
@@ -2691,7 +2740,7 @@ nidm:StatisticMap rdf:type owl:Class ;
                   rdfs:subClassOf nidm:Map ,
                                   prov:Entity ;
                   
-                  iao:IAO_0000112 """entity(niiri:statistic_map_id,
+                  obo:IAO_0000112 """entity(niiri:statistic_map_id,
       [prov:type = 'nidm:StatisticMap',
       nidm:statisticType = 'nidm:TStatistic',
       prov:location = \"file:///path/to/TStatistic.nii.gz\" %% xsd:anyURI,
@@ -2704,9 +2753,9 @@ nidm:StatisticMap rdf:type owl:Class ;
       nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" ;
                   
-                  rdfs:isDefinedBy "A map whose value at each location is a statistic. " ;
+                  obo:IAO_0000115 "A map whose value at each location is a statistic. " ;
                   
-                  iao:IAO_0000116 """BIRNLex or 
+                  obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_60. """ .
 
 
@@ -2717,7 +2766,7 @@ nidm:SubVolumeMap rdf:type owl:Class ;
                   
                   rdfs:subClassOf nidm:Map ;
                   
-                  iao:IAO_0000112 """entity(niiri:sub_volume_id,
+                  obo:IAO_0000112 """entity(niiri:sub_volume_id,
       [prov:type = 'nidm:SubVolumeMap',
       prov:location = \"file:///path/to/SubVolume.nii.gz\" %% xsd:anyURI,
       nidm:filename = \"SubVolume.nii.gz\" %% xsd:string,
@@ -2726,10 +2775,10 @@ nidm:SubVolumeMap rdf:type owl:Class ;
       nidm:atCoordinateSpace = 'niiri:coordinate_space_id_2',
       crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" ;
                   
-                  iao:IAO_0000116 """BIRNLex or 
+                  obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_101. """ ;
                   
-                  rdfs:isDefinedBy "mask defined by the user to restrain the space in which inference is performed." .
+                  obo:IAO_0000115 "mask defined by the user to restrain the space in which inference is performed." .
 
 
 
@@ -2741,7 +2790,7 @@ nidm:SubjectCoordinateSystem rdf:type owl:Class ;
                              
                              rdfs:comment "Used in FSL and SPM un-registered data." ;
                              
-                             rdfs:isDefinedBy "Coordinate system defined by the subject brain (no spatial normalisation applied)." .
+                             obo:IAO_0000115 "Coordinate system defined by the subject brain (no spatial normalisation applied)." .
 
 
 
@@ -2761,7 +2810,7 @@ nidm:TalairachCoordinateSystem rdf:type owl:Class ;
                                
                                rdfs:subClassOf nidm:StandardizedCoordinateSystem ;
                                
-                               rdfs:isDefinedBy "Reference space defined by the dissected brain used for the Talairach and Tournoux atlas." ;
+                               obo:IAO_0000115 "Reference space defined by the dissected brain used for the Talairach and Tournoux atlas." ;
                                
                                rdfs:comment "FIXME. This definition needs to be re-worked and reviewed." ;
                                
@@ -2775,7 +2824,7 @@ nidm:TwoTailedTest rdf:type owl:Class ;
                    
                    rdfs:subClassOf prov:Entity ;
                    
-                   rdfs:isDefinedBy "Re-use \"two tailed test\" from STATO"^^xsd:anyURI ;
+                   obo:IAO_0000115 "Re-use \"two tailed test\" from STATO"^^xsd:anyURI ;
                    
                    owl:sameAs "http://purl.obolibrary.org/obo/STATO_0000287"^^xsd:anyURI .
 
@@ -2787,7 +2836,7 @@ nidm:WeightedLeastSquares rdf:type owl:Class ;
                           
                           rdfs:subClassOf nidm:EstimationMethod ;
                           
-                          rdfs:isDefinedBy "FIXME" ;
+                          obo:IAO_0000115 "FIXME" ;
                           
                           rdfs:comment "WLS (heteroscedasticity accounted for, but no dependence)" .
 
@@ -2799,7 +2848,7 @@ nidm:WorldCoordinateSystem rdf:type owl:Class ;
                            
                            rdfs:subClassOf prov:Entity ;
                            
-                           rdfs:isDefinedBy "FIXME" .
+                           obo:IAO_0000115 "FIXME" .
 
 
 
@@ -2809,7 +2858,7 @@ nidm:ZStatistic rdf:type owl:Class ;
                 
                 rdfs:subClassOf nidm:Statistic ;
                 
-                rdfs:isDefinedBy "FIXME" .
+                obo:IAO_0000115 "FIXME" .
 
 
 
@@ -2819,10 +2868,10 @@ nidm:stationaryRandomField rdf:type owl:Class ;
                            
                            rdfs:subClassOf prov:Entity ;
                            
-                           iao:IAO_0000116 """BIRNLex or 
+                           obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_59. """ ;
                            
-                           rdfs:isDefinedBy "Random-field that is constant across the search volume." .
+                           obo:IAO_0000115 "Random-field that is constant across the search volume." .
 
 
 
@@ -2832,7 +2881,7 @@ spm:KConjunctionInference rdf:type owl:Class ;
                           
                           rdfs:subClassOf nidm:Inference ;
                           
-                          rdfs:isDefinedBy "FIXME" .
+                          obo:IAO_0000115 "FIXME" .
 
 
 
@@ -2842,10 +2891,10 @@ spm:ReselsPerVoxelMap rdf:type owl:Class ;
                       
                       rdfs:subClassOf nidm:Map ;
                       
-                      iao:IAO_0000116 """BIRNLex or 
+                      obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: spm_83. """ ;
                       
-                      iao:IAO_0000112 """entity(niiri:resels_per_voxel_map_id,
+                      obo:IAO_0000112 """entity(niiri:resels_per_voxel_map_id,
       [prov:type = 'spm:ReselsPerVoxelMap',
       prov:location = \"file:///path/to/ReselsPerVoxel.nii.gz\" %% xsd:anyURI,
       nidm:filename = \"ReselsPerVoxel.nii.gz\" %% xsd:string,
@@ -2854,7 +2903,7 @@ NIDM Concept ID: spm_83. """ ;
       nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" ;
                       
-                      rdfs:isDefinedBy "A map whose value at each location is the number of resels per voxel. " .
+                      obo:IAO_0000115 "A map whose value at each location is the number of resels per voxel. " .
 
 
 
@@ -2864,9 +2913,9 @@ spm:kConjunctionInference rdf:type owl:Class ;
                           
                           rdfs:subClassOf prov:Activity ;
                           
-                          rdfs:isDefinedBy "Inference testing for the joint significance of a subset of the effects." ;
+                          obo:IAO_0000115 "Inference testing for the joint significance of a subset of the effects." ;
                           
-                          iao:IAO_0000116 """BIRNLex or 
+                          obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: spm_76. """ .
 
 
@@ -2877,11 +2926,11 @@ spm:nonStationaryRandomField rdf:type owl:Class ;
                              
                              rdfs:subClassOf prov:Entity ;
                              
-                             iao:IAO_0000112 "<this is an attribute value>" ;
+                             obo:IAO_0000112 "<this is an attribute value>" ;
                              
-                             rdfs:isDefinedBy "Random field that is variable across the search volume." ;
+                             obo:IAO_0000115 "Random field that is variable across the search volume." ;
                              
-                             iao:IAO_0000116 """Range: <thisisanattributevalue> not found. BIRNLex or 
+                             obo:IAO_0000116 """Range: <thisisanattributevalue> not found. BIRNLex or 
 NIDM Concept ID: spm_81. """ .
 
 

--- a/nidm/nidm-results/terms/releases/nidm-results_020.owl
+++ b/nidm/nidm-results/terms/releases/nidm-results_020.owl
@@ -21,6 +21,13 @@
 #
 #################################################################
 
+
+###  http://purl.obolibrary.org/obo/IAO_0000111
+
+obo:IAO_0000111 rdf:type owl:AnnotationProperty .
+
+
+
 ###  http://purl.obolibrary.org/obo/IAO_0000112
 
 obo:IAO_0000112 rdf:type owl:AnnotationProperty ;
@@ -71,6 +78,8 @@ obo:IAO_0000115 rdf:type owl:AnnotationProperty ;
                 
                 obo:IAO_0000114 obo:IAO_0000122 .
 
+
+
 ###  http://purl.obolibrary.org/obo/IAO_0000116
 
 obo:IAO_0000116 rdf:type owl:AnnotationProperty ;
@@ -86,6 +95,18 @@ obo:IAO_0000116 rdf:type owl:AnnotationProperty ;
                 obo:IAO_0000111 "editor note"@en ;
                 
                 obo:IAO_0000114 obo:IAO_0000122 .
+
+
+
+###  http://purl.obolibrary.org/obo/IAO_0000117
+
+obo:IAO_0000117 rdf:type owl:AnnotationProperty .
+
+
+
+###  http://purl.obolibrary.org/obo/IAO_0000119
+
+obo:IAO_0000119 rdf:type owl:AnnotationProperty .
 
 
 
@@ -165,12 +186,12 @@ nidm:hasAlternativeHypothesis rdf:type owl:ObjectProperty ;
 
 nidm:hasClusterLabelsMap rdf:type owl:ObjectProperty ;
                          
-                         obo:IAO_0000112 "file:///path/to/cluster_labels.img" ;
-                         
                          obo:IAO_0000115 "A map whose value at each location denotes cluster membership. Each cluster is denoted by a different integer." ;
                          
                          obo:IAO_0000116 """Range: Pathtoaniftiimage not found. BIRNLex or 
 NIDM Concept ID: nidm_4. """ ;
+                         
+                         obo:IAO_0000112 "file:///path/to/cluster_labels.img" ;
                          
                          rdfs:range nidm:ClusterLabelsMap ;
                          
@@ -273,12 +294,12 @@ nidm:varianceSpatialModel rdf:type owl:ObjectProperty ;
 
 nidm:visualisation rdf:type owl:ObjectProperty ;
                    
+                   obo:IAO_0000115 "Graphical representation of an entity." ;
+                   
                    obo:IAO_0000112 "file:///path/to/design_matrix.png" ;
                    
                    obo:IAO_0000116 """Range: Pathtoanimage(e.g.png) not found. BIRNLex or 
 NIDM Concept ID: nidm_66. """ ;
-                   
-                   obo:IAO_0000115 "Graphical representation of an entity." ;
                    
                    rdfs:domain nidm:DesignMatrix ,
                                nidm:ExcursionSet ;
@@ -305,10 +326,10 @@ spm:hasMaximumIntensityProjection rdf:type owl:ObjectProperty ;
                                   
                                   obo:IAO_0000115 "Maximum intensity projection of a map." ;
                                   
-                                  obo:IAO_0000112 "file:///path/to/MIP.png" ;
-                                  
                                   obo:IAO_0000116 """Range: Pathtoanimage(e.g.png) not found. BIRNLex or 
 NIDM Concept ID: spm_77. """ ;
+                                  
+                                  obo:IAO_0000112 "file:///path/to/MIP.png" ;
                                   
                                   rdfs:domain nidm:ExcursionSet ;
                                   
@@ -399,10 +420,10 @@ dct:format rdf:type owl:DatatypeProperty ;
 
 fsl:coordinate1InVoxels rdf:type owl:DatatypeProperty ;
                         
-                        obo:IAO_0000112 "-60" ;
-                        
                         obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_16. """ ;
+                        
+                        obo:IAO_0000112 "-60" ;
                         
                         obo:IAO_0000115 "Coordinate along the first dimension in voxels." ;
                         
@@ -418,10 +439,10 @@ fsl:coordinate2InVoxels rdf:type owl:DatatypeProperty ;
                         
                         obo:IAO_0000115 "Coordinate along the second dimension in voxels." ;
                         
+                        obo:IAO_0000112 "-28" ;
+                        
                         obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_18. """ ;
-                        
-                        obo:IAO_0000112 "-28" ;
                         
                         rdfs:domain nidm:Coordinate ;
                         
@@ -436,9 +457,9 @@ fsl:coordinate3InVoxels rdf:type owl:DatatypeProperty ;
                         obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_20. """ ;
                         
-                        obo:IAO_0000115 "Coordinate along the third dimension in voxels" ;
-                        
                         obo:IAO_0000112 "13" ;
+                        
+                        obo:IAO_0000115 "Coordinate along the third dimension in voxels" ;
                         
                         rdfs:domain nidm:Coordinate ;
                         
@@ -450,9 +471,9 @@ NIDM Concept ID: nidm_20. """ ;
 
 fsl:dlh rdf:type owl:DatatypeProperty ;
         
-        rdfs:comment "To be renamed" ;
-        
         obo:IAO_0000115 "FIXME" ;
+        
+        rdfs:comment "To be renamed" ;
         
         rdfs:domain nidm:SearchSpaceMap ;
         
@@ -557,12 +578,12 @@ NIDM Concept ID: nidm_6. """ ;
 
 nidm:contrastName rdf:type owl:DatatypeProperty ;
                   
-                  obo:IAO_0000116 """BIRNLex or 
-NIDM Concept ID: nidm_11. """ ;
-                  
                   obo:IAO_0000115 "Name of the contrast." ;
                   
                   obo:IAO_0000112 "\"Listening > Rest\"" ;
+                  
+                  obo:IAO_0000116 """BIRNLex or 
+NIDM Concept ID: nidm_11. """ ;
                   
                   rdfs:domain nidm:ContrastMap ,
                               nidm:ContrastWeights ,
@@ -593,12 +614,12 @@ NIDM Concept ID: nidm_15. """ ;
 
 nidm:coordinate2 rdf:type owl:DatatypeProperty ;
                  
-                 obo:IAO_0000115 "Coordinate along the second dimension in voxel units." ;
+                 obo:IAO_0000112 "-28" ;
                  
                  obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_17. """ ;
                  
-                 obo:IAO_0000112 "-28" ;
+                 obo:IAO_0000115 "Coordinate along the second dimension in voxel units." ;
                  
                  rdfs:domain nidm:Coordinate ;
                  
@@ -612,10 +633,10 @@ nidm:coordinate3 rdf:type owl:DatatypeProperty ;
                  
                  obo:IAO_0000112 "13" ;
                  
-                 obo:IAO_0000115 "Coordinate along the third dimension in voxel units." ;
-                 
                  obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_19. """ ;
+                 
+                 obo:IAO_0000115 "Coordinate along the third dimension in voxel units." ;
                  
                  rdfs:domain nidm:Coordinate ;
                  
@@ -627,12 +648,12 @@ NIDM Concept ID: nidm_19. """ ;
 
 nidm:dimensionsInVoxels rdf:type owl:DatatypeProperty ;
                         
+                        obo:IAO_0000112 "[64 64 20]" ;
+                        
                         obo:IAO_0000116 """Range: Vectorofintegers not found. BIRNLex or 
 NIDM Concept ID: nidm_25. """ ;
                         
                         obo:IAO_0000115 "Dimensions of some N-dimensional data." ;
-                        
-                        obo:IAO_0000112 "[64 64 20]" ;
                         
                         rdfs:domain nidm:CoordinateSpace ;
                         
@@ -661,9 +682,9 @@ NIDM Concept ID: nidm_26. """ ;
 
 nidm:equivalentZStatistic rdf:type owl:DatatypeProperty ;
                           
-                          obo:IAO_0000112 "3.5" ;
-                          
                           obo:IAO_0000115 "Statistic value transformed into Z units; the output of a process which takes a non-normal statistic and transforms it to an equivalent z score." ;
+                          
+                          obo:IAO_0000112 "3.5" ;
                           
                           obo:IAO_0000116 """Context: Functional. Parent: Data transformation;  http://purl.obolibrary.org/obo/OBI_0200000 not found. BIRNLex or 
 NIDM Concept ID: nidm_27. new parent: Peak. """ ;
@@ -678,9 +699,9 @@ NIDM Concept ID: nidm_27. new parent: Peak. """ ;
 
 nidm:errorDegreesOfFreedom rdf:type owl:DatatypeProperty ;
                            
-                           obo:IAO_0000112 "72.999999" ;
-                           
                            obo:IAO_0000115 "Degrees of freedom of the error." ;
+                           
+                           obo:IAO_0000112 "72.999999" ;
                            
                            rdfs:domain nidm:StatisticMap ;
                            
@@ -697,10 +718,10 @@ nidm:errorDegreesOfFreedom rdf:type owl:DatatypeProperty ;
 
 nidm:f-statistic rdf:type owl:DatatypeProperty ;
                  
+                 obo:IAO_0000115 "The statistic from the F-test, a test of the hypothesis that the standard deviations of two normally distributed populations are equal, and thus that they are of comparable origin." ;
+                 
                  obo:IAO_0000116 """Context: io terms. Domain or Attributes: <notdirectlyinuse> not found. BIRNLex or 
 NIDM Concept ID: nidm_31. """ ;
-                 
-                 obo:IAO_0000115 "The statistic from the F-test, a test of the hypothesis that the standard deviations of two normally distributed populations are equal, and thus that they are of comparable origin." ;
                  
                  rdfs:seeAlso "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#F-Test" .
 
@@ -742,10 +763,10 @@ nidm:grandMeanScaling rdf:type owl:DatatypeProperty ;
                       
                       obo:IAO_0000112 "TRUE" ;
                       
-                      obo:IAO_0000115 "Binary flag defining whether the data was scaled. Specifically, \"grand mean scaling\" refers to multipliciation of every voxel in every scan by a common value.  Grand mean scaling is essential for first-level fMRI, to transform the arbitrary MRI units, but is generally not used with second level analyses." ;
-                      
                       obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_96. """ ;
+                      
+                      obo:IAO_0000115 "Binary flag defining whether the data was scaled. Specifically, \"grand mean scaling\" refers to multipliciation of every voxel in every scan by a common value.  Grand mean scaling is essential for first-level fMRI, to transform the arbitrary MRI units, but is generally not used with second level analyses." ;
                       
                       rdfs:domain nidm:Data ;
                       
@@ -770,14 +791,14 @@ NIDM Concept ID: nidm_22. """ ;
 
 nidm:maskedMedian rdf:type owl:DatatypeProperty ;
                   
-                  obo:IAO_0000115 "Median value considering only in-mask voxels. Useful diagnostic when computed on grand mean image when grandMeanScaling is TRUE, as the median should be close to targetIntensity." ;
+                  obo:IAO_0000112 "155.23" ;
                   
                   obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_98. """ ;
                   
-                  rdfs:seeAlso "http://purl.obolibrary.org/obo/OBI_0200119" ;
+                  obo:IAO_0000115 "Median value considering only in-mask voxels. Useful diagnostic when computed on grand mean image when grandMeanScaling is TRUE, as the median should be close to targetIntensity." ;
                   
-                  obo:IAO_0000112 "155.23" ;
+                  rdfs:seeAlso "http://purl.obolibrary.org/obo/OBI_0200119" ;
                   
                   rdfs:domain nidm:GrandMeanMap ;
                   
@@ -789,14 +810,14 @@ NIDM Concept ID: nidm_98. """ ;
 
 nidm:noiseFWHM rdf:type owl:DatatypeProperty ;
                
-               obo:IAO_0000116 """Context: Functional. Domain or Attributes: <onlychildofareusedinthedatamodel> not found. BIRNLex or 
-NIDM Concept ID: nidm_42. \"type\": SearchVol. """ ;
-               
                obo:IAO_0000112 "2.35" ;
                
                obo:IAO_0000115 "Estimated Full Width at Half Maximum of the noise distribution." ;
                
-               rdfs:seeAlso "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#Full_Width_at_Half_Maximum" .
+               rdfs:seeAlso "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#Full_Width_at_Half_Maximum" ;
+               
+               obo:IAO_0000116 """Context: Functional. Domain or Attributes: <onlychildofareusedinthedatamodel> not found. BIRNLex or 
+NIDM Concept ID: nidm_42. \"type\": SearchVol. """ .
 
 
 
@@ -832,10 +853,10 @@ nidm:numberOfDimensions rdf:type owl:DatatypeProperty ;
                         
                         obo:IAO_0000115 "Number of dimensions of a data matrix." ;
                         
+                        obo:IAO_0000112 "3" ;
+                        
                         obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_43. """ ;
-                        
-                        obo:IAO_0000112 "3" ;
                         
                         rdfs:domain nidm:CoordinateSpace ;
                         
@@ -849,12 +870,12 @@ nidm:pValue rdf:type owl:DatatypeProperty ;
             
             owl:sameAs "http://purl.obolibrary.org/obo/OBI_0000175"^^xsd:anyURI ;
             
-            obo:IAO_0000116 """Range: Floatbetween0and1 not found. BIRNLex or 
-NIDM Concept ID: nidm_47. """ ;
-            
             rdfs:seeAlso """http://purl.obolibrary.org/obo/IAO_0000121
 http://purl.obolibrary.org/obo/OBI_0000175
 http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#P-Value""" ;
+            
+            obo:IAO_0000116 """Range: Floatbetween0and1 not found. BIRNLex or 
+NIDM Concept ID: nidm_47. """ ;
             
             obo:IAO_0000112 "8.95E-14" ;
             
@@ -877,9 +898,9 @@ NIDM Concept ID: nidm_48. """ ;
                 
                 owl:sameAs "This definition is from OBI. Please update this note if the definition is modified." ;
                 
-                rdfs:seeAlso "Synonym of \"nidm:pFWE\"" ;
-                
                 obo:IAO_0000115 "\"A quantitative confidence value resulting from a multiple testing error correction method which adjusts the p-value used as input to control for Type I error in the context of multiple pairwise tests\"" ;
+                
+                rdfs:seeAlso "Synonym of \"nidm:pFWE\"" ;
                 
                 rdfs:domain nidm:Cluster ,
                             nidm:ExtentThreshold ,
@@ -894,9 +915,9 @@ NIDM Concept ID: nidm_48. """ ;
 
 nidm:pValueUncorrected rdf:type owl:DatatypeProperty ;
                        
-                       obo:IAO_0000115 "A p-value reported without correction for multiple testing.        " ;
-                       
                        obo:IAO_0000112 "0.0542" ;
+                       
+                       obo:IAO_0000115 "A p-value reported without correction for multiple testing.        " ;
                        
                        rdfs:seeAlso "http://purl.obolibrary.org/obo/IAO_0000121" ;
                        
@@ -916,14 +937,14 @@ NIDM Concept ID: nidm_49. """ ;
 
 nidm:qValueFDR rdf:type owl:DatatypeProperty ;
                
-               obo:IAO_0000112 "0.000154" ;
+               obo:IAO_0000115 "P-value adjusted for the multiple testing, controlling for the False Discovery Rate" ;
+               
+               rdfs:seeAlso "http://purl.obolibrary.org/obo/OBI_0001442" ;
                
                obo:IAO_0000116 """Parent: p-value i.e. nidm:nidm_0011 not found. Range: Floatbetween0and1 not found. BIRNLex or 
 NIDM Concept ID: nidm_50. """ ;
                
-               obo:IAO_0000115 "P-value adjusted for the multiple testing, controlling for the False Discovery Rate" ;
-               
-               rdfs:seeAlso "http://purl.obolibrary.org/obo/OBI_0001442" ;
+               obo:IAO_0000112 "0.000154" ;
                
                rdfs:domain nidm:Cluster ,
                            nidm:ExtentThreshold ,
@@ -938,12 +959,12 @@ NIDM Concept ID: nidm_50. """ ;
 
 nidm:randomFieldStationarity rdf:type owl:DatatypeProperty ;
                              
+                             obo:IAO_0000115 "Is the random field assumed to be stationary across the entire search volume?" ;
+                             
                              obo:IAO_0000112 "stationaryRandomField" ;
                              
                              obo:IAO_0000116 """Range: {nonStationaryRandomField not foundstationaryRandomField} not found. BIRNLex or 
 NIDM Concept ID: nidm_51. """ ;
-                             
-                             obo:IAO_0000115 "Is the random field assumed to be stationary across the entire search volume?" ;
                              
                              rdfs:domain nidm:SearchSpaceMap ;
                              
@@ -955,12 +976,12 @@ NIDM Concept ID: nidm_51. """ ;
 
 nidm:smoothingFWHM rdf:type owl:DatatypeProperty ;
                    
+                   obo:IAO_0000112 "[6 6 6]" ;
+                   
                    obo:IAO_0000116 """Domain or Attributes: <notinuse> not found. BIRNLex or 
 NIDM Concept ID: nidm_54. """ ;
                    
-                   obo:IAO_0000115 "Full width at half maximum of a Gaussian smoothing kernel in real world units (e.g. mm mm mm)." ;
-                   
-                   obo:IAO_0000112 "[6 6 6]" .
+                   obo:IAO_0000115 "Full width at half maximum of a Gaussian smoothing kernel in real world units (e.g. mm mm mm)." .
 
 
 
@@ -968,10 +989,10 @@ NIDM Concept ID: nidm_54. """ ;
 
 nidm:softwareVersion rdf:type owl:DatatypeProperty ;
                      
+                     obo:IAO_0000112 "SPM99, SPM2, SPM5, SPM8, SPM12b, FSL5.0.0" ;
+                     
                      obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_55. """ ;
-                     
-                     obo:IAO_0000112 "SPM99, SPM2, SPM5, SPM8, SPM12b, FSL5.0.0" ;
                      
                      obo:IAO_0000115 "Name and number that specifies the software version." ;
                      
@@ -985,12 +1006,12 @@ NIDM Concept ID: nidm_55. """ ;
 
 nidm:standardError rdf:type owl:DatatypeProperty ;
                    
+                   obo:IAO_0000115 "\"A quantitative confidence value which is the standard deviations of the sample in a frequency distribution, obtained by dividing the standard deviation by the total number of cases in the frequency distribution.\"" ;
+                   
                    owl:sameAs "This definition is from OBI. Please update this note if the definition is modified." ;
                    
                    obo:IAO_0000116 """Domain or Attributes: <notinuse> not found. BIRNLex or 
-NIDM Concept ID: nidm_58. """ ;
-                   
-                   obo:IAO_0000115 "\"A quantitative confidence value which is the standard deviations of the sample in a frequency distribution, obtained by dividing the standard deviation by the total number of cases in the frequency distribution.\"" .
+NIDM Concept ID: nidm_58. """ .
 
 
 
@@ -998,12 +1019,12 @@ NIDM Concept ID: nidm_58. """ ;
 
 nidm:targetIntensity rdf:type owl:DatatypeProperty ;
                      
-                     obo:IAO_0000115 "Value to which the grand mean of the Data was scaled (applies only if grandMeanScaling is true)." ;
+                     obo:IAO_0000116 """Range: positivefloat not found. BIRNLex or 
+NIDM Concept ID: nidm_97. """ ;
                      
                      obo:IAO_0000112 "100" ;
                      
-                     obo:IAO_0000116 """Range: positivefloat not found. BIRNLex or 
-NIDM Concept ID: nidm_97. """ ;
+                     obo:IAO_0000115 "Value to which the grand mean of the Data was scaled (applies only if grandMeanScaling is true)." ;
                      
                      rdfs:domain nidm:Data ;
                      
@@ -1015,15 +1036,15 @@ NIDM Concept ID: nidm_97. """ ;
 
 nidm:underlayFile rdf:type owl:DatatypeProperty ;
                   
-                  obo:IAO_0000115 "Map or surface on which the associated results are displayed. " ;
-                  
-                  obo:IAO_0000116 """Parent: nidm:map not found. Range: Pathtoaniftiimage not found. BIRNLex or 
+                  obo:IAO_0000116 """Parent: nidm:map not found. Range: PathtoaNIfTIimage not found. BIRNLex or 
 NIDM Concept ID: nidm_64. """ ;
                   
                   obo:IAO_0000112 "MNI152.nii.gz or cortex.surf.gii" ;
                   
-                  obo:IAO_0000116 """Parent: nidm:map not found. Range: PathtoaNIfTIimage not found. BIRNLex or 
+                  obo:IAO_0000116 """Parent: nidm:map not found. Range: Pathtoaniftiimage not found. BIRNLex or 
 NIDM Concept ID: nidm_64. """ ;
+                  
+                  obo:IAO_0000115 "Map or surface on which the associated results are displayed. " ;
                   
                   rdfs:domain nidm:ExcursionSet .
 
@@ -1065,10 +1086,10 @@ nidm:voxelSize rdf:type owl:DatatypeProperty ;
                
                obo:IAO_0000112 "[2 2 4]" ;
                
-               obo:IAO_0000115 "3D size of a voxel measured in voxelUnits." ;
-               
                rdfs:seeAlso """http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C95003 
 """ ;
+               
+               obo:IAO_0000115 "3D size of a voxel measured in voxelUnits." ;
                
                obo:IAO_0000116 """Parent: size  not found. Range: Vectoroffloats not found. BIRNLex or 
 NIDM Concept ID: nidm_67. """ ;
@@ -1083,12 +1104,12 @@ NIDM Concept ID: nidm_67. """ ;
 
 nidm:voxelToWorldMapping rdf:type owl:DatatypeProperty ;
                          
-                         obo:IAO_0000112 "[3 0 0 0;0 3 0 0;0 0 3 0; 0 0 0 1] " ;
-                         
                          obo:IAO_0000115 "Homogeneous transformation matrix to map from voxel coordinate system to world coordinate system." ;
                          
                          obo:IAO_0000116 """Range: Matrixoffloat not found. BIRNLex or 
 NIDM Concept ID: nidm_68. """ ;
+                         
+                         obo:IAO_0000112 "[3 0 0 0;0 3 0 0;0 0 3 0; 0 0 0 1] " ;
                          
                          rdfs:domain nidm:CoordinateSpace ;
                          
@@ -1102,10 +1123,10 @@ nidm:voxelUnits rdf:type owl:DatatypeProperty ;
                 
                 obo:IAO_0000115 "Units associated with each dimensions of some N-dimensional data." ;
                 
+                obo:IAO_0000112 "{'mm' 'mm' 's'}" ;
+                
                 obo:IAO_0000116 """Range: Vectorofstrings not found. BIRNLex or 
 NIDM Concept ID: nidm_69. """ ;
-                
-                obo:IAO_0000112 "{'mm' 'mm' 's'}" ;
                 
                 rdfs:domain nidm:CoordinateSpace ;
                 
@@ -1137,9 +1158,9 @@ spm:clusterSizeInResels rdf:type owl:DatatypeProperty ;
 
 spm:expectedNumberOfClusters rdf:type owl:DatatypeProperty ;
                              
-                             obo:IAO_0000115 "Expected number of clusters in an excursion set." ;
-                             
                              obo:IAO_0000112 "9.51" ;
+                             
+                             obo:IAO_0000115 "Expected number of clusters in an excursion set." ;
                              
                              rdfs:domain nidm:SearchSpaceMap ;
                              
@@ -1156,12 +1177,12 @@ spm:expectedNumberOfClusters rdf:type owl:DatatypeProperty ;
 
 spm:expectedNumberOfVerticesPerCluster rdf:type owl:DatatypeProperty ;
                                        
-                                       obo:IAO_0000112 "60.632" ;
-                                       
                                        obo:IAO_0000115 "Expected number of vertices in a cluster." ;
                                        
                                        obo:IAO_0000116 """Range: Positivefloat not found. BIRNLex or 
 NIDM Concept ID: spm_72. """ ;
+                                       
+                                       obo:IAO_0000112 "60.632" ;
                                        
                                        rdfs:domain nidm:SearchSpaceMap ;
                                        
@@ -1178,12 +1199,12 @@ NIDM Concept ID: spm_72. """ ;
 
 spm:expectedNumberOfVoxelsPerCluster rdf:type owl:DatatypeProperty ;
                                      
+                                     obo:IAO_0000115 "Expected number of voxels in a cluster." ;
+                                     
                                      obo:IAO_0000116 """Range: Positivefloat not found. BIRNLex or 
 NIDM Concept ID: spm_73. """ ;
                                      
                                      obo:IAO_0000112 "60.632" ;
-                                     
-                                     obo:IAO_0000115 "Expected number of voxels in a cluster." ;
                                      
                                      rdfs:domain nidm:SearchSpaceMap ;
                                      
@@ -1234,12 +1255,12 @@ NIDM Concept ID: spm_75. """ ;
 
 spm:noiseFWHMInUnits rdf:type owl:DatatypeProperty ;
                      
-                     obo:IAO_0000112 "[8.87, 8.89, 7.83]" ;
-                     
                      obo:IAO_0000115 "Estimated Full Width at Half Maximum of the noise distribution in world units." ;
                      
                      obo:IAO_0000116 """Range: Vectorofpositivefloats not found. BIRNLex or 
 NIDM Concept ID: spm_78. """ ;
+                     
+                     obo:IAO_0000112 "[8.87, 8.89, 7.83]" ;
                      
                      rdfs:domain nidm:SearchSpaceMap ;
                      
@@ -1253,12 +1274,12 @@ NIDM Concept ID: spm_78. """ ;
 
 spm:noiseFWHMInVertices rdf:type owl:DatatypeProperty ;
                         
-                        obo:IAO_0000116 """Range: Vectorofpositivefloats not found. BIRNLex or 
-NIDM Concept ID: spm_79. """ ;
+                        obo:IAO_0000112 "[2.95, 2.96, 2.61]" ;
                         
                         obo:IAO_0000115 "Estimated Full Width at Half Maximum of the noise distribution in world vertices." ;
                         
-                        obo:IAO_0000112 "[2.95, 2.96, 2.61]" ;
+                        obo:IAO_0000116 """Range: Vectorofpositivefloats not found. BIRNLex or 
+NIDM Concept ID: spm_79. """ ;
                         
                         rdfs:domain nidm:MaskMap ;
                         
@@ -1270,12 +1291,12 @@ NIDM Concept ID: spm_79. """ ;
 
 spm:noiseFWHMInVoxels rdf:type owl:DatatypeProperty ;
                       
+                      obo:IAO_0000112 "[3.7 3.7 3.1]" ;
+                      
                       obo:IAO_0000115 "Estimated Full Width at Half Maximum of the noise distribution in voxels." ;
                       
                       obo:IAO_0000116 """Context: NoiseFWHM nidm_0009. Range: Vectorofpositivefloats not found. BIRNLex or 
 NIDM Concept ID: spm_80. """ ;
-                      
-                      obo:IAO_0000112 "[3.7 3.7 3.1]" ;
                       
                       rdfs:seeAlso "Synonyms of or close match with nidm:NoiseFWHM" ;
                       
@@ -1291,9 +1312,9 @@ NIDM Concept ID: spm_80. """ ;
 
 spm:reselSize rdf:type owl:DatatypeProperty ;
               
-              obo:IAO_0000112 "22.325" ;
-              
               obo:IAO_0000115 "Size of one resel in voxels or vertices." ;
+              
+              obo:IAO_0000112 "22.325" ;
               
               rdfs:domain nidm:SearchSpaceMap ;
               
@@ -1312,9 +1333,9 @@ spm:searchVolumeInResels rdf:type owl:DatatypeProperty ;
                          
                          obo:IAO_0000115 "Total number of resels within the search volume." ;
                          
-                         rdfs:seeAlso "Synonyms of nidm:volumeInResels" ;
-                         
                          obo:IAO_0000112 "151.3" ;
+                         
+                         rdfs:seeAlso "Synonyms of nidm:volumeInResels" ;
                          
                          rdfs:domain nidm:SearchSpaceMap ;
                          
@@ -1331,14 +1352,14 @@ spm:searchVolumeInResels rdf:type owl:DatatypeProperty ;
 
 spm:searchVolumeInUnits rdf:type owl:DatatypeProperty ;
                         
-                        obo:IAO_0000112 "1771011" ;
-                        
                         obo:IAO_0000115 "Total number of product of coordinate units within the search volume." ;
                         
                         obo:IAO_0000116 """Context: volumeInVoxels nidm_0025. Range: Positivefloat not found. BIRNLex or 
 NIDM Concept ID: spm_84. """ ;
                         
                         obo:IAO_0000115 "The volume of the searched region in units determined by the current coordinate space units (e.g., mm^3 for axis units of mm in a three dimensional image, sec.Hz for a time by frequency two dimensional image)." ;
+                        
+                        obo:IAO_0000112 "1771011" ;
                         
                         rdfs:domain nidm:SearchSpaceMap ;
                         
@@ -1376,10 +1397,10 @@ spm:searchVolumeInVoxels rdf:type owl:DatatypeProperty ;
                          
                          rdfs:seeAlso "Synonyms of nidm:volumeInVoxels" ;
                          
+                         obo:IAO_0000115 "Total number of voxels within the search volume." ;
+                         
                          obo:IAO_0000116 """Context: volumeInVoxels nidm_0025. BIRNLex or 
 NIDM Concept ID: spm_87. """ ;
-                         
-                         obo:IAO_0000115 "Total number of voxels within the search volume." ;
                          
                          obo:IAO_0000112 "68656" ;
                          
@@ -1398,9 +1419,9 @@ NIDM Concept ID: spm_88. """ ;
                                
                                obo:IAO_0000112 "[6 68.8 589.1 1475.5]" ;
                                
-                               rdfs:seeAlso "http://www.ncbi.nlm.nih.gov/pubmed/20408186" ;
-                               
                                obo:IAO_0000115 "Description of geometry of search volume.  As per Worsley et al. [ http://www.ncbi.nlm.nih.gov/pubmed/20408186 ], the first element is the Euler Characteristic of the search volume, the second element is twice the average caliper diameter, the third element is half the surface area, and the fourth element is the volume.  With the exception of the first element (which is a unitless integer) all quantities are in units of Resels." ;
+                               
+                               rdfs:seeAlso "http://www.ncbi.nlm.nih.gov/pubmed/20408186" ;
                                
                                rdfs:domain nidm:SearchSpaceMap ;
                                
@@ -1431,13 +1452,13 @@ NIDM Concept ID: spm_90. """ ;
 
 spm:smallestSignifClusterSizeInVerticesFWE05 rdf:type owl:DatatypeProperty ;
                                              
-                                             obo:IAO_0000115 """Smallest cluster size in vertices significant at family-wise error rate corrected alpha value of 0.05. 
-""" ;
+                                             obo:IAO_0000116 """BIRNLex or 
+NIDM Concept ID: spm_91. """ ;
                                              
                                              obo:IAO_0000112 "2" ;
                                              
-                                             obo:IAO_0000116 """BIRNLex or 
-NIDM Concept ID: spm_91. """ ;
+                                             obo:IAO_0000115 """Smallest cluster size in vertices significant at family-wise error rate corrected alpha value of 0.05. 
+""" ;
                                              
                                              rdfs:domain nidm:SearchSpaceMap ;
                                              
@@ -1449,12 +1470,12 @@ NIDM Concept ID: spm_91. """ ;
 
 spm:smallestSignifClusterSizeInVoxelsFDR05 rdf:type owl:DatatypeProperty ;
                                            
-                                           obo:IAO_0000112 "3" ;
-                                           
                                            obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: spm_92. """ ;
                                            
                                            obo:IAO_0000115 "Smallest cluster size in voxels significant at false discovery rate corrected alpha value of 0.05.  " ;
+                                           
+                                           obo:IAO_0000112 "3" ;
                                            
                                            rdfs:domain nidm:SearchSpaceMap ;
                                            
@@ -1484,12 +1505,12 @@ NIDM Concept ID: spm_93. """ ;
 
 spm:softwareRevision rdf:type owl:DatatypeProperty ;
                      
-                     obo:IAO_0000116 """BIRNLex or 
-NIDM Concept ID: spm_94. """ ;
+                     obo:IAO_0000112 "5417" ;
                      
                      obo:IAO_0000115 "revision number of a piece of software." ;
                      
-                     obo:IAO_0000112 "5417" ;
+                     obo:IAO_0000116 """BIRNLex or 
+NIDM Concept ID: spm_94. """ ;
                      
                      rdfs:range xsd:string ;
                      
@@ -1506,16 +1527,6 @@ NIDM Concept ID: spm_94. """ ;
 #################################################################
 
 
-###  http://www.incf.org/ns/nidash/fsl#BinomialDistribution
-
-fsl:BinomialDistribution rdf:type owl:Class ;
-                         
-                         rdfs:subClassOf nidm:NoiseDistribution ;
-                         
-                         owl:sameAs "http://purl.obolibrary.org/obo/STATO_0000276"^^xsd:anyURI .
-
-
-
 ###  http://www.incf.org/ns/nidash/fsl#CenterOfGravity
 
 fsl:CenterOfGravity rdf:type owl:Class ;
@@ -1524,15 +1535,15 @@ fsl:CenterOfGravity rdf:type owl:Class ;
                     
                     obo:IAO_0000115 "Centre Of Gravity for the cluster, equivalent to the concept of Centre Of Gravity for a object with distributed mass, where intensity substitutes for mass in this case (definition from http://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Cluster)" ;
                     
-                    obo:IAO_0000116 """BIRNLex or 
-NIDM Concept ID: fsl_102. """ ;
-                    
                     obo:IAO_0000112 """entity(niiri:center_of_gravity_1,
         [prov:type = 'fsl:CenterOfGravity',
         prov:label = \"Center of gravity 1\",
         prov:location = 'niiri:COG_coordinate_0001'])""" ;
                     
-                    rdfs:seeAlso "http://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Cluster" .
+                    rdfs:seeAlso "http://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Cluster" ;
+                    
+                    obo:IAO_0000116 """BIRNLex or 
+NIDM Concept ID: fsl_102. """ .
 
 
 
@@ -1553,16 +1564,6 @@ fsl:ClusterMaximumStatistic rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/fsl#NonParametricSymmetricDistribution
-
-fsl:NonParametricSymmetricDistribution rdf:type owl:Class ;
-                                       
-                                       rdfs:subClassOf nidm:NoiseDistribution ;
-                                       
-                                       obo:IAO_0000115 "FIXME" .
-
-
-
 ###  http://www.incf.org/ns/nidash/fsl#VarCope
 
 fsl:VarCope rdf:type owl:Class ;
@@ -1579,8 +1580,6 @@ fsl:ZStatisticMap rdf:type owl:Class ;
                   
                   rdfs:subClassOf prov:Entity ;
                   
-                  obo:IAO_0000115 "A map whose value at each location is a Z-statistic value. " ;
-                  
                   obo:IAO_0000112 """entity(niiri:z_statistical_map_id,
         [prov:type = 'nidm:StatisticMap',
         prov:type = 'fsl:ZStatisticalMap',
@@ -1590,7 +1589,9 @@ fsl:ZStatisticMap rdf:type owl:Class ;
         nidm:originalFileName = \"zstat1.nii.gz\" %% xsd:string,
         nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
         crypto:sha = \"400a2f07d99ed9be06577e6ecc89222cf4b688c654bc89067da558e88b73b97dd1b25e6c98f2a735fa0a1409598cff7e6025bda55abb6b9f5ef65d8d307eeba8\"])
-""" .
+""" ;
+                  
+                  obo:IAO_0000115 "A map whose value at each location is a Z-statistic value. " .
 
 
 
@@ -1601,6 +1602,16 @@ nidm:ArbitrarilyCorrelatedNoise rdf:type owl:Class ;
                                 rdfs:subClassOf nidm:NoiseDependence ;
                                 
                                 obo:IAO_0000115 "FIXME" .
+
+
+
+###  http://www.incf.org/ns/nidash/nidm#BinomialDistribution
+
+nidm:BinomialDistribution rdf:type owl:Class ;
+                          
+                          rdfs:subClassOf nidm:NoiseDistribution ;
+                          
+                          owl:sameAs "http://purl.obolibrary.org/obo/STATO_0000276"^^xsd:anyURI .
 
 
 
@@ -1622,10 +1633,10 @@ nidm:Cluster rdf:type owl:Class ;
       nidm:pValueFWER = \"0\" %% xsd:float,
       nidm:qValueFDR = \"7.65021389184909e-51\" %% xsd:float])""" ;
              
-             obo:IAO_0000115 "Statistic defined at the cluster-level in an excusion set. In SPM it is defined as the cluster size. FIXME (now Cluster instead of ClusterStatistic)" ;
-             
              obo:IAO_0000116 """Range: - not found. BIRNLex or 
-NIDM Concept ID: nidm_7. """ .
+NIDM Concept ID: nidm_7. """ ;
+             
+             obo:IAO_0000115 "Statistic defined at the cluster-level in an excusion set. In SPM it is defined as the cluster size. FIXME (now Cluster instead of ClusterStatistic)" .
 
 
 
@@ -1651,13 +1662,12 @@ nidm:Colin27CoordinateSystem rdf:type owl:Class ;
                              
                              rdfs:subClassOf nidm:StandardizedCoordinateSystem ;
                              
-                             rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/Colin27Highres" ;
-                             
-                             rdfs:comment "used in SPM96 (cf. http://imaging.mrc-cbu.cam.ac.uk/imaging/MniTalairach)" ;
-                             
                              obo:IAO_0000115 "Coordinate system defined by the \"stereotaxic average of 27 T1-weighted MRI scans of the same individual\"." ;
                              
-                             rdfs:comment "FIXME. This definition needs to be re-worked and reviewed." .
+                             rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/Colin27Highres" ;
+                             
+                             rdfs:comment "used in SPM96 (cf. http://imaging.mrc-cbu.cam.ac.uk/imaging/MniTalairach)" ,
+                                          "FIXME. This definition needs to be re-worked and reviewed." .
 
 
 
@@ -1678,10 +1688,10 @@ nidm:ConjunctionInference rdf:type owl:Class ;
                           rdfs:subClassOf nidm:Inference ,
                                           prov:Activity ;
                           
-                          obo:IAO_0000116 """Range: - not found. BIRNLex or 
-NIDM Concept ID: nidm_8. """ ;
+                          obo:IAO_0000115 "Statistically testing for the joint significance of multiple effects, with emphasis on rejecting all (instead of one or more) of the respective null hypotheses." ;
                           
-                          obo:IAO_0000115 "Statistically testing for the joint significance of multiple effects, with emphasis on rejecting all (instead of one or more) of the respective null hypotheses." .
+                          obo:IAO_0000116 """Range: - not found. BIRNLex or 
+NIDM Concept ID: nidm_8. """ .
 
 
 
@@ -1695,10 +1705,10 @@ nidm:ContrastEstimation rdf:type owl:Class ;
       [prov:type = 'nidm:ContrastEstimation',
       prov:label = \"Contrast estimation\"])""" ;
                         
-                        obo:IAO_0000116 """Range: - not found. BIRNLex or 
-NIDM Concept ID: nidm_9. """ ;
+                        obo:IAO_0000115 "The process of estimating a contrast from the estimated parameters of statistical model." ;
                         
-                        obo:IAO_0000115 "The process of estimating a contrast from the estimated parameters of statistical model." .
+                        obo:IAO_0000116 """Range: - not found. BIRNLex or 
+NIDM Concept ID: nidm_9. """ .
 
 
 
@@ -1709,6 +1719,11 @@ nidm:ContrastMap rdf:type owl:Class ;
                  rdfs:subClassOf nidm:Map ,
                                  prov:Entity ;
                  
+                 obo:IAO_0000115 "A map whose value at each location is statistical contrast estimate." ;
+                 
+                 obo:IAO_0000116 """Context: io terms. Parent: nidm:map, Scan Image  not found. Range: - not found. BIRNLex or 
+NIDM Concept ID: nidm_10. """ ;
+                 
                  obo:IAO_0000112 """entity(niiri:contrast_map_id,
       [prov:type = 'nidm:ContrastMap',
       prov:location = \"file:///path/to/Contrast.nii.gz\" %% xsd:anyURI,
@@ -1717,12 +1732,7 @@ nidm:ContrastMap rdf:type owl:Class ;
       prov:label = \"Contrast Map: listening > rest\" %% xsd:string,
       nidm:contrastName = \"listening > rest\" %% xsd:string,
       nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
-      crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" ;
-                 
-                 obo:IAO_0000116 """Context: io terms. Parent: nidm:map, Scan Image  not found. Range: - not found. BIRNLex or 
-NIDM Concept ID: nidm_10. """ ;
-                 
-                 obo:IAO_0000115 "A map whose value at each location is statistical contrast estimate." .
+      crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" .
 
 
 
@@ -1732,6 +1742,8 @@ nidm:ContrastStandardErrorMap rdf:type owl:Class ;
                               
                               rdfs:subClassOf nidm:Map ;
                               
+                              obo:IAO_0000115 "A map whose value at each location is the standard error of a given contrast." ;
+                              
                               obo:IAO_0000112 """entity(niiri:contrast_standard_error_map_id,
       [prov:type = 'nidm:ContrastStandardErrorMap',
       prov:location = \"file:///path/to/ContrastStandardError.nii.gz\" %% xsd:anyURI,
@@ -1740,8 +1752,6 @@ nidm:ContrastStandardErrorMap rdf:type owl:Class ;
       prov:label = \"Contrast Standard Error Map\" %% xsd:string,
       nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" ;
-                              
-                              obo:IAO_0000115 "A map whose value at each location is the standard error of a given contrast." ;
                               
                               obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_12. """ .
@@ -1754,6 +1764,8 @@ nidm:ContrastWeights rdf:type owl:Class ;
                      
                      rdfs:subClassOf prov:Entity ;
                      
+                     obo:IAO_0000115 "Vector defining the linear combination associated with a particular contrast. " ;
+                     
                      obo:IAO_0000112 """entity(niiri:contrast_weights_id,
       [prov:type = 'nidm:ContrastWeights',
       nidm:statisticType = 'nidm:TStatistic',
@@ -1762,9 +1774,7 @@ nidm:ContrastWeights rdf:type owl:Class ;
       prov:value = \"[1, 0, 0]\" %% xsd:string])""" ;
                      
                      obo:IAO_0000116 """Range: Vectorofintegers not found. BIRNLex or 
-NIDM Concept ID: nidm_13. """ ;
-                     
-                     obo:IAO_0000115 "Vector defining the linear combination associated with a particular contrast. " .
+NIDM Concept ID: nidm_13. """ .
 
 
 
@@ -1782,8 +1792,15 @@ nidm:Coordinate rdf:type owl:Class ;
       prov:label = \"Coordinate: 0001\" %% xsd:string,
       nidm:coordinate1 = \"-60\" %% xsd:float,
       nidm:coordinate2 = \"-28\" %% xsd:float,
-      nidm:coordinate3 = \"13\" %% xsd:float])""" ,
-                                """entity(niiri:coordinate_0001,
+      nidm:coordinate3 = \"13\" %% xsd:float])""" ;
+                
+                obo:IAO_0000116 """Model: - search for coordinate uri
+- subclasses of coordinate
+- additional properties (e.g. units) 
+. Context: Functional. BIRNLex or 
+NIDM Concept ID: nidm_14. """ ;
+                
+                obo:IAO_0000112 """entity(niiri:coordinate_0001,
         [prov:type = 'prov:Location',
         prov:type = 'nidm:Coordinate',
         prov:label = \"Coordinate 1\" %% xsd:string,
@@ -1792,13 +1809,7 @@ nidm:Coordinate rdf:type owl:Class ;
         fsl:coordinate3InVoxels = \"14\" %% xsd:float,
         nidm:coordinate1 = \"-48.1\" %% xsd:float,
         nidm:coordinate2 = \"-73.7\" %% xsd:float,
-        nidm:coordinate3 = \"-9.24\" %% xsd:float])""" ;
-                
-                obo:IAO_0000116 """Model: - search for coordinate uri
-- subclasses of coordinate
-- additional properties (e.g. units) 
-. Context: Functional. BIRNLex or 
-NIDM Concept ID: nidm_14. """ .
+        nidm:coordinate3 = \"-9.24\" %% xsd:float])""" .
 
 
 
@@ -1808,8 +1819,7 @@ nidm:CoordinateSpace rdf:type owl:Class ;
                      
                      rdfs:subClassOf prov:Entity ;
                      
-                     obo:IAO_0000116 """BIRNLex or 
-NIDM Concept ID: nidm_21. """ ;
+                     obo:IAO_0000115 "An entity with spatial attributes (e.g., dimensions, units, and voxel-to-world mapping) that provides context to a SpatialImage (e.g., a StatisticMap)." ;
                      
                      obo:IAO_0000112 """entity(niiri:coordinate_space_id_1,
       [prov:type = 'nidm:CoordinateSpace',
@@ -1821,7 +1831,8 @@ NIDM Concept ID: nidm_21. """ ;
       nidm:numberOfDimensions = \"3\" %% xsd:int,
       nidm:dimensionsInVoxels = \"[53,63,46]\" %% xsd:string])""" ;
                      
-                     obo:IAO_0000115 "An entity with spatial attributes (e.g., dimensions, units, and voxel-to-world mapping) that provides context to a SpatialImage (e.g., a StatisticMap)." .
+                     obo:IAO_0000116 """BIRNLex or 
+NIDM Concept ID: nidm_21. """ .
 
 
 
@@ -1841,6 +1852,9 @@ nidm:CustomMaskMap rdf:type owl:Class ;
                    
                    rdfs:subClassOf nidm:Map ;
                    
+                   obo:IAO_0000116 """BIRNLex or 
+NIDM Concept ID: nidm_99. """ ;
+                   
                    obo:IAO_0000112 """entity(niiri:custom_mask_id_1,
       [prov:type = 'nidm:CustomMaskMap',
       prov:location = \"file:///path/to/CustomMask.nii.gz\" %% xsd:anyURI,
@@ -1849,9 +1863,6 @@ nidm:CustomMaskMap rdf:type owl:Class ;
       prov:label = \"Custom mask\" %% xsd:string,
       nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" ;
-                   
-                   obo:IAO_0000116 """BIRNLex or 
-NIDM Concept ID: nidm_99. """ ;
                    
                    obo:IAO_0000115 "mask defined by the user to restrain the space in which model fitting is performed." .
 
@@ -1863,12 +1874,7 @@ nidm:Data rdf:type owl:Class ;
           
           rdfs:subClassOf prov:Entity ;
           
-          obo:IAO_0000116 """BIRNLex or 
-NIDM Concept ID: nidm_23. """ ;
-          
           obo:IAO_0000115 "\"A collection or single item of factual information, derived from measurement or research, from which conclusions may be drawn.\"" ;
-          
-          owl:sameAs "This definition is from NCIT. Please update this note if the definition is modified." ;
           
           obo:IAO_0000112 """entity(niiri:data_id,
       [prov:type = 'nidm:Data',
@@ -1876,6 +1882,11 @@ NIDM Concept ID: nidm_23. """ ;
       prov:label = \"Data\" %% xsd:string,
       nidm:grandMeanScaling = \"true\" %%xsd:boolean,
       nidm:targetIntensity = \"100\" %% xsd:float])""" ;
+          
+          owl:sameAs "This definition is from NCIT. Please update this note if the definition is modified." ;
+          
+          obo:IAO_0000116 """BIRNLex or 
+NIDM Concept ID: nidm_23. """ ;
           
           rdfs:seeAlso "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C25474" .
 
@@ -1898,9 +1909,9 @@ NIDM Concept ID: nidm_24. """ ;
       nidm:visualisation = 'niiri:design_matrix_png_id',
       prov:label = \"Design Matrix\" %% xsd:string])""" ;
                   
-                  rdfs:seeAlso "stato:design matrix" ;
+                  obo:IAO_0000115 "A matrix of values defining the explanatory variables used in a regression model.  Each column corresponds to one explanatory variable, each row corresponds to one observation." ;
                   
-                  obo:IAO_0000115 "A matrix of values defining the explanatory variables used in a regression model.  Each column corresponds to one explanatory variable, each row corresponds to one observation." .
+                  rdfs:seeAlso "stato:design matrix" .
 
 
 
@@ -1918,9 +1929,9 @@ nidm:ExchangeableNoise rdf:type owl:Class ;
                        
                        rdfs:subClassOf nidm:NoiseDependence ;
                        
-                       rdfs:comment "Under gaussianity assumption this is equivalent to compound symmetry but not in general." ;
+                       obo:IAO_0000115 "FIXME" ;
                        
-                       obo:IAO_0000115 "FIXME" .
+                       rdfs:comment "Under gaussianity assumption this is equivalent to compound symmetry but not in general." .
 
 
 
@@ -1929,6 +1940,11 @@ nidm:ExchangeableNoise rdf:type owl:Class ;
 nidm:ExcursionSet rdf:type owl:Class ;
                   
                   rdfs:subClassOf nidm:Map ;
+                  
+                  obo:IAO_0000116 """BIRNLex or 
+NIDM Concept ID: nidm_29. """ ;
+                  
+                  obo:IAO_0000115 "Set of map elements surviving a thresholding procedure." ;
                   
                   obo:IAO_0000112 """entity(niiri:excursion_set_id,
       [prov:type = 'nidm:ExcursionSet',
@@ -1941,12 +1957,7 @@ nidm:ExcursionSet rdf:type owl:Class ;
       nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string,
       nidm:numberOfClusters = \"8\" %% xsd:int,
-      nidm:pValue = \"8.95949980872501e-14\" %% xsd:float])""" ;
-                  
-                  obo:IAO_0000116 """BIRNLex or 
-NIDM Concept ID: nidm_29. """ ;
-                  
-                  obo:IAO_0000115 "Set of map elements surviving a thresholding procedure." .
+      nidm:pValue = \"8.95949980872501e-14\" %% xsd:float])""" .
 
 
 
@@ -1981,10 +1992,10 @@ nidm:FSL rdf:type owl:Class ;
          
          rdfs:seeAlso "http://fsl.fmrib.ox.ac.uk" ;
          
-         obo:IAO_0000115 "FMRIB Software Library software package for the analysis of neuroimaging data from the FMRIB" ;
-         
          obo:IAO_0000116 """BIRNLex or 
-NIDM Concept ID: nidm_57. """ .
+NIDM Concept ID: nidm_57. """ ;
+         
+         obo:IAO_0000115 "FMRIB Software Library software package for the analysis of neuroimaging data from the FMRIB" .
 
 
 
@@ -1994,13 +2005,13 @@ nidm:FSLResults rdf:type owl:Class ;
                 
                 rdfs:subClassOf nidm:NIDMObjectModel ;
                 
-                obo:IAO_0000115 "FIXME" ;
-                
                 obo:IAO_0000112 """entity(niiri:fsl_results_id,
     [prov:type = 'prov:Bundle',
     prov:label = \"FSL Results\",
     nidm:objectModel = 'nidm:FSLResults',
-    nidm:version = \"0.2.0\"])""" .
+    nidm:version = \"0.2.0\"])""" ;
+                
+                obo:IAO_0000115 "FIXME" .
 
 
 
@@ -2113,12 +2124,13 @@ nidm:IcbmMni152LinearCoordinateSystem rdf:type owl:Class ;
                                       
                                       rdfs:subClassOf nidm:MNICoordinateSystem ;
                                       
-                                      rdfs:comment "FIXME. This definition needs to be re-worked and reviewed." ,
-                                                   "used in SPM99 to SPM8 (cf. http://imaging.mrc-cbu.cam.ac.uk/imaging/MniTalairach and spm8/spm_templates.man)" ;
+                                      rdfs:comment "FIXME. This definition needs to be re-worked and reviewed." ;
                                       
-                                      rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152Lin" ;
+                                      obo:IAO_0000115 "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, linearly transformed to Talairach space\"." ;
                                       
-                                      obo:IAO_0000115 "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, linearly transformed to Talairach space\"." .
+                                      rdfs:comment "used in SPM99 to SPM8 (cf. http://imaging.mrc-cbu.cam.ac.uk/imaging/MniTalairach and spm8/spm_templates.man)" ;
+                                      
+                                      rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152Lin" .
 
 
 
@@ -2158,9 +2170,9 @@ nidm:IcbmMni152NonLinear2009bAsymmetricCoordinateSystem rdf:type owl:Class ;
                                                         
                                                         rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009" ;
                                                         
-                                                        rdfs:comment "FIXME. This definition needs to be re-worked and reviewed." ;
+                                                        obo:IAO_0000115 "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." ;
                                                         
-                                                        obo:IAO_0000115 "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." .
+                                                        rdfs:comment "FIXME. This definition needs to be re-worked and reviewed." .
 
 
 
@@ -2200,9 +2212,9 @@ nidm:IcbmMni152NonLinear2009cSymmetricCoordinateSystem rdf:type owl:Class ;
                                                        
                                                        rdfs:subClassOf nidm:MNICoordinateSystem ;
                                                        
-                                                       obo:IAO_0000115 "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." ;
-                                                       
                                                        rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009" ;
+                                                       
+                                                       obo:IAO_0000115 "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." ;
                                                        
                                                        rdfs:comment "FIXME. This definition needs to be re-worked and reviewed." .
 
@@ -2233,16 +2245,17 @@ nidm:Image rdf:type owl:Class ;
       [prov:type = 'nidm:Image',
       prov:location = \"file:///path/to/DesignMatrix.png\" %% xsd:anyURI,
       nidm:filename = \"DesignMatrix.png\",
-      dct:format = \"image/png\"])""" ,
-                           """entity(niiri:maximum_intensity_projection_id,
-      [prov:type = 'nidm:Image',
-      prov:location = \"file:///path/to/MaximumIntensityProjection.png\" %% xsd:anyURI,
-      nidm:filename = \"MaximumIntensityProjection.png\" %% xsd:string,
       dct:format = \"image/png\"])""" ;
            
            rdfs:comment "Class used to represent png, gif..." ;
            
-           obo:IAO_0000115 "FIXME" .
+           obo:IAO_0000115 "FIXME" ;
+           
+           obo:IAO_0000112 """entity(niiri:maximum_intensity_projection_id,
+      [prov:type = 'nidm:Image',
+      prov:location = \"file:///path/to/MaximumIntensityProjection.png\" %% xsd:anyURI,
+      nidm:filename = \"MaximumIntensityProjection.png\" %% xsd:string,
+      dct:format = \"image/png\"])""" .
 
 
 
@@ -2265,12 +2278,12 @@ nidm:Inference rdf:type owl:Class ;
                obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_35. """ ;
                
-               obo:IAO_0000115 "The process of inferring the excursion set from a statistical map." ;
-               
                obo:IAO_0000112 """activity(niiri:inference_id,
       [prov:type = 'nidm:Inference',
       nidm:hasAlternativeHypothesis = 'nidm:OneTailedTest',
-      prov:label = \"Inference\"])""" .
+      prov:label = \"Inference\"])""" ;
+               
+               obo:IAO_0000115 "The process of inferring the excursion set from a statistical map." .
 
 
 
@@ -2298,10 +2311,10 @@ nidm:MNICoordinateSystem rdf:type owl:Class ;
                          
                          rdfs:seeAlso "birnlex_2125" ;
                          
+                         rdfs:comment "FIXME. This definition needs to be re-worked and reviewed." ;
+                         
                          obo:IAO_0000116 """Context: io terms. Parent: reference atlas not found. BIRNLex or 
 NIDM Concept ID: nidm:nidm_40. """ ;
-                         
-                         rdfs:comment "FIXME. This definition needs to be re-worked and reviewed." ;
                          
                          obo:IAO_0000115 "Coordinate system defined with reference to the MNI atlas." .
 
@@ -2336,6 +2349,9 @@ nidm:MaskMap rdf:type owl:Class ;
              
              obo:IAO_0000115 "map or surface on which the associated results are displayed. " ;
              
+             obo:IAO_0000116 """BIRNLex or 
+NIDM Concept ID: nidm_39. """ ;
+             
              obo:IAO_0000112 """entity(niiri:mask_id_2,
       [prov:type = 'nidm:MaskMap',
       prov:location = \"file:///path/to/Mask.nii.gz\" %% xsd:anyURI,
@@ -2343,10 +2359,7 @@ nidm:MaskMap rdf:type owl:Class ;
       dct:format = \"image/nifti\",
       prov:label = \"Mask\" %% xsd:string,
       nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
-      crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" ;
-             
-             obo:IAO_0000116 """BIRNLex or 
-NIDM Concept ID: nidm_39. """ .
+      crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" .
 
 
 
@@ -2356,9 +2369,9 @@ nidm:Mni305CoordinateSystem rdf:type owl:Class ;
                             
                             rdfs:subClassOf nidm:MNICoordinateSystem ;
                             
-                            obo:IAO_0000115 "Coordinate system defined by the \"average of 305 T1-weighted MRI scans, linearly transformed to Talairach space\"." ;
-                            
                             rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/MNI305" ;
+                            
+                            obo:IAO_0000115 "Coordinate system defined by the \"average of 305 T1-weighted MRI scans, linearly transformed to Talairach space\"." ;
                             
                             rdfs:comment "FIXME. This definition needs to be re-worked and reviewed." .
 
@@ -2373,13 +2386,13 @@ nidm:ModelParametersEstimation rdf:type owl:Class ;
                                obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_41. """ ;
                                
+                               rdfs:seeAlso "stato:model parameter estimation" ;
+                               
                                obo:IAO_0000112 """activity(niiri:model_pe_id,
       [prov:type = 'nidm:ModelParametersEstimation',
       prov:label = \"Model parameters estimation\",
       nidm:withEstimationMethod = 'nidm:OrdinaryLeastSquares'
       ])""" ;
-                               
-                               rdfs:seeAlso "stato:model parameter estimation" ;
                                
                                obo:IAO_0000115 "The process of estimating the parameters of a general linear model from the available data." .
 
@@ -2419,15 +2432,15 @@ nidm:NoiseModel rdf:type owl:Class ;
                 
                 rdfs:subClassOf prov:Entity ;
                 
-                obo:IAO_0000115 "FIXME" ;
-                
                 obo:IAO_0000112 """entity(niiri:noise_model_id,
       [prov:type = 'nidm:NoiseModel',
       nidm:hasNoiseDistribution = 'nidm:GaussianDistribution',
       nidm:noiseVarianceHomogeneous = \"true\" %%xsd:boolean,
       nidm:varianceSpatialModel = 'nidm:SpatiallyLocal',
       nidm:hasNoiseDependence = 'nidm:IndependentNoise',
-      nidm:dependenceSpatialModel = 'nidm:SpatiallyLocal'])""" .
+      nidm:dependenceSpatialModel = 'nidm:SpatiallyLocal'])""" ;
+                
+                obo:IAO_0000115 "FIXME" .
 
 
 
@@ -2438,6 +2451,16 @@ nidm:NonParametricDistribution rdf:type owl:Class ;
                                rdfs:subClassOf nidm:NoiseDistribution ;
                                
                                obo:IAO_0000115 "FIXME" .
+
+
+
+###  http://www.incf.org/ns/nidash/nidm#NonParametricSymmetricDistribution
+
+nidm:NonParametricSymmetricDistribution rdf:type owl:Class ;
+                                        
+                                        rdfs:subClassOf nidm:NoiseDistribution ;
+                                        
+                                        obo:IAO_0000115 "FIXME" .
 
 
 
@@ -2471,11 +2494,6 @@ nidm:ParameterEstimateMap rdf:type owl:Class ;
                           
                           rdfs:subClassOf nidm:Map ;
                           
-                          obo:IAO_0000116 """BIRNLex or 
-NIDM Concept ID: nidm_45. """ ;
-                          
-                          obo:IAO_0000115 "A map whose value at each location is the estimate of a model parameter." ;
-                          
                           obo:IAO_0000112 """entity(niiri:parameter_estimate_map_id_1,
       [prov:type = 'nidm:ParameterEstimateMap',
       prov:location = \"file:///path/to/ParameterEstimate_0001.nii.gz\" %% xsd:anyURI,
@@ -2483,7 +2501,12 @@ NIDM Concept ID: nidm_45. """ ;
       nidm:filename = \"ParameterEstimate_0001.nii.gz\" %% xsd:string,
       dct:format = \"image/nifti\",
       nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
-      crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" .
+      crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" ;
+                          
+                          obo:IAO_0000116 """BIRNLex or 
+NIDM Concept ID: nidm_45. """ ;
+                          
+                          obo:IAO_0000115 "A map whose value at each location is the estimate of a model parameter." .
 
 
 
@@ -2492,6 +2515,8 @@ NIDM Concept ID: nidm_45. """ ;
 nidm:Peak rdf:type owl:Class ;
           
           rdfs:subClassOf prov:Entity ;
+          
+          obo:IAO_0000115 "Statistic defined at the peak-level in an excursion set. FIXME (now Peak instead of PeakStatistic)" ;
           
           obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: nidm_46. """ ;
@@ -2504,9 +2529,7 @@ NIDM Concept ID: nidm_46. """ ;
       nidm:equivalentZStatistic = \"INF\" %% xsd:float,
       nidm:pValueUncorrected = \"4.44089209850063e-16\" %% xsd:float,
       nidm:pValueFWER = \"0\" %% xsd:float,
-      nidm:qValueFDR = \"6.3705194444993e-11\" %% xsd:float])""" ;
-          
-          obo:IAO_0000115 "Statistic defined at the peak-level in an excursion set. FIXME (now Peak instead of PeakStatistic)" .
+      nidm:qValueFDR = \"6.3705194444993e-11\" %% xsd:float])""" .
 
 
 
@@ -2529,8 +2552,7 @@ nidm:ResidualMeanSquaresMap rdf:type owl:Class ;
                             obo:IAO_0000115 """A map whose value at each location is the residual of the mean squares fit to the data.
 """ ;
                             
-                            obo:IAO_0000116 """BIRNLex or 
-NIDM Concept ID: nidm_52. """ ;
+                            rdfs:seeAlso "This is a map of \"residuals\" as defined at http://bioportal.bioontology.org/ontologies/STATO/?p=classes&conceptid=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FSTATO_0000234 " ;
                             
                             obo:IAO_0000112 """entity(niiri:residual_mean_squares_map_id,
       [prov:type = 'nidm:ResidualMeanSquaresMap',
@@ -2541,7 +2563,8 @@ NIDM Concept ID: nidm_52. """ ;
       nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" ;
                             
-                            rdfs:seeAlso "This is a map of \"residuals\" as defined at http://bioportal.bioontology.org/ontologies/STATO/?p=classes&conceptid=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FSTATO_0000234 " .
+                            obo:IAO_0000116 """BIRNLex or 
+NIDM Concept ID: nidm_52. """ .
 
 
 
@@ -2563,8 +2586,6 @@ nidm:SPM rdf:type owl:Class ;
          
          rdfs:subClassOf prov:SoftwareAgent ;
          
-         obo:IAO_0000115 "Statistical Parametric Mapping software package for the analysis of neuroimaging data from the FIL Methods Group." ;
-         
          obo:IAO_0000112 """agent(niiri:software_id,
       [prov:type = 'nidm:SPM',
       prov:type = 'prov:SoftwareAgent',
@@ -2572,10 +2593,12 @@ nidm:SPM rdf:type owl:Class ;
       nidm:softwareVersion = \"SPM12b\" %% xsd:string,
       spm:softwareRevision = \"5853\" %% xsd:string])""" ;
          
-         obo:IAO_0000116 """BIRNLex or 
-NIDM Concept ID: nidm_56. """ ;
+         obo:IAO_0000115 "Statistical Parametric Mapping software package for the analysis of neuroimaging data from the FIL Methods Group." ;
          
-         rdfs:seeAlso "http://www.fil.ion.ucl.ac.uk/spm/" .
+         rdfs:seeAlso "http://www.fil.ion.ucl.ac.uk/spm/" ;
+         
+         obo:IAO_0000116 """BIRNLex or 
+NIDM Concept ID: nidm_56. """ .
 
 
 
@@ -2585,13 +2608,13 @@ nidm:SPMResults rdf:type owl:Class ;
                 
                 rdfs:subClassOf nidm:NIDMObjectModel ;
                 
+                obo:IAO_0000115 "FIXME" ;
+                
                 obo:IAO_0000112 """entity(niiri:spm_results_id,
     [prov:type = 'prov:Bundle',
     prov:label = \"SPM Results\",
     nidm:objectModel = 'nidm:SPMResults',
-    nidm:version = \"0.2.0\"])""" ;
-                
-                obo:IAO_0000115 "FIXME" .
+    nidm:version = \"0.2.0\"])""" .
 
 
 
@@ -2602,7 +2625,16 @@ nidm:SearchSpaceMap rdf:type owl:Class ;
                     rdfs:subClassOf nidm:Map ,
                                     prov:Entity ;
                     
-                    obo:IAO_0000112 """entity(niiri:search_space_id,
+                    obo:IAO_0000112 """entity(niiri:stat_image_properties_id,
+      [prov:type = 'nidm:SearchSpaceMap',
+      prov:label = \"Statistical image properties\",
+      spm:expectedNumberOfVoxelsPerCluster = \"0.553331387916112\" %% xsd:float,
+      spm:expectedNumberOfClusters = \"0.0889172687960151\" %% xsd:float,
+      spm:heightCriticalThresholdFWE05 = \"5.23529984739211\" %% xsd:float,
+      spm:heightCriticalThresholdFDR05 = \"6.22537899017334\" %% xsd:float,
+      spm:smallestSignifClusterSizeInVoxelsFWE05 = \"1\" %% xsd:float,
+      spm:smallestSignifClusterSizeInVoxelsFDR05 = \"3\" %% xsd:float])""" ,
+                                    """entity(niiri:search_space_id,
         [prov:type = 'nidm:SearchSpaceMap',
         prov:location = \"file:///path/to/SearchSpace.nii.gz\" %% xsd:anyURI,
         dct:format = \"image/nifti\",
@@ -2612,26 +2644,12 @@ nidm:SearchSpaceMap rdf:type owl:Class ;
         nidm:atCoordinateSpace = 'niiri:coordinate_space_id_2',
         prov:label = \"Search Space Map\" %% xsd:string,
         fsl:searchVolumeInVoxels = \"45359\" %% xsd:int,
-        fsl:reselSizeInVoxels = \"12.2251\" %%xsd:float])""" ,
-                                    """entity(niiri:stat_image_properties_id,
-      [prov:type = 'nidm:SearchSpaceMap',
-      prov:label = \"Statistical image properties\",
-      spm:expectedNumberOfVoxelsPerCluster = \"0.553331387916112\" %% xsd:float,
-      spm:expectedNumberOfClusters = \"0.0889172687960151\" %% xsd:float,
-      spm:heightCriticalThresholdFWE05 = \"5.23529984739211\" %% xsd:float,
-      spm:heightCriticalThresholdFDR05 = \"6.22537899017334\" %% xsd:float,
-      spm:smallestSignifClusterSizeInVoxelsFWE05 = \"1\" %% xsd:float,
-      spm:smallestSignifClusterSizeInVoxelsFDR05 = \"3\" %% xsd:float])""" ;
-                    
-                    obo:IAO_0000116 """Domain or Attributes: spm:searchVolumeInUnits not found. BIRNLex or 
-NIDM Concept ID: nidm_100. """ ;
+        fsl:reselSizeInVoxels = \"12.2251\" %%xsd:float])""" ;
                     
                     rdfs:seeAlso "http://purl.obolibrary.org/obo/OBI_0000235" ;
                     
-                    obo:IAO_0000116 """BIRNLex or 
-NIDM Concept ID: spm_95. """ ;
-                    
-                    obo:IAO_0000115 "mask in which the inference was performed." ;
+                    obo:IAO_0000116 """Domain or Attributes: spm:searchVolumeInUnits not found. BIRNLex or 
+NIDM Concept ID: nidm_100. """ ;
                     
                     obo:IAO_0000112 """entity(niiri:search_space_id,
       [prov:type = 'nidm:SearchSpaceMap',
@@ -2656,7 +2674,11 @@ NIDM Concept ID: spm_95. """ ;
       nidm:randomFieldStationarity = \"false\" %%xsd:boolean,
       crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" ;
                     
-                    obo:IAO_0000115 "Properties of the underlying statistical process." .
+                    obo:IAO_0000116 """BIRNLex or 
+NIDM Concept ID: spm_95. """ ;
+                    
+                    obo:IAO_0000115 "mask in which the inference was performed." ,
+                                    "Properties of the underlying statistical process." .
 
 
 
@@ -2716,10 +2738,10 @@ nidm:StandardizedCoordinateSystem rdf:type owl:Class ;
                                   
                                   rdfs:subClassOf nidm:WorldCoordinateSystem ;
                                   
-                                  rdfs:comment "This is meant to be used for retrospective export when exact template is unknown." ,
-                                               "FIXME. This definition needs to be re-worked and reviewed." ;
+                                  obo:IAO_0000115 "Parent of all reference spaces except \"Subject\"." ;
                                   
-                                  obo:IAO_0000115 "Parent of all reference spaces except \"Subject\"." .
+                                  rdfs:comment "This is meant to be used for retrospective export when exact template is unknown." ,
+                                               "FIXME. This definition needs to be re-worked and reviewed." .
 
 
 
@@ -2753,10 +2775,10 @@ nidm:StatisticMap rdf:type owl:Class ;
       nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
       crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" ;
                   
-                  obo:IAO_0000115 "A map whose value at each location is a statistic. " ;
-                  
                   obo:IAO_0000116 """BIRNLex or 
-NIDM Concept ID: nidm_60. """ .
+NIDM Concept ID: nidm_60. """ ;
+                  
+                  obo:IAO_0000115 "A map whose value at each location is a statistic. " .
 
 
 
@@ -2766,6 +2788,9 @@ nidm:SubVolumeMap rdf:type owl:Class ;
                   
                   rdfs:subClassOf nidm:Map ;
                   
+                  obo:IAO_0000116 """BIRNLex or 
+NIDM Concept ID: nidm_101. """ ;
+                  
                   obo:IAO_0000112 """entity(niiri:sub_volume_id,
       [prov:type = 'nidm:SubVolumeMap',
       prov:location = \"file:///path/to/SubVolume.nii.gz\" %% xsd:anyURI,
@@ -2774,9 +2799,6 @@ nidm:SubVolumeMap rdf:type owl:Class ;
       prov:label = \"Sub-volume Map\" %% xsd:string,
       nidm:atCoordinateSpace = 'niiri:coordinate_space_id_2',
       crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" ;
-                  
-                  obo:IAO_0000116 """BIRNLex or 
-NIDM Concept ID: nidm_101. """ ;
                   
                   obo:IAO_0000115 "mask defined by the user to restrain the space in which inference is performed." .
 
@@ -2788,9 +2810,9 @@ nidm:SubjectCoordinateSystem rdf:type owl:Class ;
                              
                              rdfs:subClassOf nidm:WorldCoordinateSystem ;
                              
-                             rdfs:comment "Used in FSL and SPM un-registered data." ;
+                             obo:IAO_0000115 "Coordinate system defined by the subject brain (no spatial normalisation applied)." ;
                              
-                             obo:IAO_0000115 "Coordinate system defined by the subject brain (no spatial normalisation applied)." .
+                             rdfs:comment "Used in FSL and SPM un-registered data." .
 
 
 
@@ -2810,9 +2832,9 @@ nidm:TalairachCoordinateSystem rdf:type owl:Class ;
                                
                                rdfs:subClassOf nidm:StandardizedCoordinateSystem ;
                                
-                               obo:IAO_0000115 "Reference space defined by the dissected brain used for the Talairach and Tournoux atlas." ;
-                               
                                rdfs:comment "FIXME. This definition needs to be re-worked and reviewed." ;
+                               
+                               obo:IAO_0000115 "Reference space defined by the dissected brain used for the Talairach and Tournoux atlas." ;
                                
                                rdfs:seeAlso "http://www.talairach.org/" .
 
@@ -2891,6 +2913,8 @@ spm:ReselsPerVoxelMap rdf:type owl:Class ;
                       
                       rdfs:subClassOf nidm:Map ;
                       
+                      obo:IAO_0000115 "A map whose value at each location is the number of resels per voxel. " ;
+                      
                       obo:IAO_0000116 """BIRNLex or 
 NIDM Concept ID: spm_83. """ ;
                       
@@ -2901,9 +2925,7 @@ NIDM Concept ID: spm_83. """ ;
       dct:format = \"image/nifti\",
       prov:label = \"Resels per Voxel Map\" %% xsd:string,
       nidm:atCoordinateSpace = 'niiri:coordinate_space_id_1',
-      crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" ;
-                      
-                      obo:IAO_0000115 "A map whose value at each location is the number of resels per voxel. " .
+      crypto:sha512 = \"e43b6e01b0463fe7d40782137867a...\" %% xsd:string])""" .
 
 
 
@@ -2926,12 +2948,12 @@ spm:nonStationaryRandomField rdf:type owl:Class ;
                              
                              rdfs:subClassOf prov:Entity ;
                              
+                             obo:IAO_0000116 """Range: <thisisanattributevalue> not found. BIRNLex or 
+NIDM Concept ID: spm_81. """ ;
+                             
                              obo:IAO_0000112 "<this is an attribute value>" ;
                              
-                             obo:IAO_0000115 "Random field that is variable across the search volume." ;
-                             
-                             obo:IAO_0000116 """Range: <thisisanattributevalue> not found. BIRNLex or 
-NIDM Concept ID: spm_81. """ .
+                             obo:IAO_0000115 "Random field that is variable across the search volume." .
 
 
 

--- a/scripts/OwlReader.py
+++ b/scripts/OwlReader.py
@@ -22,7 +22,7 @@ class OwlReader():
         self.classes = self.get_class_names() 
         self.properties = self.get_property_names()
         # For each class find out attribute list as defined by domain in attributes
-        self.attributes, self.ranges,  self.type_restrictions = self.get_attributes()
+        self.attributes, self.ranges,  self.type_restrictions, self.parent_ranges = self.get_attributes()
 
 
     def get_class_names(self):
@@ -103,6 +103,8 @@ class OwlReader():
         # For each ObjectProperty found out corresponding range
         ranges = dict()
 
+        parent_ranges = dict()
+
         restrictions = dict()
 
         # Attributes that can be found in all classes
@@ -144,14 +146,14 @@ class OwlReader():
                             range_name = sub_range_name
 
 
-                    ranges.setdefault(data_property, set()).add(range_name)
+                    parent_ranges.setdefault(data_property, set()).add(range_name)
 
                     # Add child_class to range (for ObjectProperty)
                     for child in self.graph.transitive_subjects(RDFS['subClassOf'], range_name):
                         ranges.setdefault(data_property, set()).add(child)
                     
 
-        return list((attributes, ranges, restrictions))
+        return list((attributes, ranges, restrictions, parent_ranges))
 
     def get_graph(self):
         # Read owl (turtle) file

--- a/scripts/OwlReader.py
+++ b/scripts/OwlReader.py
@@ -22,10 +22,7 @@ class OwlReader():
         self.classes = self.get_class_names() 
         self.properties = self.get_property_names()
         # For each class find out attribute list as defined by domain in attributes
-        attributes_ranges = self.get_attributes()
-        self.attributes = attributes_ranges[0]
-        self.ranges = attributes_ranges[1]      
-        self.type_restrictions = attributes_ranges[2]     
+        self.attributes, self.ranges,  self.type_restrictions = self.get_attributes()
 
 
     def get_class_names(self):
@@ -146,41 +143,12 @@ class OwlReader():
                         for sub_range_name in self.graph.objects(range_name, OWL['onDatatype']):
                             range_name = sub_range_name
 
-                    if data_property in ranges:
-                        ranges[data_property].add(range_name)
-                    else:
-                        ranges[data_property] = set([range_name])
-                    # FIXME: more elegant?
+
+                    ranges.setdefault(data_property, set()).add(range_name)
+
                     # Add child_class to range (for ObjectProperty)
-                    for child_class in self.graph.subjects(RDFS['subClassOf'], range_name):
-                        # Add range to current class
-                        if data_property in ranges:
-                            ranges[data_property].add(child_class)
-                        else:
-                            ranges[data_property] = set([child_class])
-                        range_name = child_class
-                        for child_class in self.graph.subjects(RDFS['subClassOf'], range_name):
-                            # Add attribute to current class
-                            if data_property in ranges:
-                                ranges[data_property].add(child_class)
-                            else:
-                                ranges[data_property] = set([child_class])
-                            range_name = child_class
-                            for child_class in self.graph.subjects(RDFS['subClassOf'], range_name):
-                                # Add attribute to current class
-                                if data_property in ranges:
-                                    ranges[data_property].add(child_class)
-                                else:
-                                    ranges[data_property] = set([child_class])
-                                range_name = child_class
-                                for child_class in self.graph.subjects(RDFS['subClassOf'], range_name):
-                                    # Add attribute to current class
-                                    if data_property in ranges:
-                                        ranges[data_property].add(child_class)
-                                    else:
-                                        ranges[data_property] = set([child_class])
-                                    range_name = child_class
-                
+                    for child in self.graph.transitive_subjects(RDFS['subClassOf'], range_name):
+                        ranges.setdefault(data_property, set()).add(child)
                     
 
         return list((attributes, ranges, restrictions))

--- a/scripts/owl_to_webpage.py
+++ b/scripts/owl_to_webpage.py
@@ -261,7 +261,7 @@ class OwlSpecification(object):
                         </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> """+\
                         self.format_definition(att_def)
 
-                    if att in self.owl.ranges:
+                    if att in self.owl.parent_ranges:
                         # range_names = map(self._get_name, \
                             # sorted(self.owl.ranges[att]))
 
@@ -271,24 +271,59 @@ class OwlSpecification(object):
                            self._get_name(list(self.owl.ranges[att])[0]).startswith("spm"):
                             nidm_namespace = True
                             
-
+                        child_ranges = sorted(self.owl.ranges[att] - self.owl.parent_ranges[att])
                         if nidm_namespace:
-                            if len(self.owl.ranges[att]) >= 2:
+                            child_range_txt = ""
+                            if child_ranges:
+                                # Get all child ranges
+                                if len(child_ranges) >= 2:
+                                    child_range_txt = " such as <a>"+"</a>, <a>".join(map(self._get_name, \
+                                        child_ranges[:-1]))+"</a> or <a>"+\
+                                        self._get_name(child_ranges[-1])+\
+                                        "</a>"
+                                else:
+                                    child_range_txt = \
+                                        " such as <a>"+self._get_name(list(child_ranges)[0])+\
+                                        "</a>"
+
+                            if len(self.owl.parent_ranges[att]) >= 2:
                                 self.text += " (range <a>"+"</a>, <a>".join(map(self._get_name, \
-                                    sorted(self.owl.ranges[att])[:-1]))+"</a> and <a>"+\
-                                    self._get_name(sorted(self.owl.ranges[att])[-1])+\
-                                    "</a>)"
+                                    sorted(self.owl.parent_ranges[att])[:-1]))+"</a> and <a>"+\
+                                    self._get_name(sorted(self.owl.parent_ranges[att])[-1])+\
+                                    "</a>"+child_range_txt+")"
                             else:
                                 self.text += \
-                                    " (range <a>"+self._get_name(list(self.owl.ranges[att])[0])+\
-                                    "</a>)"
+                                    " (range <a>"+self._get_name(list(self.owl.parent_ranges[att])[0])+\
+                                    "</a>"+child_range_txt+")"
                         else:
+                            child_range_txt = ""
+                            if child_ranges:
+                                child_range_txt = " such as "
+                                for child_range in child_ranges:
+                                    child_range_txt += '<a title="'+self.owl.graph.qname(child_range)+\
+                                    '" href="'+str(child_range)+'">'+\
+                                    self._get_name(child_range)+'</a>, '
+                                child_range_txt  = child_range_txt[:-2]
+                                child_range_txt = child_range_txt[::-1].replace(","[::-1], " or"[::-1], 1)[::-1]
+
+                                # # Get all child ranges
+                                # if len(child_ranges) >= 2:
+                                #     child_range_txt = " such as <a>"+"</a>, <a>".join(map(self._get_name, \
+                                #         child_ranges[:-1]))+"</a> or <a>"+\
+                                #         self._get_name(child_ranges[-1])+\
+                                #         "</a>"
+                                # else:
+                                #     child_range_txt = \
+                                #         " such as <a>"+self._get_name(list(child_ranges)[0])+\
+                                #         "</a>"
+
                             self.text += " (range "
-                            for range_uri in sorted(self.owl.ranges[att]):
+                            for range_uri in sorted(self.owl.parent_ranges[att]):
                                 self.text += '<a title="'+self.owl.graph.qname(range_uri)+\
                                 '" href="'+str(range_uri)+'">'+\
                                 self._get_name(range_uri)+'</a>, '
                             self.text = self.text[:-2]
+                            self.text += child_range_txt
                             self.text += ")"
 
 


### PR DESCRIPTION
- [x] Remove mention of `nidm:Nifti1Gz` in `ContrastMap` example (NIDM 0.2.0 spec).
- [x] `BinomialDistribution` should be in `nidm` namespace (not `fsl` namespace).
- [x] When listing possible classes as range, it is not very clear to have parent and children classes displayed (e.g. in "range `fsl:BinomialDistribution`, `fsl:NonParametricSymmetricDistribution`, `nidm:ErrorDistribution`, `nidm:GaussianDistribution`, `nidm:NonParametricDistribution`, `nidm:PoissonDistribution`" we would like to remove "`nidm:ErrorDistribution`".)
