### PR TITLE
Definition of "ExtentThreshold" (metadata complete)

### DIFF
--- a/doc/content/specs/nidm-results_dev.html
+++ b/doc/content/specs/nidm-results_dev.html
@@ -1555,8 +1555,7 @@
             <section id="section-nidm:ExtentThreshold"> 
                 <h1 label="nidm:ExtentThreshold">nidm:ExtentThreshold</h1>
                 <div class="glossary-ref">
-                    A <dfn>nidm:ExtentThreshold</dfn>                    <sup><a title="nidm:ExtentThreshold">                    <span class="diamond">&#9826;</span></a></sup> is a numerical value that establishes a bound on a range of cluster-sizes. / [from extentThresh:]        Minimum cluster size used when thresholding a statistic image        5voxels
-. <a>nidm:ExtentThreshold</a> is a prov:Entity. 
+                    A <dfn>nidm:ExtentThreshold</dfn>                    <sup><a title="nidm:ExtentThreshold">                    <span class="diamond">&#9826;</span></a></sup> is a numerical value that establishes a lower bound on cluster-sizes and can be specified by the user in terms of FWER-corrected p-value, uncorrected p-value or minimum cluster size in voxels. <a>nidm:ExtentThreshold</a> is a prov:Entity. 
                 </div>
                 <p></p>
                 <div class="attributes" id="attributes-nidm:ExtentThreshold"> A <a>nidm:ExtentThreshold</a> has attributes:

--- a/nidm/nidm-results/terms/README.md
+++ b/nidm/nidm-results/terms/README.md
@@ -142,11 +142,6 @@ Range: Vector of integers not found.)</td>
 </tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/orange.png?raw=true"/>  </td>
-    <td><b>nidm:ExtentThreshold: </b>A numerical value that establishes a bound on a range of cluster-sizes. / [from extentThresh:]        Minimum cluster size used when thresholding a statistic image        5voxels
- (Under discussion at: https://github.com/incf-nidash/nidm/pull/273)</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/orange.png?raw=true"/>  </td>
     <td><b>nidm:MNICoordinateSystem: </b>Coordinate system defined with reference to the MNI atlas</td>
 </tr>
 <tr>

--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -1418,12 +1418,12 @@ nfo:fileName rdf:type owl:DatatypeProperty ;
 dctype:Image rdf:type owl:Class ;
              
              rdfs:subClassOf [ rdf:type owl:Restriction ;
-                               owl:onProperty nfo:fileName ;
+                               owl:onProperty dct:format ;
                                owl:minQualifiedCardinality "0"^^xsd:nonNegativeInteger ;
                                owl:onDataRange xsd:string
                              ] ,
                              [ rdf:type owl:Restriction ;
-                               owl:onProperty dct:format ;
+                               owl:onProperty nfo:fileName ;
                                owl:minQualifiedCardinality "0"^^xsd:nonNegativeInteger ;
                                owl:onDataRange xsd:string
                              ] .
@@ -1726,11 +1726,6 @@ nidm:DesignMatrix rdf:type owl:Class ;
                   
                   rdfs:subClassOf prov:Entity ,
                                   [ rdf:type owl:Restriction ;
-                                    owl:onProperty dc:description ;
-                                    owl:onClass dctype:Image ;
-                                    owl:minQualifiedCardinality "0"^^xsd:nonNegativeInteger
-                                  ] ,
-                                  [ rdf:type owl:Restriction ;
                                     owl:onProperty dct:format ;
                                     owl:minQualifiedCardinality "0"^^xsd:nonNegativeInteger ;
                                     owl:onDataRange xsd:string
@@ -1739,6 +1734,11 @@ nidm:DesignMatrix rdf:type owl:Class ;
                                     owl:onProperty nfo:fileName ;
                                     owl:minQualifiedCardinality "0"^^xsd:nonNegativeInteger ;
                                     owl:onDataRange xsd:string
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty dc:description ;
+                                    owl:onClass dctype:Image ;
+                                    owl:minQualifiedCardinality "0"^^xsd:nonNegativeInteger
                                   ] ;
                   
                   obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/DesignMatrix.txt"^^xsd:anyURI ;
@@ -1854,12 +1854,11 @@ nidm:ExtentThreshold rdf:type owl:Class ;
                      
                      obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ExtentThreshold.txt"^^xsd:anyURI ;
                      
-                     obo:IAO_0000115 """A numerical value that establishes a bound on a range of cluster-sizes. / [from extentThresh:]        Minimum cluster size used when thresholding a statistic image        5voxels
-""" ;
+                     obo:IAO_0000115 "A numerical value that establishes a lower bound on cluster-sizes and can be specified by the user in terms of FWER-corrected p-value, uncorrected p-value or minimum cluster size in voxels" ;
                      
-                     obo:IAO_0000116 "Under discussion at: https://github.com/incf-nidash/nidm/pull/273" ;
+                     obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/pull/273" ;
                      
-                     obo:IAO_0000114 obo:IAO_0000120 .
+                     obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -2016,12 +2015,12 @@ nidm:MapHeader rdf:type owl:Class ;
                
                rdfs:subClassOf prov:Entity ,
                                [ rdf:type owl:Restriction ;
-                                 owl:onProperty nfo:fileName ;
+                                 owl:onProperty dct:format ;
                                  owl:minQualifiedCardinality "0"^^xsd:nonNegativeInteger ;
                                  owl:onDataRange xsd:string
                                ] ,
                                [ rdf:type owl:Restriction ;
-                                 owl:onProperty dct:format ;
+                                 owl:onProperty nfo:fileName ;
                                  owl:minQualifiedCardinality "0"^^xsd:nonNegativeInteger ;
                                  owl:onDataRange xsd:string
                                ] ;


### PR DESCRIPTION
This issue is open to curate the definition of **nidm:ExtentThreshold**.

###### Current definition
- *nidm:ExtentThreshold*: "A numerical value that establishes a bound on a range of cluster-sizes. / [from extentThresh:] Minimum cluster size used when thresholding a statistic image 5voxels"

###### Term usage
A `nidm:ExtentThreshold` is used an an input of `nidm:Inference` (see also [ExtentThreshold in the spec](http://nidm.nidash.org/specs/nidm-results_dev.html#section-nidm:ExtentThreshold)). 

 - E.g. of `nidm:ExtentThreshold` entity for a cluster-wise threshold of p<0.05:
```
niiri:extent_threshold_id a prov:Entity , nidm:ExtentThreshold ;
	rdfs:label "Extent Threshold: p<0.05 (FWE)" ;
	nidm:userSpecifiedThresholdType "p-value FWE"^^xsd:string ;
	nidm:pValueFWER "0.05"^^xsd:float .
```

 - E.g. of `nidm:ExtentThreshold` entity with a cluster-wise threshold of k>=0:
```
niiri:extent_threshold_id a prov:Entity , nidm:ExtentThreshold ;
	rdfs:label "Extent Threshold: k>=0" ;
	nidm:clusterSizeInVoxels "0"^^xsd:int ;
	spm:clusterSizeInResels "0"^^xsd:float ;
	nidm:pValueUncorrected "1"^^xsd:float ;
	nidm:pValueFWER "1"^^xsd:float .
```

-----

###### Proposal

How about adding a small extension to the current definition:
- *nidm:ExtentThreshold*: A numerical value that establishes a bound on a range of cluster-sizes **and can be specified by the user in terms of FWER-corrected p-value, uncorrected p-value or minimum cluster size in voxels**.

? Would you have alternative suggestions or comments? Thank you!