### PR TITLE
Definition of "HeightThreshold" (current status: pending final vetting)

### DIFF
--- a/doc/content/specs/nidm-results_dev.html
+++ b/doc/content/specs/nidm-results_dev.html
@@ -1649,8 +1649,7 @@ niiri:extent_threshold_id a prov:Entity , nidm_ExtentThreshold: ;
             <section id="section-nidm:'Height Threshold'"> 
                 <h1 label="NIDM_0000034">nidm:'Height Threshold'</h1>
                 <div class="glossary-ref">
-                    A <a title="NIDM_0000034"><dfn title="NIDM_0000034">nidm:'Height Threshold'</dfn></a> is a numerical value that establishes a bound on a range of voxelwise or vertex-wise defined statistic.
-. <a title="NIDM_0000034">nidm:'Height Threshold'</a> is a prov:Entity. 
+                    A <a title="NIDM_0000034"><dfn title="NIDM_0000034">nidm:'Height Threshold'</dfn></a> is a numerical value that establishes a lower bound on statistic values and can be specified by the user in terms of FWER-corrected p-value, uncorrected p-value or minimum statistic value. <a title="NIDM_0000034">nidm:'Height Threshold'</a> is a prov:Entity. 
                 </div>
                 <p></p>
                 <div class="attributes" id="attributes-nidm:'Height Threshold'"> A <a title="NIDM_0000034">nidm:'Height Threshold'</a> has attributes:

--- a/nidm/nidm-results/terms/README.md
+++ b/nidm/nidm-results/terms/README.md
@@ -41,12 +41,6 @@ Thank you in advance for taking part in NIDM-Results term curation!
 </tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/280">#280</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Height Threshold'"> [more] </a></td>
-    <td><b>nidm:'Height Threshold': </b>A numerical value that establishes a bound on a range of voxelwise or vertex-wise defined statistic.
-</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
     <td><a href="https://github.com/incf-nidash/nidm//issues?&q='SPM's DCT Drift Model'"> [find issues/PR] </a></td>
     <td><b>spm:'SPM's DCT Drift Model': </b>A drift model in which the drifts are modeled by a Discrete Cosine Transform basis added to regression model</td>
 </tr>

--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -2352,12 +2352,11 @@ nidm:NIDM_0000034 rdf:type owl:Class ;
                   
                   obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/HeightThreshold_P.txt"^^xsd:anyURI ;
                   
-                  obo:IAO_0000115 """A numerical value that establishes a bound on a range of voxelwise or vertex-wise defined statistic.
-""" ;
+                  obo:IAO_0000115 "A numerical value that establishes a lower bound on statistic values and can be specified by the user in terms of FWER-corrected p-value, uncorrected p-value or minimum statistic value." ;
                   
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/280" ;
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/280" ;
                   
-                  obo:IAO_0000114 obo:IAO_0000125 .
+                  obo:IAO_0000114 obo:IAO_0000122 .
 
 
 


### PR DESCRIPTION
This issue is open to curate the definition of **nidm:HeightThreshold**.

###### Current definition
- *nidm:HeightThreshold*: "A numerical value that establishes a bound on a range of voxelwise or vertex-wise defined statistic."

###### Term usage
A `nidm:HeightThreshold` is used an an input of `nidm:Inference` (see also [example of usage of HeightThreshold in the spec](http://nidm.nidash.org/specs/nidm-results_dev.html#dfn-nidm-heightthreshold)). 

###### Proposal

Similarly to what was recently agreed for *nidm:ExtentThreshold* (cf. #273), how about:
- *nidm:HeightThreshold*: **A numerical value that establishes a bound on a range of statistic values and can be specified by the user in terms of FWER-corrected p-value, uncorrected p-value or minimum statistic value.**

?