### PR TITLE
Definition of "ClusterLabelsMap" (current status: uncurated)

### DIFF
--- a/doc/content/specs/nidm-results_dev.html
+++ b/doc/content/specs/nidm-results_dev.html
@@ -1504,7 +1504,7 @@ niiri:cluster_definition_criteria_id a prov:Entity , nidm_ClusterDefinitionCrite
             <section id="section-nidm:'Cluster Labels Map'"> 
                 <h1 label="NIDM_0000008">nidm:'Cluster Labels Map'</h1>
                 <div class="glossary-ref">
-                    A <a title="NIDM_0000008"><dfn title="NIDM_0000008">nidm:'Cluster Labels Map'</dfn></a> is . <a title="NIDM_0000008">nidm:'Cluster Labels Map'</a> is a prov:Entity. 
+                    A <a title="NIDM_0000008"><dfn title="NIDM_0000008">nidm:'Cluster Labels Map'</dfn></a> is a map whose value at each element (e.g., pixel, voxel, vertex, or face) denotes cluster membership within the excursion set. Each cluster is denoted by a different integer and all members of the same cluster have the same value. <a title="NIDM_0000008">nidm:'Cluster Labels Map'</a> is a prov:Entity. 
                 </div>
                 <p></p>
                 <div class="attributes" id="attributes-nidm:'Cluster Labels Map'"> A <a title="NIDM_0000008">nidm:'Cluster Labels Map'</a> has attributes:
@@ -1584,7 +1584,7 @@ niiri:display_map_id a prov:Entity , nidm_DisplayMaskMap: ;
                 <ul>
                     <li><span class="attribute" id="nidm:'Excursion Set Map'.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:'Excursion Set Map'.</li>
                      
-                        <li><a title="NIDM_0000098"><dfn title="NIDM_0000098">nidm:'has Cluster Labels Map'</dfn></a></span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a map whose value at each location denotes cluster membership. Each cluster is denoted by a different integer.(range <a title="NIDM_0000008">nidm:'Cluster Labels Map'</a>)</li> 
+                        <li><a title="NIDM_0000098"><dfn title="NIDM_0000098">nidm:'has Cluster Labels Map'</dfn></a></span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a property that associates a clusters label map to the excursion set.(range <a title="NIDM_0000008">nidm:'Cluster Labels Map'</a>)</li> 
                         <li><a title="NIDM_0000103">nidm:'has Map Header'</a></span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a Property that associates an additional file containing the map header with a map.(range <a title="NIDM_0000053">nidm:'Map Header'</a>)</li> 
                         <li><a title="NIDM_0000104">nidm:'in Coordinate Space'</a></span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file.(range <a title="NIDM_0000016">nidm:'Coordinate Space'</a>)</li> 
                         <li><a title="NIDM_0000111"><dfn title="NIDM_0000111">nidm:'number Of Clusters'</dfn></a></span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> .(range <a title="int" href ="http://www.w3.org/2001/XMLSchema#int">xsd:int</a>)</li> 

--- a/nidm/nidm-results/terms/README.md
+++ b/nidm/nidm-results/terms/README.md
@@ -107,11 +107,6 @@ Discussed with @afni-rickr in <a href="https://github.com/incf-nidash/nidm/pull/
 </tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/282">#282</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Cluster Labels Map'"> [more] </a></td>
-    <td><b>nidm:'Cluster Labels Map': </b>&lt;undefined&gt;</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
     <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/137">#137</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='FSL Results'"> [more] </a></td>
     <td><b>nidm:'FSL Results': </b>&lt;undefined&gt;</td>
 </tr>
@@ -551,13 +546,6 @@ Range: Vector of integers not found.<br/><a href="https://github.com/incf-nidash
     <td><b>nidm:'error Degrees Of Freedom': </b>Degrees of freedom of the error</td>
     <td>nidm:NIDM_0000076 </td>
     <td></td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/orange.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/282">#282</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='has Cluster Labels Map'"> [more] </a></td>
-    <td><b>nidm:'has Cluster Labels Map': </b>A map whose value at each location denotes cluster membership. Each cluster is denoted by a different integer</td>
-    <td>nidm:NIDM_0000025 </td>
-    <td>nidm:NIDM_0000008 </td>
 </tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/orange.png?raw=true"/>  </td>

--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -115,13 +115,11 @@ nidm:NIDM_0000098 rdf:type owl:ObjectProperty ;
                   
                   rdfs:label "has Cluster Labels Map" ;
                   
-                  obo:IAO_0000115 "A map whose value at each location denotes cluster membership. Each cluster is denoted by a different integer." ;
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/282" ;
                   
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/282" ;
+                  obo:IAO_0000115 "A property that associates a clusters label map to the excursion set." ;
                   
-                  obo:IAO_0000112 "file:///path/to/cluster_labels.img" ;
-                  
-                  obo:IAO_0000114 obo:IAO_0000120 ;
+                  obo:IAO_0000114 obo:IAO_0000122 ;
                   
                   rdfs:range nidm:NIDM_0000008 ;
                   
@@ -1921,9 +1919,11 @@ nidm:NIDM_0000008 rdf:type owl:Class ;
                   
                   obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ClusterLabelsMap.txt"^^xsd:anyURI ;
                   
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/282" ;
+                  obo:IAO_0000115 "A map whose value at each element (e.g., pixel, voxel, vertex, or face) denotes cluster membership within the excursion set. Each cluster is denoted by a different integer and all members of the same cluster have the same value." ;
                   
-                  obo:IAO_0000114 obo:IAO_0000124 .
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/282" ;
+                  
+                  obo:IAO_0000114 obo:IAO_0000122 .
 
 
 


### PR DESCRIPTION
This issue is open to curate the definition of **nidm:ClusterLabelsMap** and its corresponding object property **nidm:hasClusterLabelsMap**:

###### Proposal
How about:
 - **nidm:ClusterLabelsMap**: Map whose value at each location denotes cluster membership within the excursion set. Each cluster is denoted by a different integer.
 - **nidm:hasClusterLabelsMap**: Property that associates a clusters label map to the excursion set.

?

Note:
 - The proposed definition of *nidm:hasClusterLabelsMap* is similar to definitions used for other object properties (e.g. [nidm:hasConnectivityCriterion](http://nidm.nidash.org/specs/nidm-results_dev.html#dfn-nidm-hasconnectivitycriterion), [nidm:hasErrorDependence](http://nidm.nidash.org/specs/nidm-results_dev.html#dfn-nidm-haserrordependence))
 - Adding "within the excursion set" to the definition of *nidm:ClusterLabelsMap* is consistent with what was agreed upon for *nidm:clusterLabelId* in #271).

###### Current definitions
 - *nidm:ClusterLabelsMap*: \<undefined\>
 - *nidm:hasClusterLabelsMap*: A map whose value at each location denotes cluster membership. Each cluster is denoted by a different integer.

###### Term usage
A `nidm:hasClusterLabelsMap` is an attribute of `nidm:ExcursionSetMap`, used to associate a `nidm:ClusterLabelsMap` with the excursion set (see also [example of usage of ClusterLabelsMap](http://nidm.nidash.org/specs/nidm-results_dev.html#dfn-nidm-clusterlabelsmap) and [ExcursionSetMap](http://nidm.nidash.org/specs/nidm-results_dev.html#dfn-nidm-excursionsetmap) in the spec). 