### PR TITLE
Definition of voxelUnits, voxelSize and numberOfDimensions 

### DIFF
--- a/doc/content/specs/nidm-results_dev.html
+++ b/doc/content/specs/nidm-results_dev.html
@@ -374,16 +374,16 @@
                         </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> type of coordinate system. (range <a>nidm:WorldCoordinateSystem</a> such as <a>nidm:StandardizedCoordinateSystem</a> or <a>nidm:SubjectCoordinateSystem</a>)</li> 
                         <li><span class="attribute" id="nidm:CoordinateSpace.nidm:numberOfDimensions">
                         <dfn>nidm:numberOfDimensions</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> number of dimensions of a data matrix. (range <a title="xsd:positiveInteger" href="http://www.w3.org/2001/XMLSchema#positiveInteger">xsd:positiveInteger</a>)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> number of dimensions of the data matrix (e.g. 3 for volumetric data). (range <a title="xsd:positiveInteger" href="http://www.w3.org/2001/XMLSchema#positiveInteger">xsd:positiveInteger</a>)</li> 
                         <li><span class="attribute" id="nidm:CoordinateSpace.nidm:voxelSize">
                         <dfn>nidm:voxelSize</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> 3D size of a voxel measured in voxelUnits. (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> 3D size of a voxel measured in voxel units (e.g. [2, 2, 4]). (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li> 
                         <li><span class="attribute" id="nidm:CoordinateSpace.nidm:voxelToWorldMapping">
                         <dfn>nidm:voxelToWorldMapping</dfn>
                         </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> homogeneous transformation matrix to map from voxel coordinate system to world coordinate system. (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li> 
                         <li><span class="attribute" id="nidm:CoordinateSpace.nidm:voxelUnits">
                         <dfn>nidm:voxelUnits</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> units associated with each dimensions of some N-dimensional data. (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> set of units associated with the dimensions of some N-dimensional data (e.g. [mm, mm, mm]). (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>niiri:coordinate_space_id_1 a prov:Entity , nidm:CoordinateSpace ;

--- a/nidm/nidm-results/terms/README.md
+++ b/nidm/nidm-results/terms/README.md
@@ -624,31 +624,10 @@ Range: Vector of integers not found.<br/><a href="https://github.com/incf-nidash
 </tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/orange.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/295">#295</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q=numberOfDimensions"> [more] </a></td>
-    <td><b>nidm:numberOfDimensions: </b>Number of dimensions of a data matrix</td>
-    <td>nidm:CoordinateSpace </td>
-    <td>xsd:positiveInteger </td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/orange.png?raw=true"/>  </td>
     <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/130">#130</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q=randomFieldStationarity"> [more] </a></td>
     <td><b>nidm:randomFieldStationarity: </b>Is the random field assumed to be stationary across the entire search volume?</td>
     <td>nidm:SearchSpaceMaskMap </td>
     <td>xsd:boolean </td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/orange.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/295">#295</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q=voxelSize"> [more] </a></td>
-    <td><b>nidm:voxelSize: </b>3D size of a voxel measured in voxelUnits</td>
-    <td>nidm:CoordinateSpace </td>
-    <td>xsd:string </td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/orange.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/295">#295</a> (previously discussed in <a href="https://github.com/incf-nidash/nidm/pull/147">#147</a>)<br/><a href="https://github.com/incf-nidash/nidm//issues?&q=voxelUnits"> [more] </a></td>
-    <td><b>nidm:voxelUnits: </b>Units associated with each dimensions of some N-dimensional data</td>
-    <td>nidm:CoordinateSpace </td>
-    <td>xsd:string </td>
 </tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/orange.png?raw=true"/>  </td>

--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -126,7 +126,7 @@ nidm:hasConnectivityCriterion rdf:type owl:ObjectProperty ;
 ###  http://purl.org/nidash/nidm#hasDriftModel
 
 nidm:hasDriftModel rdf:type owl:ObjectProperty ;
-
+                   
                    rdfs:label "has Drift Model" ;
                    
                    obo:IAO_0000115 "A property that associates a drift model to a design matrix (only used for first-level fMRI experiments)." ;
@@ -342,7 +342,7 @@ dct:format rdf:type owl:DatatypeProperty ;
 ###  http://purl.org/nidash/afni#driftBasisOrder
 
 afni:driftBasisOrder rdf:type owl:DatatypeProperty ;
-
+                     
                      rdfs:label "AFNI's drift Basis Order" ;
                      
                      obo:IAO_0000115 "The number of basis in the drift model." ;
@@ -392,7 +392,7 @@ fsl:dlh rdf:type owl:DatatypeProperty ;
 ###  http://purl.org/nidash/fsl#driftCutoffPeriod
 
 fsl:driftCutoffPeriod rdf:type owl:DatatypeProperty ;
-
+                      
                       rdfs:label "FSL's Drift Cut-off Period" ;
                       
                       obo:IAO_0000115 "Full Width at Half Maximum in seconds of the Gaussian weight function used in the running line smoother." ;
@@ -767,13 +767,13 @@ nidm:numberOfClusters rdf:type owl:DatatypeProperty ;
 
 nidm:numberOfDimensions rdf:type owl:DatatypeProperty ;
                         
-                        obo:IAO_0000115 "Number of dimensions of a data matrix." ;
+                        obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/295" ;
+                        
+                        obo:IAO_0000115 "Number of dimensions of the data matrix (e.g. 3 for volumetric data)" ;
                         
                         obo:IAO_0000112 "3" ;
                         
-                        obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/295" ;
-                        
-                        obo:IAO_0000114 obo:IAO_0000120 ;
+                        obo:IAO_0000114 obo:IAO_0000122 ;
                         
                         rdfs:domain nidm:CoordinateSpace ;
                         
@@ -988,6 +988,7 @@ nidm:userSpecifiedThresholdType rdf:type owl:DatatypeProperty ;
                                 obo:IAO_0000112 "nidm:pValueFWER" ;
                                 
                                 obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/150" ;
+                                
                                 rdfs:comment "Range is currently string but should be limited to {'nidm:pValueFWER' not found'nidm:pValueFDR' not found'nidm:pValueUncorrected';'nidm:statistic'}?" ;
                                 
                                 
@@ -1018,18 +1019,13 @@ nidm:version rdf:type owl:DatatypeProperty ;
 
 nidm:voxelSize rdf:type owl:DatatypeProperty ;
                
-               obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/295" ;
+               obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/295" ;
                
-               obo:IAO_0000112 "[2 2 4]" ;
+               obo:IAO_0000112 "[2, 2, 4]" ;
                
-               rdfs:seeAlso """http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C95003 
-""" ;
+               obo:IAO_0000115 "3D size of a voxel measured in voxel units (e.g. [2, 2, 4])" ;
                
-               obo:IAO_0000115 "3D size of a voxel measured in voxelUnits." ;
-               
-               rdfs:comment "Range: Vector of floats." ;
-               
-               obo:IAO_0000114 obo:IAO_0000120 ;
+               obo:IAO_0000114 obo:IAO_0000122 ;
                
                rdfs:domain nidm:CoordinateSpace ;
                
@@ -1061,15 +1057,15 @@ nidm:voxelToWorldMapping rdf:type owl:DatatypeProperty ;
 
 nidm:voxelUnits rdf:type owl:DatatypeProperty ;
                 
-                obo:IAO_0000115 "Units associated with each dimensions of some N-dimensional data." ;
-                
-                obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/295 (previously discussed in https://github.com/incf-nidash/nidm/issues/147)" ;
+                obo:IAO_0000115 "Set of units associated with the dimensions of some N-dimensional data (e.g. [mm, mm, mm])" ;
                 
                 rdfs:comment "Range: Vector of strings." ;
                 
-                obo:IAO_0000112 "{'mm' 'mm' 's'}" ;
+                obo:IAO_0000112 "['mm', 'mm', 's']" ;
                 
-                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/295 and https://github.com/incf-nidash/nidm/issues/147" ;
+                
+                obo:IAO_0000114 obo:IAO_0000122 ;
                 
                 rdfs:domain nidm:CoordinateSpace ;
                 
@@ -1104,7 +1100,7 @@ spm:clusterSizeInResels rdf:type owl:DatatypeProperty ;
 ###  http://purl.org/nidash/spm#driftCutoffPeriod
 
 spm:driftCutoffPeriod rdf:type owl:DatatypeProperty ;
-
+                      
                       rdfs:label "SPM's Drift Cut-off Period" ;
                       
                       obo:IAO_0000115 "Discrete Cosine Transform basis cut-off, specified as period length in seconds and ensures that all basis elements will have period of this duration or longer." ;


### PR DESCRIPTION
This issue is open to curate the remaining uncurated attributes of *nidm:CoordinateSpace* (cf. [example of usage](http://nidm.nidash.org/specs/nidm-results_dev.html#dfn-nidm-coordinatespace) in the spec).

###### Proposal
 - **nidm:voxelUnits**: **set of** units associated with each dimensions of some N-dimensional data **(e.g. [mm, mm, mm])**.
 - **nidm:voxelSize**: 3D size of a voxel measured in voxel units (e.g. [2, 2, 4]).
 - **nidm:numberOfDimensions**: Number of dimensions of the data matrix (e.g. 3 for volumetric data)

###### Current definitions (for reference)
 - **nidm:voxelUnits**: Units associated with each dimensions of some N-dimensional data.
 - **nidm:voxelSize**: 3D size of a voxel measured in voxelUnits.
 - **nidm:numberOfDimensions**: Number of dimensions of a data matrix