### PR TITLE
Definition of "nidm:numberOfClusters" (current status: uncurated)

### DIFF
--- a/doc/content/specs/nidm-results_dev.html
+++ b/doc/content/specs/nidm-results_dev.html
@@ -1604,7 +1604,7 @@ niiri:display_map_id a prov:Entity , nidm_DisplayMaskMap: ;
                         <li><a title="NIDM_0000098"><dfn title="NIDM_0000098">nidm:'has Cluster Labels Map'</dfn></a></span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a property that associates a clusters label map to the excursion set.(range <a title="NIDM_0000008">nidm:'Cluster Labels Map'</a>)</li> 
                         <li><a title="NIDM_0000103">nidm:'has Map Header'</a></span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a Property that associates an additional file containing the map header with a map.(range <a title="NIDM_0000053">nidm:'Map Header'</a>)</li> 
                         <li><a title="NIDM_0000104">nidm:'in Coordinate Space'</a></span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property of a DataArray to associate a CoordinateSpace with a physical file.(range <a title="NIDM_0000016">nidm:'Coordinate Space'</a>)</li> 
-                        <li><a title="NIDM_0000111"><dfn title="NIDM_0000111">nidm:'number Of Clusters'</dfn></a></span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> .(range <a title="int" href ="http://www.w3.org/2001/XMLSchema#int">xsd:int</a>)</li> 
+                        <li><a title="NIDM_0000111"><dfn title="NIDM_0000111">nidm:'number Of Significant Clusters'</dfn></a></span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> number of significant clusters found by the inference activity. This is SPM's set level statistic.(range <a title="int" href ="http://www.w3.org/2001/XMLSchema#int">xsd:int</a>)</li> 
                         <li><a title="NIDM_0000114"><dfn title="NIDM_0000114">nidm:'p Value'</dfn></a></span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> .(range <a title="float" href ="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li> 
                         <li><a title="NIDM_0000138"><dfn title="NIDM_0000138">nidm:'has Maximum Intensity Projection'</dfn></a></span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property that associates an image of the maximum intensity projection with an excursion set map.(range <a title="Image" href ="http://purl.org/dc/dcmitype/Image">dctype:Image</a>)</li>        
                 </ul>
@@ -1613,7 +1613,7 @@ niiri:display_map_id a prov:Entity , nidm_DisplayMaskMap: ;
 @prefix nidm_hasClusterLabelsMap: &lt;http://purl.org/nidash/nidm#NIDM_0000098&gt; .
 @prefix nidm_hasMaximumIntensityProjection: &lt;http://purl.org/nidash/nidm#NIDM_0000138&gt; .
 @prefix nidm_inCoordinateSpace: &lt;http://purl.org/nidash/nidm#NIDM_0000104&gt; .
-@prefix nidm_numberOfClusters: &lt;http://purl.org/nidash/nidm#NIDM_0000111&gt; .
+@prefix nidm_numberOfSignificantClusters: &lt;http://purl.org/nidash/nidm#NIDM_0000111&gt; .
 @prefix nidm_pValue: &lt;http://purl.org/nidash/nidm#NIDM_0000114&gt; .
 
 
@@ -1626,7 +1626,7 @@ niiri:excursion_set_map_id a prov:Entity , nidm_ExcursionSetMap: ;
 	nidm_hasMaximumIntensityProjection: niiri:maximum_intensity_projection_id ;
 	nidm_inCoordinateSpace: niiri:coordinate_space_id_1 ;
 	crypto:sha512 "e43b6e01b0463fe7d40782137867a..."^^xsd:string ;
-	nidm_numberOfClusters: "8"^^xsd:int ;
+	nidm_numberOfSignificantClusters: "8"^^xsd:int ;
 	nidm_pValue: "8.95949980872501e-14"^^xsd:float ;
 	prov:wasGeneratedBy niiri:inference_id .</pre>  
             </section>

--- a/nidm/nidm-results/spm/example001/example001_spm_results.provn
+++ b/nidm/nidm-results/spm/example001/example001_spm_results.provn
@@ -27,6 +27,7 @@ prefix nidm_isUserDefined <http://purl.org/nidash/nidm#NIDM_0000106>
 prefix nidm_hasClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000098>
 prefix obo_Toeplitzcovariancestructure <http://purl.obolibrary.org/obo/STATO_0000357>
 prefix dc <http://purl.org/dc/elements/1.1/>
+prefix nidm_numberOfSignificantClusters <http://purl.org/nidash/nidm#NIDM_0000111>
 prefix nidm_pValueUncorrected <http://purl.org/nidash/nidm#NIDM_0000116>
 prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
 prefix nidm_SignificantCluster <http://purl.org/nidash/nidm#NIDM_0000070>
@@ -51,7 +52,6 @@ prefix nidm_clusterSizeInVoxels <http://purl.org/nidash/nidm#NIDM_0000084>
 prefix nidm_inWorldCoordinateSystem <http://purl.org/nidash/nidm#NIDM_0000105>
 prefix nidm_hasMaximumIntensityProjection <http://purl.org/nidash/nidm#NIDM_0000138>
 prefix nidm_ResidualMeanSquaresMap <http://purl.org/nidash/nidm#NIDM_0000066>
-prefix nidm_numberOfClusters <http://purl.org/nidash/nidm#NIDM_0000111>
 prefix dctype <http://purl.org/dc/dcmitype/>
 prefix nidm_hasAlternativeHypothesis <http://purl.org/nidash/nidm#NIDM_0000097>
 prefix nidm_HeightThreshold <http://purl.org/nidash/nidm#NIDM_0000034>

--- a/nidm/nidm-results/spm/example001/example001_spm_results.ttl
+++ b/nidm/nidm-results/spm/example001/example001_spm_results.ttl
@@ -60,7 +60,7 @@
 @prefix nidm_ExcursionSetMap: <http://purl.org/nidash/nidm#NIDM_0000025> .
 @prefix nidm_hasClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000098> .
 @prefix nidm_hasMaximumIntensityProjection: <http://purl.org/nidash/nidm#NIDM_0000138> .
-@prefix nidm_numberOfClusters: <http://purl.org/nidash/nidm#NIDM_0000111> .
+@prefix nidm_numberOfSignificantClusters: <http://purl.org/nidash/nidm#NIDM_0000111> .
 @prefix nidm_pValue: <http://purl.org/nidash/nidm#NIDM_0000114> .
 @prefix nidm_ExtentThreshold: <http://purl.org/nidash/nidm#NIDM_0000026> .
 @prefix nidm_clusterSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000084> .
@@ -274,7 +274,7 @@ niiri:excursion_set_map_id a prov:Entity , nidm_ExcursionSetMap: ;
 	nidm_hasMaximumIntensityProjection: niiri:maximum_intensity_projection_id ;
 	nidm_inCoordinateSpace: niiri:coordinate_space_id_1 ;
 	crypto:sha512 "d96b82761c299a66978893cab6034f3f8aed25d0a135636b0ffe79f4cf11becce86ba261f7aeb43717f5d0e47ad0b14cfb0402786251e3f2c507890c83b27652"^^xsd:string ;
-	nidm_numberOfClusters: "5"^^xsd:int ;
+	nidm_numberOfSignificantClusters: "5"^^xsd:int ;
 	nidm_pValue: "2.83510681598e-09"^^xsd:float ;
 	prov:wasGeneratedBy niiri:inference_id .
 

--- a/nidm/nidm-results/spm/spm_results.provn
+++ b/nidm/nidm-results/spm/spm_results.provn
@@ -27,6 +27,7 @@ prefix nidm_ParameterEstimateMap <http://purl.org/nidash/nidm#NIDM_0000061>
 prefix nidm_isUserDefined <http://purl.org/nidash/nidm#NIDM_0000106>
 prefix nidm_hasClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000098>
 prefix dc <http://purl.org/dc/elements/1.1/>
+prefix nidm_numberOfSignificantClusters <http://purl.org/nidash/nidm#NIDM_0000111>
 prefix nidm_pValueUncorrected <http://purl.org/nidash/nidm#NIDM_0000116>
 prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
 prefix nidm_SignificantCluster <http://purl.org/nidash/nidm#NIDM_0000070>
@@ -52,7 +53,6 @@ prefix nidm_clusterSizeInVoxels <http://purl.org/nidash/nidm#NIDM_0000084>
 prefix nidm_inWorldCoordinateSystem <http://purl.org/nidash/nidm#NIDM_0000105>
 prefix nidm_hasMaximumIntensityProjection <http://purl.org/nidash/nidm#NIDM_0000138>
 prefix nidm_ResidualMeanSquaresMap <http://purl.org/nidash/nidm#NIDM_0000066>
-prefix nidm_numberOfClusters <http://purl.org/nidash/nidm#NIDM_0000111>
 prefix dctype <http://purl.org/dc/dcmitype/>
 prefix nidm_hasAlternativeHypothesis <http://purl.org/nidash/nidm#NIDM_0000097>
 prefix nidm_HeightThreshold <http://purl.org/nidash/nidm#NIDM_0000034>

--- a/nidm/nidm-results/spm/spm_results.ttl
+++ b/nidm/nidm-results/spm/spm_results.ttl
@@ -59,7 +59,7 @@
 @prefix nidm_ExcursionSetMap: <http://purl.org/nidash/nidm#NIDM_0000025> .
 @prefix nidm_hasClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000098> .
 @prefix nidm_hasMaximumIntensityProjection: <http://purl.org/nidash/nidm#NIDM_0000138> .
-@prefix nidm_numberOfClusters: <http://purl.org/nidash/nidm#NIDM_0000111> .
+@prefix nidm_numberOfSignificantClusters: <http://purl.org/nidash/nidm#NIDM_0000111> .
 @prefix nidm_pValue: <http://purl.org/nidash/nidm#NIDM_0000114> .
 @prefix nidm_ExtentThreshold: <http://purl.org/nidash/nidm#NIDM_0000026> .
 @prefix nidm_clusterSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000084> .
@@ -326,7 +326,7 @@ niiri:excursion_set_map_id a prov:Entity , nidm_ExcursionSetMap: ;
 	nidm_hasMaximumIntensityProjection: niiri:maximum_intensity_projection_id ;
 	nidm_inCoordinateSpace: niiri:coordinate_space_id_1 ;
 	crypto:sha512 "e43b6e01b0463fe7d40782137867a..."^^xsd:string ;
-	nidm_numberOfClusters: "8"^^xsd:int ;
+	nidm_numberOfSignificantClusters: "8"^^xsd:int ;
 	nidm_pValue: "8.95949980872501e-14"^^xsd:float ;
 	prov:wasGeneratedBy niiri:inference_id .
 

--- a/nidm/nidm-results/terms/README.md
+++ b/nidm/nidm-results/terms/README.md
@@ -395,13 +395,6 @@ Range: Vector of integers not found.<br/><a href="https://github.com/incf-nidash
 </tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/292">#292</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='number Of Clusters'"> [more] </a></td>
-    <td><b>nidm:'number Of Clusters': </b>&lt;undefined&gt;</td>
-    <td>nidm:NIDM_0000025 </td>
-    <td>xsd:int </td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
     <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/137">#137</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='object Model'"> [more] </a></td>
     <td><b>nidm:'object Model': </b>&lt;undefined&gt;</td>
     <td>prov:Bundle </td>

--- a/nidm/nidm-results/terms/examples/ExcursionSetMap.txt
+++ b/nidm/nidm-results/terms/examples/ExcursionSetMap.txt
@@ -2,7 +2,7 @@
 @prefix nidm_hasClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000098> .
 @prefix nidm_hasMaximumIntensityProjection: <http://purl.org/nidash/nidm#NIDM_0000138> .
 @prefix nidm_inCoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000104> .
-@prefix nidm_numberOfClusters: <http://purl.org/nidash/nidm#NIDM_0000111> .
+@prefix nidm_numberOfSignificantClusters: <http://purl.org/nidash/nidm#NIDM_0000111> .
 @prefix nidm_pValue: <http://purl.org/nidash/nidm#NIDM_0000114> .
 
 
@@ -15,6 +15,6 @@ niiri:excursion_set_map_id a prov:Entity , nidm_ExcursionSetMap: ;
 	nidm_hasMaximumIntensityProjection: niiri:maximum_intensity_projection_id ;
 	nidm_inCoordinateSpace: niiri:coordinate_space_id_1 ;
 	crypto:sha512 "e43b6e01b0463fe7d40782137867a..."^^xsd:string ;
-	nidm_numberOfClusters: "8"^^xsd:int ;
+	nidm_numberOfSignificantClusters: "8"^^xsd:int ;
 	nidm_pValue: "8.95949980872501e-14"^^xsd:float ;
 	prov:wasGeneratedBy niiri:inference_id .

--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -791,11 +791,13 @@ nidm:NIDM_0000110 rdf:type owl:DatatypeProperty ;
 
 nidm:NIDM_0000111 rdf:type owl:DatatypeProperty ;
                   
-                  rdfs:label "number Of Clusters" ;
+                  rdfs:label "number Of Significant Clusters" ;
                   
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/292" ;
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/292" ;
                   
-                  obo:IAO_0000114 obo:IAO_0000124 ;
+                  obo:IAO_0000115 "Number of significant clusters found by the inference activity. This is SPM's set level statistic." ;
+                  
+                  obo:IAO_0000114 obo:IAO_0000122 ;
                   
                   rdfs:domain nidm:NIDM_0000025 ;
                   


### PR DESCRIPTION
###### Proposal
How do you feel about:
 - **nidm:numberOfClusters**: number of significant clusters found by the inference activity. 

?

###### Current usage
*nidm:numberOfClusters* is an attribute of a *nidm:ExcursionSetMap*, cf. [example of usage](http://nidm.nidash.org/specs/nidm-results_dev.html#dfn-nidm-excursionsetmap) in the spec.