### PR TITLE
Definition of "MapHeader" (current status: uncurated)

### DIFF
--- a/doc/content/specs/nidm-results_dev.html
+++ b/doc/content/specs/nidm-results_dev.html
@@ -339,7 +339,7 @@
                      
                         <li><span class="attribute" id="nidm:Map.nidm:hasMapHeader">
                         <dfn>nidm:hasMapHeader</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a>nidm:MapHeader</a>)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a Property that associates an additional file containing the map header with a map. (range <a>nidm:MapHeader</a>)</li> 
                         <li><span class="attribute" id="nidm:Map.nidm:inCoordinateSpace">
                         <dfn>nidm:inCoordinateSpace</dfn>
                         </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range <a>nidm:CoordinateSpace</a>)</li>
@@ -347,7 +347,7 @@
             <section id="section-nidm:MapHeader"> 
                 <h1 label="nidm:MapHeader">nidm:MapHeader</h1>
                 <div class="glossary-ref">
-                    A <dfn>nidm:MapHeader</dfn>                    <sup><a title="nidm:MapHeader">                    <span class="diamond">&#9826;</span></a></sup> is . <a>nidm:MapHeader</a> is a prov:Entity. 
+                    A <dfn>nidm:MapHeader</dfn>                    <sup><a title="nidm:MapHeader">                    <span class="diamond">&#9826;</span></a></sup> is a file associated with a Map to provide header information (e.g. NIfTI header file). <a>nidm:MapHeader</a> is a prov:Entity. 
                 </div>
                 <p></p>
                 <div class="attributes" id="attributes-nidm:MapHeader"> A <a>nidm:MapHeader</a> has attributes:
@@ -941,7 +941,7 @@
                      
                         <li><span class="attribute" id="nidm:GrandMeanMap.nidm:hasMapHeader">
                         <a>nidm:hasMapHeader</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a>nidm:MapHeader</a>)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a Property that associates an additional file containing the map header with a map. (range <a>nidm:MapHeader</a>)</li> 
                         <li><span class="attribute" id="nidm:GrandMeanMap.nidm:inCoordinateSpace">
                         <a>nidm:inCoordinateSpace</a>
                         </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range <a>nidm:CoordinateSpace</a>)</li> 
@@ -973,7 +973,7 @@
                      
                         <li><span class="attribute" id="nidm:MaskMap.nidm:hasMapHeader">
                         <a>nidm:hasMapHeader</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a>nidm:MapHeader</a>)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a Property that associates an additional file containing the map header with a map. (range <a>nidm:MapHeader</a>)</li> 
                         <li><span class="attribute" id="nidm:MaskMap.nidm:inCoordinateSpace">
                         <a>nidm:inCoordinateSpace</a>
                         </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range <a>nidm:CoordinateSpace</a>)</li> 
@@ -1005,7 +1005,7 @@ niiri:mask_id_2 a prov:Entity , nidm:MaskMap ;
                      
                         <li><span class="attribute" id="nidm:ParameterEstimateMap.nidm:hasMapHeader">
                         <a>nidm:hasMapHeader</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a>nidm:MapHeader</a>)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a Property that associates an additional file containing the map header with a map. (range <a>nidm:MapHeader</a>)</li> 
                         <li><span class="attribute" id="nidm:ParameterEstimateMap.nidm:inCoordinateSpace">
                         <a>nidm:inCoordinateSpace</a>
                         </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range <a>nidm:CoordinateSpace</a>)</li>        
@@ -1029,7 +1029,7 @@ niiri:mask_id_2 a prov:Entity , nidm:MaskMap ;
                      
                         <li><span class="attribute" id="nidm:ResidualMeanSquaresMap.nidm:hasMapHeader">
                         <a>nidm:hasMapHeader</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a>nidm:MapHeader</a>)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a Property that associates an additional file containing the map header with a map. (range <a>nidm:MapHeader</a>)</li> 
                         <li><span class="attribute" id="nidm:ResidualMeanSquaresMap.nidm:inCoordinateSpace">
                         <a>nidm:inCoordinateSpace</a>
                         </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range <a>nidm:CoordinateSpace</a>)</li>        
@@ -1134,7 +1134,7 @@ niiri:mask_id_2 a prov:Entity , nidm:MaskMap ;
                         </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> name of the contrast. (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li> 
                         <li><span class="attribute" id="nidm:ContrastMap.nidm:hasMapHeader">
                         <a>nidm:hasMapHeader</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a>nidm:MapHeader</a>)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a Property that associates an additional file containing the map header with a map. (range <a>nidm:MapHeader</a>)</li> 
                         <li><span class="attribute" id="nidm:ContrastMap.nidm:inCoordinateSpace">
                         <a>nidm:inCoordinateSpace</a>
                         </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range <a>nidm:CoordinateSpace</a>)</li>        
@@ -1164,7 +1164,7 @@ niiri:mask_id_2 a prov:Entity , nidm:MaskMap ;
                      
                         <li><span class="attribute" id="nidm:ContrastStandardErrorMap.nidm:hasMapHeader">
                         <a>nidm:hasMapHeader</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a>nidm:MapHeader</a>)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a Property that associates an additional file containing the map header with a map. (range <a>nidm:MapHeader</a>)</li> 
                         <li><span class="attribute" id="nidm:ContrastStandardErrorMap.nidm:inCoordinateSpace">
                         <a>nidm:inCoordinateSpace</a>
                         </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range <a>nidm:CoordinateSpace</a>)</li>        
@@ -1226,7 +1226,7 @@ niiri:mask_id_2 a prov:Entity , nidm:MaskMap ;
                         </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> degrees of freedom of the error. (range <a title="xsd:float" href="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li> 
                         <li><span class="attribute" id="nidm:StatisticMap.nidm:hasMapHeader">
                         <a>nidm:hasMapHeader</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a>nidm:MapHeader</a>)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a Property that associates an additional file containing the map header with a map. (range <a>nidm:MapHeader</a>)</li> 
                         <li><span class="attribute" id="nidm:StatisticMap.nidm:inCoordinateSpace">
                         <a>nidm:inCoordinateSpace</a>
                         </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range <a>nidm:CoordinateSpace</a>)</li> 
@@ -1490,7 +1490,7 @@ niiri:mask_id_2 a prov:Entity , nidm:MaskMap ;
                      
                         <li><span class="attribute" id="nidm:ClusterLabelsMap.nidm:hasMapHeader">
                         <a>nidm:hasMapHeader</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a>nidm:MapHeader</a>)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a Property that associates an additional file containing the map header with a map. (range <a>nidm:MapHeader</a>)</li> 
                         <li><span class="attribute" id="nidm:ClusterLabelsMap.nidm:inCoordinateSpace">
                         <a>nidm:inCoordinateSpace</a>
                         </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range <a>nidm:CoordinateSpace</a>)</li>        
@@ -1542,7 +1542,7 @@ niiri:mask_id_2 a prov:Entity , nidm:MaskMap ;
                      
                         <li><span class="attribute" id="nidm:DisplayMaskMap.nidm:hasMapHeader">
                         <a>nidm:hasMapHeader</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a>nidm:MapHeader</a>)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a Property that associates an additional file containing the map header with a map. (range <a>nidm:MapHeader</a>)</li> 
                         <li><span class="attribute" id="nidm:DisplayMaskMap.nidm:inCoordinateSpace">
                         <a>nidm:inCoordinateSpace</a>
                         </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range <a>nidm:CoordinateSpace</a>)</li> 
@@ -1575,7 +1575,7 @@ niiri:mask_id_2 a prov:Entity , nidm:MaskMap ;
                         </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a map whose value at each location denotes cluster membership. Each cluster is denoted by a different integer. (range <a>nidm:ClusterLabelsMap</a>)</li> 
                         <li><span class="attribute" id="nidm:ExcursionSetMap.nidm:hasMapHeader">
                         <a>nidm:hasMapHeader</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a>nidm:MapHeader</a>)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a Property that associates an additional file containing the map header with a map. (range <a>nidm:MapHeader</a>)</li> 
                         <li><span class="attribute" id="nidm:ExcursionSetMap.nidm:inCoordinateSpace">
                         <a>nidm:inCoordinateSpace</a>
                         </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range <a>nidm:CoordinateSpace</a>)</li> 
@@ -1743,7 +1743,7 @@ niiri:mask_id_2 a prov:Entity , nidm:MaskMap ;
                      
                         <li><span class="attribute" id="nidm:SearchSpaceMaskMap.nidm:hasMapHeader">
                         <a>nidm:hasMapHeader</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a>nidm:MapHeader</a>)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a Property that associates an additional file containing the map header with a map. (range <a>nidm:MapHeader</a>)</li> 
                         <li><span class="attribute" id="nidm:SearchSpaceMaskMap.nidm:inCoordinateSpace">
                         <a>nidm:inCoordinateSpace</a>
                         </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range <a>nidm:CoordinateSpace</a>)</li> 
@@ -1861,7 +1861,7 @@ niiri:mask_id_2 a prov:Entity , nidm:MaskMap ;
                      
                         <li><span class="attribute" id="spm:ReselsPerVoxelMap.nidm:hasMapHeader">
                         <a>nidm:hasMapHeader</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a>nidm:MapHeader</a>)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a Property that associates an additional file containing the map header with a map. (range <a>nidm:MapHeader</a>)</li> 
                         <li><span class="attribute" id="spm:ReselsPerVoxelMap.nidm:inCoordinateSpace">
                         <a>nidm:inCoordinateSpace</a>
                         </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range <a>nidm:CoordinateSpace</a>)</li>        
@@ -1987,7 +1987,7 @@ niiri:mask_id_2 a prov:Entity , nidm:MaskMap ;
                      
                         <li><span class="attribute" id="nidm:BinaryMap.nidm:hasMapHeader">
                         <a>nidm:hasMapHeader</a>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a>nidm:MapHeader</a>)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a Property that associates an additional file containing the map header with a map. (range <a>nidm:MapHeader</a>)</li> 
                         <li><span class="attribute" id="nidm:BinaryMap.nidm:inCoordinateSpace">
                         <a>nidm:inCoordinateSpace</a>
                         </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file. (range <a>nidm:CoordinateSpace</a>)</li> 

--- a/nidm/nidm-results/terms/README.md
+++ b/nidm/nidm-results/terms/README.md
@@ -153,11 +153,6 @@ Discussed with @afni-rickr in <a href="https://github.com/incf-nidash/nidm/pull/
 </tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/289">#289</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q=MapHeader"> [more] </a></td>
-    <td><b>nidm:MapHeader: </b>&lt;undefined&gt;</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
     <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/137">#137</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q=NIDMObjectModel"> [more] </a></td>
     <td><b>nidm:NIDMObjectModel: </b>&lt;undefined&gt;</td>
 </tr>
@@ -436,13 +431,6 @@ Range: Vector of integers not found.<br/><a href="https://github.com/incf-nidash
     <td><b>nidm:hasHRFBasis: </b>&lt;undefined&gt;</td>
     <td>nidm:DesignMatrix </td>
     <td>nidm:HemodynamicResponseFunctionBasis </td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/289">#289</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q=hasMapHeader"> [more] </a></td>
-    <td><b>nidm:hasMapHeader: </b>&lt;undefined&gt;</td>
-    <td>nidm:Map </td>
-    <td>nidm:MapHeader </td>
 </tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>

--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -56,7 +56,7 @@ dc:description rdfs:range dctype:Image .
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#dependenceSpatialModel
+###  http://purl.org/nidash/nidm#dependenceSpatialModel
 
 nidm:dependenceSpatialModel rdf:type owl:ObjectProperty ;
                             
@@ -70,7 +70,7 @@ nidm:dependenceSpatialModel rdf:type owl:ObjectProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#hasAlternativeHypothesis
+###  http://purl.org/nidash/nidm#hasAlternativeHypothesis
 
 nidm:hasAlternativeHypothesis rdf:type owl:ObjectProperty ;
                               
@@ -89,7 +89,7 @@ nidm:hasAlternativeHypothesis rdf:type owl:ObjectProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#hasClusterLabelsMap
+###  http://purl.org/nidash/nidm#hasClusterLabelsMap
 
 nidm:hasClusterLabelsMap rdf:type owl:ObjectProperty ;
                          
@@ -107,7 +107,7 @@ nidm:hasClusterLabelsMap rdf:type owl:ObjectProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#hasConnectivityCriterion
+###  http://purl.org/nidash/nidm#hasConnectivityCriterion
 
 nidm:hasConnectivityCriterion rdf:type owl:ObjectProperty ;
                               
@@ -123,7 +123,7 @@ nidm:hasConnectivityCriterion rdf:type owl:ObjectProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#hasErrorDependence
+###  http://purl.org/nidash/nidm#hasErrorDependence
 
 nidm:hasErrorDependence rdf:type owl:ObjectProperty ;
                         
@@ -137,7 +137,7 @@ nidm:hasErrorDependence rdf:type owl:ObjectProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#hasErrorDistribution
+###  http://purl.org/nidash/nidm#hasErrorDistribution
 
 nidm:hasErrorDistribution rdf:type owl:ObjectProperty ;
                           
@@ -151,7 +151,7 @@ nidm:hasErrorDistribution rdf:type owl:ObjectProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#hasHRFBasis
+###  http://purl.org/nidash/nidm#hasHRFBasis
 
 nidm:hasHRFBasis rdf:type owl:ObjectProperty ;
                  
@@ -165,7 +165,7 @@ nidm:hasHRFBasis rdf:type owl:ObjectProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#hasMapHeader
+###  http://purl.org/nidash/nidm#hasMapHeader
 
 nidm:hasMapHeader rdf:type owl:ObjectProperty ;
                   
@@ -181,7 +181,7 @@ nidm:hasMapHeader rdf:type owl:ObjectProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#inCoordinateSpace
+###  http://purl.org/nidash/nidm#inCoordinateSpace
 
 nidm:inCoordinateSpace rdf:type owl:ObjectProperty ;
                        
@@ -197,7 +197,7 @@ nidm:inCoordinateSpace rdf:type owl:ObjectProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#inWorldCoordinateSystem
+###  http://purl.org/nidash/nidm#inWorldCoordinateSystem
 
 nidm:inWorldCoordinateSystem rdf:type owl:ObjectProperty ;
                              
@@ -215,7 +215,7 @@ nidm:inWorldCoordinateSystem rdf:type owl:ObjectProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#objectModel
+###  http://purl.org/nidash/nidm#objectModel
 
 nidm:objectModel rdf:type owl:ObjectProperty ;
                  
@@ -229,7 +229,7 @@ nidm:objectModel rdf:type owl:ObjectProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#statisticType
+###  http://purl.org/nidash/nidm#statisticType
 
 nidm:statisticType rdf:type owl:ObjectProperty ;
                    
@@ -244,7 +244,7 @@ nidm:statisticType rdf:type owl:ObjectProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#varianceSpatialModel
+###  http://purl.org/nidash/nidm#varianceSpatialModel
 
 nidm:varianceSpatialModel rdf:type owl:ObjectProperty ;
                           
@@ -258,7 +258,7 @@ nidm:varianceSpatialModel rdf:type owl:ObjectProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#withEstimationMethod
+###  http://purl.org/nidash/nidm#withEstimationMethod
 
 nidm:withEstimationMethod rdf:type owl:ObjectProperty ;
                           
@@ -423,7 +423,7 @@ fsl:reselSizeInVoxels rdf:type owl:DatatypeProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#clusterLabelId
+###  http://purl.org/nidash/nidm#clusterLabelId
 
 nidm:clusterLabelId rdf:type owl:DatatypeProperty ;
                     
@@ -441,7 +441,7 @@ nidm:clusterLabelId rdf:type owl:DatatypeProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#clusterSizeInVertices
+###  http://purl.org/nidash/nidm#clusterSizeInVertices
 
 nidm:clusterSizeInVertices rdf:type owl:DatatypeProperty ;
                            
@@ -458,7 +458,7 @@ nidm:clusterSizeInVertices rdf:type owl:DatatypeProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#clusterSizeInVoxels
+###  http://purl.org/nidash/nidm#clusterSizeInVoxels
 
 nidm:clusterSizeInVoxels rdf:type owl:DatatypeProperty ;
                          
@@ -475,7 +475,7 @@ nidm:clusterSizeInVoxels rdf:type owl:DatatypeProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#contrastName
+###  http://purl.org/nidash/nidm#contrastName
 
 nidm:contrastName rdf:type owl:DatatypeProperty ;
                   
@@ -493,7 +493,7 @@ nidm:contrastName rdf:type owl:DatatypeProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#coordinate1
+###  http://purl.org/nidash/nidm#coordinate1
 
 nidm:coordinate1 rdf:type owl:DatatypeProperty ;
                  
@@ -511,7 +511,7 @@ nidm:coordinate1 rdf:type owl:DatatypeProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#coordinate2
+###  http://purl.org/nidash/nidm#coordinate2
 
 nidm:coordinate2 rdf:type owl:DatatypeProperty ;
                  
@@ -529,7 +529,7 @@ nidm:coordinate2 rdf:type owl:DatatypeProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#coordinate3
+###  http://purl.org/nidash/nidm#coordinate3
 
 nidm:coordinate3 rdf:type owl:DatatypeProperty ;
                  
@@ -547,7 +547,7 @@ nidm:coordinate3 rdf:type owl:DatatypeProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#dimensionsInVoxels
+###  http://purl.org/nidash/nidm#dimensionsInVoxels
 
 nidm:dimensionsInVoxels rdf:type owl:DatatypeProperty ;
                         
@@ -565,7 +565,7 @@ nidm:dimensionsInVoxels rdf:type owl:DatatypeProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#effectDegreesOfFreedom
+###  http://purl.org/nidash/nidm#effectDegreesOfFreedom
 
 nidm:effectDegreesOfFreedom rdf:type owl:DatatypeProperty ;
                             
@@ -588,7 +588,7 @@ nidm:effectDegreesOfFreedom rdf:type owl:DatatypeProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#equivalentZStatistic
+###  http://purl.org/nidash/nidm#equivalentZStatistic
 
 nidm:equivalentZStatistic rdf:type owl:DatatypeProperty ;
                           
@@ -604,7 +604,7 @@ nidm:equivalentZStatistic rdf:type owl:DatatypeProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#errorDegreesOfFreedom
+###  http://purl.org/nidash/nidm#errorDegreesOfFreedom
 
 nidm:errorDegreesOfFreedom rdf:type owl:DatatypeProperty ;
                            
@@ -627,7 +627,7 @@ nidm:errorDegreesOfFreedom rdf:type owl:DatatypeProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#errorVarianceHomogeneous
+###  http://purl.org/nidash/nidm#errorVarianceHomogeneous
 
 nidm:errorVarianceHomogeneous rdf:type owl:DatatypeProperty ;
                               
@@ -641,7 +641,7 @@ nidm:errorVarianceHomogeneous rdf:type owl:DatatypeProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#globalNullDegree
+###  http://purl.org/nidash/nidm#globalNullDegree
 
 nidm:globalNullDegree rdf:type owl:DatatypeProperty ;
                       
@@ -655,7 +655,7 @@ nidm:globalNullDegree rdf:type owl:DatatypeProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#grandMeanScaling
+###  http://purl.org/nidash/nidm#grandMeanScaling
 
 nidm:grandMeanScaling rdf:type owl:DatatypeProperty ;
                       
@@ -673,7 +673,7 @@ nidm:grandMeanScaling rdf:type owl:DatatypeProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#inWorldCoordinateSystem
+###  http://purl.org/nidash/nidm#inWorldCoordinateSystem
 
 nidm:inWorldCoordinateSystem rdf:type owl:DatatypeProperty ;
                              
@@ -687,7 +687,7 @@ nidm:inWorldCoordinateSystem rdf:type owl:DatatypeProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#isUserDefined
+###  http://purl.org/nidash/nidm#isUserDefined
 
 nidm:isUserDefined rdf:type owl:DatatypeProperty ;
                    
@@ -703,7 +703,7 @@ nidm:isUserDefined rdf:type owl:DatatypeProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#maskedMedian
+###  http://purl.org/nidash/nidm#maskedMedian
 
 nidm:maskedMedian rdf:type owl:DatatypeProperty ;
                   
@@ -723,7 +723,7 @@ nidm:maskedMedian rdf:type owl:DatatypeProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#maxNumberOfPeaksPerCluster
+###  http://purl.org/nidash/nidm#maxNumberOfPeaksPerCluster
 
 nidm:maxNumberOfPeaksPerCluster rdf:type owl:DatatypeProperty ;
                                 
@@ -739,7 +739,7 @@ nidm:maxNumberOfPeaksPerCluster rdf:type owl:DatatypeProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#minDistanceBetweenPeaks
+###  http://purl.org/nidash/nidm#minDistanceBetweenPeaks
 
 nidm:minDistanceBetweenPeaks rdf:type owl:DatatypeProperty ;
                              
@@ -755,7 +755,7 @@ nidm:minDistanceBetweenPeaks rdf:type owl:DatatypeProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#noiseFWHM
+###  http://purl.org/nidash/nidm#noiseFWHM
 
 nidm:noiseFWHM rdf:type owl:DatatypeProperty ;
                
@@ -771,7 +771,7 @@ nidm:noiseFWHM rdf:type owl:DatatypeProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#numberOfClusters
+###  http://purl.org/nidash/nidm#numberOfClusters
 
 nidm:numberOfClusters rdf:type owl:DatatypeProperty ;
                       
@@ -787,7 +787,7 @@ nidm:numberOfClusters rdf:type owl:DatatypeProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#numberOfDimensions
+###  http://purl.org/nidash/nidm#numberOfDimensions
 
 nidm:numberOfDimensions rdf:type owl:DatatypeProperty ;
                         
@@ -805,7 +805,7 @@ nidm:numberOfDimensions rdf:type owl:DatatypeProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#pValue
+###  http://purl.org/nidash/nidm#pValue
 
 nidm:pValue rdf:type owl:DatatypeProperty ;
             
@@ -834,7 +834,7 @@ http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#P-Value""" ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#pValueFWER
+###  http://purl.org/nidash/nidm#pValueFWER
 
 nidm:pValueFWER rdf:type owl:DatatypeProperty ;
                 
@@ -866,7 +866,7 @@ nidm:pValueFWER rdf:type owl:DatatypeProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#pValueUncorrected
+###  http://purl.org/nidash/nidm#pValueUncorrected
 
 nidm:pValueUncorrected rdf:type owl:DatatypeProperty ;
                        
@@ -896,7 +896,7 @@ nidm:pValueUncorrected rdf:type owl:DatatypeProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#qValueFDR
+###  http://purl.org/nidash/nidm#qValueFDR
 
 nidm:qValueFDR rdf:type owl:DatatypeProperty ;
                
@@ -926,7 +926,7 @@ nidm:qValueFDR rdf:type owl:DatatypeProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#randomFieldStationarity
+###  http://purl.org/nidash/nidm#randomFieldStationarity
 
 nidm:randomFieldStationarity rdf:type owl:DatatypeProperty ;
                              
@@ -942,7 +942,7 @@ nidm:randomFieldStationarity rdf:type owl:DatatypeProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#searchVolumeInVoxels
+###  http://purl.org/nidash/nidm#searchVolumeInVoxels
 
 nidm:searchVolumeInVoxels rdf:type owl:DatatypeProperty ;
                           
@@ -962,7 +962,7 @@ nidm:searchVolumeInVoxels rdf:type owl:DatatypeProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#softwareVersion
+###  http://purl.org/nidash/nidm#softwareVersion
 
 nidm:softwareVersion rdf:type owl:DatatypeProperty ;
                      
@@ -980,7 +980,7 @@ nidm:softwareVersion rdf:type owl:DatatypeProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#targetIntensity
+###  http://purl.org/nidash/nidm#targetIntensity
 
 nidm:targetIntensity rdf:type owl:DatatypeProperty ;
                      
@@ -1003,7 +1003,7 @@ nidm:targetIntensity rdf:type owl:DatatypeProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#userSpecifiedThresholdType
+###  http://purl.org/nidash/nidm#userSpecifiedThresholdType
 
 nidm:userSpecifiedThresholdType rdf:type owl:DatatypeProperty ;
                                 
@@ -1024,7 +1024,7 @@ nidm:userSpecifiedThresholdType rdf:type owl:DatatypeProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#version
+###  http://purl.org/nidash/nidm#version
 
 nidm:version rdf:type owl:DatatypeProperty ;
              
@@ -1038,7 +1038,7 @@ nidm:version rdf:type owl:DatatypeProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#voxelSize
+###  http://purl.org/nidash/nidm#voxelSize
 
 nidm:voxelSize rdf:type owl:DatatypeProperty ;
                
@@ -1061,7 +1061,7 @@ nidm:voxelSize rdf:type owl:DatatypeProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#voxelToWorldMapping
+###  http://purl.org/nidash/nidm#voxelToWorldMapping
 
 nidm:voxelToWorldMapping rdf:type owl:DatatypeProperty ;
                          
@@ -1081,7 +1081,7 @@ nidm:voxelToWorldMapping rdf:type owl:DatatypeProperty ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#voxelUnits
+###  http://purl.org/nidash/nidm#voxelUnits
 
 nidm:voxelUnits rdf:type owl:DatatypeProperty ;
                 
@@ -1720,7 +1720,7 @@ fsl:TemporalDerivative rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#ArbitrarilyCorrelatedError
+###  http://purl.org/nidash/nidm#ArbitrarilyCorrelatedError
 
 nidm:ArbitrarilyCorrelatedError rdf:type owl:Class ;
                                 
@@ -1734,7 +1734,7 @@ nidm:ArbitrarilyCorrelatedError rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#BinaryMap
+###  http://purl.org/nidash/nidm#BinaryMap
 
 nidm:BinaryMap rdf:type owl:Class ;
                
@@ -1748,7 +1748,7 @@ nidm:BinaryMap rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#BinomialDistribution
+###  http://purl.org/nidash/nidm#BinomialDistribution
 
 nidm:BinomialDistribution rdf:type owl:Class ;
                           
@@ -1762,7 +1762,7 @@ nidm:BinomialDistribution rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#Cluster
+###  http://purl.org/nidash/nidm#Cluster
 
 nidm:Cluster rdf:type owl:Class ;
              
@@ -1776,7 +1776,7 @@ nidm:Cluster rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#ClusterDefinitionCriteria
+###  http://purl.org/nidash/nidm#ClusterDefinitionCriteria
 
 nidm:ClusterDefinitionCriteria rdf:type owl:Class ;
                                
@@ -1790,7 +1790,7 @@ nidm:ClusterDefinitionCriteria rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#ClusterLabelsMap
+###  http://purl.org/nidash/nidm#ClusterLabelsMap
 
 nidm:ClusterLabelsMap rdf:type owl:Class ;
                       
@@ -1804,7 +1804,7 @@ nidm:ClusterLabelsMap rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#CompoundSymmetricError
+###  http://purl.org/nidash/nidm#CompoundSymmetricError
 
 nidm:CompoundSymmetricError rdf:type owl:Class ;
                             
@@ -1818,7 +1818,7 @@ nidm:CompoundSymmetricError rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#ConjunctionInference
+###  http://purl.org/nidash/nidm#ConjunctionInference
 
 nidm:ConjunctionInference rdf:type owl:Class ;
                           
@@ -1832,7 +1832,7 @@ nidm:ConjunctionInference rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#ConnectivityCriterion
+###  http://purl.org/nidash/nidm#ConnectivityCriterion
 
 nidm:ConnectivityCriterion rdf:type owl:Class ;
                            
@@ -1847,7 +1847,7 @@ nidm:ConnectivityCriterion rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#ContrastEstimation
+###  http://purl.org/nidash/nidm#ContrastEstimation
 
 nidm:ContrastEstimation rdf:type owl:Class ;
                         
@@ -1865,7 +1865,7 @@ nidm:ContrastEstimation rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#ContrastMap
+###  http://purl.org/nidash/nidm#ContrastMap
 
 nidm:ContrastMap rdf:type owl:Class ;
                  
@@ -1881,7 +1881,7 @@ nidm:ContrastMap rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#ContrastStandardErrorMap
+###  http://purl.org/nidash/nidm#ContrastStandardErrorMap
 
 nidm:ContrastStandardErrorMap rdf:type owl:Class ;
                               
@@ -1897,7 +1897,7 @@ nidm:ContrastStandardErrorMap rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#ContrastWeights
+###  http://purl.org/nidash/nidm#ContrastWeights
 
 nidm:ContrastWeights rdf:type owl:Class ;
                      
@@ -1914,7 +1914,7 @@ Range: Vector of integers not found.""" ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#Coordinate
+###  http://purl.org/nidash/nidm#Coordinate
 
 nidm:Coordinate rdf:type owl:Class ;
                 
@@ -1930,7 +1930,7 @@ nidm:Coordinate rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#CoordinateSpace
+###  http://purl.org/nidash/nidm#CoordinateSpace
 
 nidm:CoordinateSpace rdf:type owl:Class ;
                      
@@ -1946,7 +1946,7 @@ nidm:CoordinateSpace rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#CustomCoordinateSystem
+###  http://purl.org/nidash/nidm#CustomCoordinateSystem
 
 nidm:CustomCoordinateSystem rdf:type owl:Class ;
                             
@@ -1958,7 +1958,7 @@ nidm:CustomCoordinateSystem rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#Data
+###  http://purl.org/nidash/nidm#Data
 
 nidm:Data rdf:type owl:Class ;
           
@@ -1976,7 +1976,7 @@ nidm:Data rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#DesignMatrix
+###  http://purl.org/nidash/nidm#DesignMatrix
 
 nidm:DesignMatrix rdf:type owl:Class ;
                   
@@ -2016,7 +2016,7 @@ nidm:DesignMatrix rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#DisplayMaskMap
+###  http://purl.org/nidash/nidm#DisplayMaskMap
 
 nidm:DisplayMaskMap rdf:type owl:Class ;
                     
@@ -2032,7 +2032,7 @@ nidm:DisplayMaskMap rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#ErrorDependence
+###  http://purl.org/nidash/nidm#ErrorDependence
 
 nidm:ErrorDependence rdf:type owl:Class ;
                      
@@ -2044,7 +2044,7 @@ nidm:ErrorDependence rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#ErrorDistribution
+###  http://purl.org/nidash/nidm#ErrorDistribution
 
 nidm:ErrorDistribution rdf:type owl:Class ;
                        
@@ -2056,7 +2056,7 @@ nidm:ErrorDistribution rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#ErrorModel
+###  http://purl.org/nidash/nidm#ErrorModel
 
 nidm:ErrorModel rdf:type owl:Class ;
                 
@@ -2070,7 +2070,7 @@ nidm:ErrorModel rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#ExchangeableError
+###  http://purl.org/nidash/nidm#ExchangeableError
 
 nidm:ExchangeableError rdf:type owl:Class ;
                        
@@ -2086,7 +2086,7 @@ nidm:ExchangeableError rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#ExcursionSetMap
+###  http://purl.org/nidash/nidm#ExcursionSetMap
 
 nidm:ExcursionSetMap rdf:type owl:Class ;
                      
@@ -2107,7 +2107,7 @@ nidm:ExcursionSetMap rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#ExtentThreshold
+###  http://purl.org/nidash/nidm#ExtentThreshold
 
 nidm:ExtentThreshold rdf:type owl:Class ;
                      
@@ -2123,7 +2123,7 @@ nidm:ExtentThreshold rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#FSLResults
+###  http://purl.org/nidash/nidm#FSLResults
 
 nidm:FSLResults rdf:type owl:Class ;
                 
@@ -2135,7 +2135,7 @@ nidm:FSLResults rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#FiniteImpulseResponseHRB
+###  http://purl.org/nidash/nidm#FiniteImpulseResponseHRB
 
 nidm:FiniteImpulseResponseHRB rdf:type owl:Class ;
                               
@@ -2147,7 +2147,7 @@ nidm:FiniteImpulseResponseHRB rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#GammaDifferenceHRF
+###  http://purl.org/nidash/nidm#GammaDifferenceHRF
 
 nidm:GammaDifferenceHRF rdf:type owl:Class ;
                         
@@ -2159,7 +2159,7 @@ nidm:GammaDifferenceHRF rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#GammaHRB
+###  http://purl.org/nidash/nidm#GammaHRB
 
 nidm:GammaHRB rdf:type owl:Class ;
               
@@ -2171,7 +2171,7 @@ nidm:GammaHRB rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#GammaHRF
+###  http://purl.org/nidash/nidm#GammaHRF
 
 nidm:GammaHRF rdf:type owl:Class ;
               
@@ -2181,7 +2181,7 @@ nidm:GammaHRF rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#GaussianDistribution
+###  http://purl.org/nidash/nidm#GaussianDistribution
 
 nidm:GaussianDistribution rdf:type owl:Class ;
                           
@@ -2195,7 +2195,7 @@ nidm:GaussianDistribution rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#GrandMeanMap
+###  http://purl.org/nidash/nidm#GrandMeanMap
 
 nidm:GrandMeanMap rdf:type owl:Class ;
                   
@@ -2209,7 +2209,7 @@ nidm:GrandMeanMap rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#HeightThreshold
+###  http://purl.org/nidash/nidm#HeightThreshold
 
 nidm:HeightThreshold rdf:type owl:Class ;
                      
@@ -2226,7 +2226,7 @@ nidm:HeightThreshold rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#HemodynamicResponseFunction
+###  http://purl.org/nidash/nidm#HemodynamicResponseFunction
 
 nidm:HemodynamicResponseFunction rdf:type owl:Class ;
                                  
@@ -2238,7 +2238,7 @@ nidm:HemodynamicResponseFunction rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#HemodynamicResponseFunctionBasis
+###  http://purl.org/nidash/nidm#HemodynamicResponseFunctionBasis
 
 nidm:HemodynamicResponseFunctionBasis rdf:type owl:Class ;
                                       
@@ -2252,7 +2252,7 @@ nidm:HemodynamicResponseFunctionBasis rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#HemodynamicResponseFunctionDerivative
+###  http://purl.org/nidash/nidm#HemodynamicResponseFunctionDerivative
 
 nidm:HemodynamicResponseFunctionDerivative rdf:type owl:Class ;
                                            
@@ -2264,7 +2264,7 @@ nidm:HemodynamicResponseFunctionDerivative rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#IndependentError
+###  http://purl.org/nidash/nidm#IndependentError
 
 nidm:IndependentError rdf:type owl:Class ;
                       
@@ -2278,7 +2278,7 @@ nidm:IndependentError rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#Inference
+###  http://purl.org/nidash/nidm#Inference
 
 nidm:Inference rdf:type owl:Class ;
                
@@ -2294,7 +2294,7 @@ nidm:Inference rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#MNICoordinateSystem
+###  http://purl.org/nidash/nidm#MNICoordinateSystem
 
 nidm:MNICoordinateSystem rdf:type owl:Class ;
                          
@@ -2310,7 +2310,7 @@ nidm:MNICoordinateSystem rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#Map
+###  http://purl.org/nidash/nidm#Map
 
 nidm:Map rdf:type owl:Class ;
          
@@ -2334,7 +2334,7 @@ nidm:Map rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#MapHeader
+###  http://purl.org/nidash/nidm#MapHeader
 
 nidm:MapHeader rdf:type owl:Class ;
                
@@ -2358,7 +2358,7 @@ nidm:MapHeader rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#MaskMap
+###  http://purl.org/nidash/nidm#MaskMap
 
 nidm:MaskMap rdf:type owl:Class ;
              
@@ -2374,7 +2374,7 @@ nidm:MaskMap rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#ModelParametersEstimation
+###  http://purl.org/nidash/nidm#ModelParametersEstimation
 
 nidm:ModelParametersEstimation rdf:type owl:Class ;
                                
@@ -2390,7 +2390,7 @@ nidm:ModelParametersEstimation rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#NIDMObjectModel
+###  http://purl.org/nidash/nidm#NIDMObjectModel
 
 nidm:NIDMObjectModel rdf:type owl:Class ;
                      
@@ -2402,7 +2402,7 @@ nidm:NIDMObjectModel rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#NonParametricDistribution
+###  http://purl.org/nidash/nidm#NonParametricDistribution
 
 nidm:NonParametricDistribution rdf:type owl:Class ;
                                
@@ -2414,7 +2414,7 @@ nidm:NonParametricDistribution rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#NonParametricSymmetricDistribution
+###  http://purl.org/nidash/nidm#NonParametricSymmetricDistribution
 
 nidm:NonParametricSymmetricDistribution rdf:type owl:Class ;
                                         
@@ -2426,7 +2426,7 @@ nidm:NonParametricSymmetricDistribution rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#OneTailedTest
+###  http://purl.org/nidash/nidm#OneTailedTest
 
 nidm:OneTailedTest rdf:type owl:Class ;
                    
@@ -2440,7 +2440,7 @@ nidm:OneTailedTest rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#ParameterEstimateMap
+###  http://purl.org/nidash/nidm#ParameterEstimateMap
 
 nidm:ParameterEstimateMap rdf:type owl:Class ;
                           
@@ -2456,7 +2456,7 @@ nidm:ParameterEstimateMap rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#Peak
+###  http://purl.org/nidash/nidm#Peak
 
 nidm:Peak rdf:type owl:Class ;
           
@@ -2472,7 +2472,7 @@ nidm:Peak rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#PeakDefinitionCriteria
+###  http://purl.org/nidash/nidm#PeakDefinitionCriteria
 
 nidm:PeakDefinitionCriteria rdf:type owl:Class ;
                             
@@ -2488,7 +2488,7 @@ nidm:PeakDefinitionCriteria rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#PixelConnectivityCriterion
+###  http://purl.org/nidash/nidm#PixelConnectivityCriterion
 
 nidm:PixelConnectivityCriterion rdf:type owl:Class ;
                                 
@@ -2502,7 +2502,7 @@ nidm:PixelConnectivityCriterion rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#PoissonDistribution
+###  http://purl.org/nidash/nidm#PoissonDistribution
 
 nidm:PoissonDistribution rdf:type owl:Class ;
                          
@@ -2516,7 +2516,7 @@ nidm:PoissonDistribution rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#ResidualMeanSquaresMap
+###  http://purl.org/nidash/nidm#ResidualMeanSquaresMap
 
 nidm:ResidualMeanSquaresMap rdf:type owl:Class ;
                             
@@ -2532,7 +2532,7 @@ nidm:ResidualMeanSquaresMap rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#SPMResults
+###  http://purl.org/nidash/nidm#SPMResults
 
 nidm:SPMResults rdf:type owl:Class ;
                 
@@ -2544,7 +2544,7 @@ nidm:SPMResults rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#SearchSpaceMaskMap
+###  http://purl.org/nidash/nidm#SearchSpaceMaskMap
 
 nidm:SearchSpaceMaskMap rdf:type owl:Class ;
                         
@@ -2560,7 +2560,7 @@ nidm:SearchSpaceMaskMap rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#SeriallyCorrelatedError
+###  http://purl.org/nidash/nidm#SeriallyCorrelatedError
 
 nidm:SeriallyCorrelatedError rdf:type owl:Class ;
                              
@@ -2574,7 +2574,7 @@ nidm:SeriallyCorrelatedError rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#SignificantCluster
+###  http://purl.org/nidash/nidm#SignificantCluster
 
 nidm:SignificantCluster rdf:type owl:Class ;
                         
@@ -2590,7 +2590,7 @@ nidm:SignificantCluster rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#SpatialModel
+###  http://purl.org/nidash/nidm#SpatialModel
 
 nidm:SpatialModel rdf:type owl:Class ;
                   
@@ -2602,7 +2602,7 @@ nidm:SpatialModel rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#SpatiallyGlobalModel
+###  http://purl.org/nidash/nidm#SpatiallyGlobalModel
 
 nidm:SpatiallyGlobalModel rdf:type owl:Class ;
                           
@@ -2614,7 +2614,7 @@ nidm:SpatiallyGlobalModel rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#SpatiallyLocalModel
+###  http://purl.org/nidash/nidm#SpatiallyLocalModel
 
 nidm:SpatiallyLocalModel rdf:type owl:Class ;
                          
@@ -2626,7 +2626,7 @@ nidm:SpatiallyLocalModel rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#SpatiallyRegularizedModel
+###  http://purl.org/nidash/nidm#SpatiallyRegularizedModel
 
 nidm:SpatiallyRegularizedModel rdf:type owl:Class ;
                                
@@ -2638,7 +2638,7 @@ nidm:SpatiallyRegularizedModel rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#StandardizedCoordinateSystem
+###  http://purl.org/nidash/nidm#StandardizedCoordinateSystem
 
 nidm:StandardizedCoordinateSystem rdf:type owl:Class ;
                                   
@@ -2654,7 +2654,7 @@ nidm:StandardizedCoordinateSystem rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#StatisticMap
+###  http://purl.org/nidash/nidm#StatisticMap
 
 nidm:StatisticMap rdf:type owl:Class ;
                   
@@ -2670,7 +2670,7 @@ nidm:StatisticMap rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#SubjectCoordinateSystem
+###  http://purl.org/nidash/nidm#SubjectCoordinateSystem
 
 nidm:SubjectCoordinateSystem rdf:type owl:Class ;
                              
@@ -2686,7 +2686,7 @@ nidm:SubjectCoordinateSystem rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#TalairachCoordinateSystem
+###  http://purl.org/nidash/nidm#TalairachCoordinateSystem
 
 nidm:TalairachCoordinateSystem rdf:type owl:Class ;
                                
@@ -2702,7 +2702,7 @@ nidm:TalairachCoordinateSystem rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#TwoTailedTest
+###  http://purl.org/nidash/nidm#TwoTailedTest
 
 nidm:TwoTailedTest rdf:type owl:Class ;
                    
@@ -2716,7 +2716,7 @@ nidm:TwoTailedTest rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#VoxelConnectivityCriterion
+###  http://purl.org/nidash/nidm#VoxelConnectivityCriterion
 
 nidm:VoxelConnectivityCriterion rdf:type owl:Class ;
                                 
@@ -2730,7 +2730,7 @@ nidm:VoxelConnectivityCriterion rdf:type owl:Class ;
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#WorldCoordinateSystem
+###  http://purl.org/nidash/nidm#WorldCoordinateSystem
 
 nidm:WorldCoordinateSystem rdf:type owl:Class ;
                            
@@ -2851,7 +2851,7 @@ spm:TemporalDerivative rdf:type owl:Class ;
 #################################################################
 
 
-###  http://www.incf.org/ns/nidash/nidm#Colin27CoordinateSystem
+###  http://purl.org/nidash/nidm#Colin27CoordinateSystem
 
 nidm:Colin27CoordinateSystem rdf:type nidm:StandardizedCoordinateSystem ,
                                       owl:NamedIndividual ;
@@ -2868,7 +2868,7 @@ nidm:Colin27CoordinateSystem rdf:type nidm:StandardizedCoordinateSystem ,
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#Icbm452AirCoordinateSystem
+###  http://purl.org/nidash/nidm#Icbm452AirCoordinateSystem
 
 nidm:Icbm452AirCoordinateSystem rdf:type nidm:MNICoordinateSystem ,
                                          owl:NamedIndividual ;
@@ -2883,7 +2883,7 @@ nidm:Icbm452AirCoordinateSystem rdf:type nidm:MNICoordinateSystem ,
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#Icbm452Warp5CoordinateSystem
+###  http://purl.org/nidash/nidm#Icbm452Warp5CoordinateSystem
 
 nidm:Icbm452Warp5CoordinateSystem rdf:type nidm:MNICoordinateSystem ,
                                            owl:NamedIndividual ;
@@ -2898,7 +2898,7 @@ nidm:Icbm452Warp5CoordinateSystem rdf:type nidm:MNICoordinateSystem ,
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#IcbmMni152LinearCoordinateSystem
+###  http://purl.org/nidash/nidm#IcbmMni152LinearCoordinateSystem
 
 nidm:IcbmMni152LinearCoordinateSystem rdf:type nidm:MNICoordinateSystem ,
                                                owl:NamedIndividual ;
@@ -2915,7 +2915,7 @@ nidm:IcbmMni152LinearCoordinateSystem rdf:type nidm:MNICoordinateSystem ,
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#IcbmMni152NonLinear2009aAsymmetricCoordinateSystem
+###  http://purl.org/nidash/nidm#IcbmMni152NonLinear2009aAsymmetricCoordinateSystem
 
 nidm:IcbmMni152NonLinear2009aAsymmetricCoordinateSystem rdf:type nidm:MNICoordinateSystem ,
                                                                  owl:NamedIndividual ;
@@ -2930,7 +2930,7 @@ nidm:IcbmMni152NonLinear2009aAsymmetricCoordinateSystem rdf:type nidm:MNICoordin
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#IcbmMni152NonLinear2009aSymmetricCoordinateSystem
+###  http://purl.org/nidash/nidm#IcbmMni152NonLinear2009aSymmetricCoordinateSystem
 
 nidm:IcbmMni152NonLinear2009aSymmetricCoordinateSystem rdf:type nidm:MNICoordinateSystem ,
                                                                 owl:NamedIndividual ;
@@ -2945,7 +2945,7 @@ nidm:IcbmMni152NonLinear2009aSymmetricCoordinateSystem rdf:type nidm:MNICoordina
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#IcbmMni152NonLinear2009bAsymmetricCoordinateSystem
+###  http://purl.org/nidash/nidm#IcbmMni152NonLinear2009bAsymmetricCoordinateSystem
 
 nidm:IcbmMni152NonLinear2009bAsymmetricCoordinateSystem rdf:type nidm:MNICoordinateSystem ,
                                                                  owl:NamedIndividual ;
@@ -2960,7 +2960,7 @@ nidm:IcbmMni152NonLinear2009bAsymmetricCoordinateSystem rdf:type nidm:MNICoordin
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#IcbmMni152NonLinear2009bSymmetricCoordinateSystem
+###  http://purl.org/nidash/nidm#IcbmMni152NonLinear2009bSymmetricCoordinateSystem
 
 nidm:IcbmMni152NonLinear2009bSymmetricCoordinateSystem rdf:type nidm:MNICoordinateSystem ,
                                                                 owl:NamedIndividual ;
@@ -2975,7 +2975,7 @@ nidm:IcbmMni152NonLinear2009bSymmetricCoordinateSystem rdf:type nidm:MNICoordina
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#IcbmMni152NonLinear2009cAsymmetricCoordinateSystem
+###  http://purl.org/nidash/nidm#IcbmMni152NonLinear2009cAsymmetricCoordinateSystem
 
 nidm:IcbmMni152NonLinear2009cAsymmetricCoordinateSystem rdf:type nidm:MNICoordinateSystem ,
                                                                  owl:NamedIndividual ;
@@ -2992,7 +2992,7 @@ nidm:IcbmMni152NonLinear2009cAsymmetricCoordinateSystem rdf:type nidm:MNICoordin
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#IcbmMni152NonLinear2009cSymmetricCoordinateSystem
+###  http://purl.org/nidash/nidm#IcbmMni152NonLinear2009cSymmetricCoordinateSystem
 
 nidm:IcbmMni152NonLinear2009cSymmetricCoordinateSystem rdf:type nidm:MNICoordinateSystem ,
                                                                 owl:NamedIndividual ;
@@ -3007,7 +3007,7 @@ nidm:IcbmMni152NonLinear2009cSymmetricCoordinateSystem rdf:type nidm:MNICoordina
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#IcbmMni152NonLinear6thGenerationCoordinateSystem
+###  http://purl.org/nidash/nidm#IcbmMni152NonLinear6thGenerationCoordinateSystem
 
 nidm:IcbmMni152NonLinear6thGenerationCoordinateSystem rdf:type nidm:MNICoordinateSystem ,
                                                                owl:NamedIndividual ;
@@ -3024,7 +3024,7 @@ nidm:IcbmMni152NonLinear6thGenerationCoordinateSystem rdf:type nidm:MNICoordinat
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#Ixi549CoordinateSystem
+###  http://purl.org/nidash/nidm#Ixi549CoordinateSystem
 
 nidm:Ixi549CoordinateSystem rdf:type nidm:MNICoordinateSystem ,
                                      owl:NamedIndividual ;
@@ -3041,7 +3041,7 @@ nidm:Ixi549CoordinateSystem rdf:type nidm:MNICoordinateSystem ,
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#Mni305CoordinateSystem
+###  http://purl.org/nidash/nidm#Mni305CoordinateSystem
 
 nidm:Mni305CoordinateSystem rdf:type nidm:MNICoordinateSystem ,
                                      owl:NamedIndividual ;
@@ -3056,7 +3056,7 @@ nidm:Mni305CoordinateSystem rdf:type nidm:MNICoordinateSystem ,
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#pixel4connected
+###  http://purl.org/nidash/nidm#pixel4connected
 
 nidm:pixel4connected rdf:type nidm:PixelConnectivityCriterion ,
                               owl:NamedIndividual ;
@@ -3069,7 +3069,7 @@ nidm:pixel4connected rdf:type nidm:PixelConnectivityCriterion ,
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#pixel8connected
+###  http://purl.org/nidash/nidm#pixel8connected
 
 nidm:pixel8connected rdf:type nidm:PixelConnectivityCriterion ,
                               owl:NamedIndividual ;
@@ -3082,7 +3082,7 @@ nidm:pixel8connected rdf:type nidm:PixelConnectivityCriterion ,
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#voxel18connected
+###  http://purl.org/nidash/nidm#voxel18connected
 
 nidm:voxel18connected rdf:type nidm:VoxelConnectivityCriterion ,
                                owl:NamedIndividual ;
@@ -3095,7 +3095,7 @@ nidm:voxel18connected rdf:type nidm:VoxelConnectivityCriterion ,
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#voxel26connected
+###  http://purl.org/nidash/nidm#voxel26connected
 
 nidm:voxel26connected rdf:type nidm:VoxelConnectivityCriterion ,
                                owl:NamedIndividual ;
@@ -3108,7 +3108,7 @@ nidm:voxel26connected rdf:type nidm:VoxelConnectivityCriterion ,
 
 
 
-###  http://www.incf.org/ns/nidash/nidm#voxel6connected
+###  http://purl.org/nidash/nidm#voxel6connected
 
 nidm:voxel6connected rdf:type nidm:VoxelConnectivityCriterion ,
                               owl:NamedIndividual ;

--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -169,9 +169,11 @@ nidm:hasHRFBasis rdf:type owl:ObjectProperty ;
 
 nidm:hasMapHeader rdf:type owl:ObjectProperty ;
                   
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/289" ;
+                  obo:IAO_0000115 "A Property that associates an additional file containing the map header with a map" ;
                   
-                  obo:IAO_0000114 obo:IAO_0000124 ;
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/289" ;
+                  
+                  obo:IAO_0000114 obo:IAO_0000122 ;
                   
                   rdfs:domain nidm:Map ;
                   
@@ -2348,9 +2350,11 @@ nidm:MapHeader rdf:type owl:Class ;
                                  owl:onDataRange xsd:string
                                ] ;
                
-               obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/289" ;
+               obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/289" ;
                
-               obo:IAO_0000114 obo:IAO_0000124 .
+               obo:IAO_0000115 "A file associated with a Map to provide header information (e.g. NIfTI header file)" ;
+               
+               obo:IAO_0000114 obo:IAO_0000122 .
 
 
 


### PR DESCRIPTION
This issue is open to discuss the definition of **nidm:MapHeader** and its associated object property **nidm:hasMapHeader**.

###### Proposal
How about:

- **nidm:MapHeader**: Nifti header file (.hdr).
- **nidm:hasMapHeader**: Property that associates a map header with a map.

?

###### Example of usage
<pre>
niiri:contrast_map_id_der a prov:Entity , nidm:ContrastMap ;
    nfo:fileName "con_0001.img"^^xsd:string ;
    dct:format "image/nifti"^^xsd:string ;
    <b>nidm:hasMapHeader niiri:original_contrast_map_header_id ;</b>
    crypto:sha512 "e43b6e01b0463fe7d40782137867a..."^^xsd:string .

niiri:original_contrast_map_header_id a prov:Entity , <b>nidm:MapHeader</b> ;
    dct:format "image/nifti"^^xsd:string ;
    nfo:fileName "con_0001.hdr"^^xsd:string ;
    crypto:sha512 "e43b6e01b0463fe7d40782137867a..."^^xsd:string .
</pre>