### PR TITLE
Definition of `clusterLabelId` (pending final vetting)

### DIFF
--- a/doc/content/specs/nidm-results_dev.html
+++ b/doc/content/specs/nidm-results_dev.html
@@ -1800,7 +1800,7 @@ niiri:mask_id_2 a prov:Entity , nidm:MaskMap ;
                      
                         <li><span class="attribute" id="nidm:SignificantCluster.nidm:clusterLabelId">
                         <dfn>nidm:clusterLabelId</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> integer associated with a particular cluster as specified in the clusterLabelsMap. (range <a title="xsd:int" href="http://www.w3.org/2001/XMLSchema#int">xsd:int</a>)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> integer value used in the cluster label map to identify the location of the cluster within the excursion set. (range <a title="xsd:int" href="http://www.w3.org/2001/XMLSchema#int">xsd:int</a>)</li> 
                         <li><span class="attribute" id="nidm:SignificantCluster.nidm:clusterSizeInVertices">
                         <a>nidm:clusterSizeInVertices</a>
                         </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> number of vertices that make up the cluster. (range <a title="xsd:positiveInteger" href="http://www.w3.org/2001/XMLSchema#positiveInteger">xsd:positiveInteger</a>)</li> 

--- a/nidm/nidm-results/terms/README.md
+++ b/nidm/nidm-results/terms/README.md
@@ -311,13 +311,6 @@ Range: Vector of integers not found.</td>
 <tr><th>Curation Status</th><th>Issue/PR</th><th>Term</th><th>Domain</th><th>Range</th></tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
-    <td>Under discussion at: #271</td>
-    <td><b>nidm:clusterLabelId: </b>Integer associated with a particular cluster as specified in the clusterLabelsMap</td>
-    <td>nidm:SignificantCluster </td>
-    <td>xsd:int </td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
     <td></td>
     <td><b>nidm:clusterSizeInVoxels: </b>Number of voxels that make up the cluster</td>
     <td>nidm:ExtentThreshold nidm:SignificantCluster </td>

--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -429,13 +429,13 @@ fsl:reselSizeInVoxels rdf:type owl:DatatypeProperty ;
 
 nidm:clusterLabelId rdf:type owl:DatatypeProperty ;
                     
-                    obo:IAO_0000116 "Under discussion at: https://github.com/incf-nidash/nidm/pull/271" ;
-                    
                     obo:IAO_0000112 "5" ;
                     
-                    obo:IAO_0000115 "Integer associated with a particular cluster as specified in the clusterLabelsMap." ;
+                    obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/pull/271" ;
                     
-                    obo:IAO_0000114 obo:IAO_0000125 ;
+                    obo:IAO_0000115 "Integer value used in the cluster label map to identify the location of the cluster within the excursion set." ;
+                    
+                    obo:IAO_0000114 obo:IAO_0000122 ;
                     
                     rdfs:domain nidm:SignificantCluster ;
                     
@@ -1476,6 +1476,18 @@ nfo:fileName rdf:type owl:DatatypeProperty ;
 #################################################################
 
 
+###  http://neurolex.org/wiki/birnlex_2067
+
+nlx:birnlex_2067 rdfs:subClassOf prov:SoftwareAgent .
+
+
+
+###  http://neurolex.org/wiki/nif-0000-00343
+
+nlx:nif-0000-00343 rdfs:subClassOf prov:SoftwareAgent .
+
+
+
 ###  http://purl.org/dc/dcmitype/Image
 
 dctype:Image rdf:type owl:Class ;
@@ -1526,15 +1538,6 @@ afni:GammaHRF rdf:type owl:Class ;
               prov:editorialNote "Discussed with @afni-rickr in https://github.com/incf-nidash/nidm/pull/248: supported via GAM."^^xsd:string .
 
 
-###  http://neurolex.org/wiki/birnlex_2067
-
-nlx:birnlex_2067 rdfs:subClassOf prov:SoftwareAgent .
-
-
-
-###  http://neurolex.org/wiki/nif-0000-00343
-
-nlx:nif-0000-00343 rdfs:subClassOf prov:SoftwareAgent .
 
 ###  http://www.incf.org/ns/nidash/fsl#CenterOfGravity
 


### PR DESCRIPTION
This issue is open to curate the definition of **nidm:clusterLabelId**.

###### Current definition
- *nidm:clusterLabelId*: Integer associated with a particular cluster as specified in the clusterLabelsMap. 

###### Term usage
`nidm:clusterLabelId` is an attribute in entities of type `nidm:SignificantCluster`, e.g.:
<pre>
niiri:significant_cluster_0002 a prov:Entity , nidm:SignificantCluster ;
	rdfs:label "Significant Cluster: 0002" ;
	<b>nidm:clusterLabelId "2"^^xsd:int ;</b>
	...
	prov:wasDerivedFrom niiri:excursion_set_map_id .

niiri:excursion_set_map_id a prov:Entity , nidm:ExcursionSetMap ;
	rdfs:label "Excursion Set Map" ;
	...
	nidm:hasClusterLabelsMap niiri:cluster_label_map_id .
</pre>

-----

###### Proposal
I wonder if something like:
 - *nidm:clusterLabelId*: An integer value used in the cluster label map to identify the location of the cluster. 

would be more explicit?

Are you happy with the original definition? Would you have alternative suggestions or comments? Thank you!