### PR TITLE
Definition of "nidm:DataScaling" (replacing "nidm:Data")

### DIFF
--- a/doc/content/specs/nidm-results_dev.html
+++ b/doc/content/specs/nidm-results_dev.html
@@ -486,12 +486,12 @@ niiri:coordinate_space_id_1 a prov:Entity , nidm_CoordinateSpace: ;
                             </tr>
                 
                         <tr>
-                            <td><a title="NIDM_0000018">nidm:'Data'</a>
+                            <td><a title="NIDM_0000018">nidm:'Data Scaling'</a>
                             </td>
                     
                                 <td rowspan="8" style="text-align: center;">NIDM-Results Types<br/>                                 (PROV Entity)</td>
                         
-                                <td><a title="NIDM_0000018">nidm:'Data'</a></td>
+                                <td><a title="NIDM_0000018">nidm:'Data Scaling'</a></td>
                             </tr>
                 
                         <tr>
@@ -550,7 +550,7 @@ niiri:coordinate_space_id_1 a prov:Entity , nidm_CoordinateSpace: ;
             <section id="section-nidm:'Model Parameters Estimation'"> 
                 <h1 label="NIDM_0000056">nidm:'Model Parameters Estimation'</h1>
                 <div class="glossary-ref">
-                    A <a title="NIDM_0000056"><dfn title="NIDM_0000056">nidm:'Model Parameters Estimation'</dfn></a> is the process of performing a <a href="http://purl.obolibrary.org/obo/STATO_0000119) at each element (e.g., pixel, voxel, vertex, or face">obo:model parameter estimation</a> of a map. <a title="NIDM_0000056">nidm:'Model Parameters Estimation'</a> is a prov:Activity that uses <a title="NIDM_0000018">nidm:'Data'</a>, <a title="NIDM_0000019">nidm:'Design Matrix'</a>, <a title="NIDM_0000023">nidm:'Error Model'</a>, <a title="NIDM_0000054">nidm:'Mask Map'</a> entities. This activity generates <a title="NIDM_0000054">nidm:'Mask Map'</a>, <a title="NIDM_0000061">nidm:'Parameter Estimate Map'</a>, <a title="NIDM_0000144">nidm:'Resels Per Voxel Map'</a>, <a title="NIDM_0000066">nidm:'Residual Mean Squares Map'</a> entities. 
+                    A <a title="NIDM_0000056"><dfn title="NIDM_0000056">nidm:'Model Parameters Estimation'</dfn></a> is the process of performing a <a href="http://purl.obolibrary.org/obo/STATO_0000119) at each element (e.g., pixel, voxel, vertex, or face">obo:model parameter estimation</a> of a map. <a title="NIDM_0000056">nidm:'Model Parameters Estimation'</a> is a prov:Activity that uses <a title="NIDM_0000018">nidm:'Data Scaling'</a>, <a title="NIDM_0000019">nidm:'Design Matrix'</a>, <a title="NIDM_0000023">nidm:'Error Model'</a>, <a title="NIDM_0000054">nidm:'Mask Map'</a> entities. This activity generates <a title="NIDM_0000054">nidm:'Mask Map'</a>, <a title="NIDM_0000061">nidm:'Parameter Estimate Map'</a>, <a title="NIDM_0000144">nidm:'Resels Per Voxel Map'</a>, <a title="NIDM_0000066">nidm:'Residual Mean Squares Map'</a> entities. 
                 </div>
                 <p></p>
                 <div class="attributes" id="attributes-nidm:'Model Parameters Estimation'"> A <a title="NIDM_0000056">nidm:'Model Parameters Estimation'</a> has attributes:
@@ -574,27 +574,27 @@ niiri:model_pe_id prov:used niiri:error_model_id ;
     prov:used niiri:error_model_id ;
     prov:wasAssociatedWith niiri:software_id .</pre>  
             </section>
-            <!-- nidm:'Data' (NIDM_0000018) -->
-            <section id="section-nidm:'Data'"> 
-                <h1 label="NIDM_0000018">nidm:'Data'</h1>
+            <!-- nidm:'Data Scaling' (NIDM_0000018) -->
+            <section id="section-nidm:'Data Scaling'"> 
+                <h1 label="NIDM_0000018">nidm:'Data Scaling'</h1>
                 <div class="glossary-ref">
-                    A <a title="NIDM_0000018"><dfn title="NIDM_0000018">nidm:'Data'</dfn></a> is "A collection or single item of factual information, derived from measurement or research, from which conclusions may be drawn." (This definition is from NCIT). <a title="NIDM_0000018">nidm:'Data'</a> is a prov:Entity used by <a title="NIDM_0000056">nidm:'Model Parameters Estimation'</a>. 
+                    A <a title="NIDM_0000018"><dfn title="NIDM_0000018">nidm:'Data Scaling'</dfn></a> is scaling applied to the data before parameter estimation, including specification of the target intensity. <a title="NIDM_0000018">nidm:'Data Scaling'</a> is a prov:Entity used by <a title="NIDM_0000056">nidm:'Model Parameters Estimation'</a>. 
                 </div>
                 <p></p>
-                <div class="attributes" id="attributes-nidm:'Data'"> A <a title="NIDM_0000018">nidm:'Data'</a> has attributes:
+                <div class="attributes" id="attributes-nidm:'Data Scaling'"> A <a title="NIDM_0000018">nidm:'Data Scaling'</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:'Data'.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:'Data'.</li>
+                    <li><span class="attribute" id="nidm:'Data Scaling'.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:'Data Scaling'.</li>
                      
-                        <li><a title="NIDM_0000096"><dfn title="NIDM_0000096">nidm:'grand Mean Scaling'</dfn></a></span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> binary flag defining whether the data was scaled. Specifically, "grand mean scaling" refers to multipliciation of every voxel in every scan by a common value.  Grand mean scaling is essential for first-level fMRI, to transform the arbitrary MRI units, but is generally not used with second level analyses.(range <a title="boolean" href ="http://www.w3.org/2001/XMLSchema#boolean">xsd:boolean</a>)</li> 
-                        <li><a title="NIDM_0000124"><dfn title="NIDM_0000124">nidm:'target Intensity'</dfn></a></span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> value to which the grand mean of the Data was scaled (applies only if grandMeanScaling is true).(range <a title="float" href ="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li>        
+                        <li><a title="NIDM_0000096"><dfn title="NIDM_0000096">nidm:'grand Mean Scaling'</dfn></a></span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> binary flag defining whether the data was scaled (true for scaled). Specifically, "grand mean scaling" refers to multiplication of every voxel in every scan by a common (or session-specific) value.(range <a title="boolean" href ="http://www.w3.org/2001/XMLSchema#boolean">xsd:boolean</a>)</li> 
+                        <li><a title="NIDM_0000124"><dfn title="NIDM_0000124">nidm:'target Intensity'</dfn></a></span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> value to which the grand mean of the Data was scaled (applies only if grand mean scaling is true).(range <a title="float" href ="http://www.w3.org/2001/XMLSchema#float">xsd:float</a>)</li>        
                 </ul>
                 </div>
-                <pre class='example highlight'>@prefix nidm_Data: &lt;http://purl.org/nidash/nidm#NIDM_0000018&gt; .
+                <pre class='example highlight'>@prefix nidm_DataScaling: &lt;http://purl.org/nidash/nidm#NIDM_0000018&gt; .
 @prefix nidm_grandMeanScaling: &lt;http://purl.org/nidash/nidm#NIDM_0000096&gt; .
 @prefix nidm_targetIntensity: &lt;http://purl.org/nidash/nidm#NIDM_0000124&gt; .
 
 
-niiri:data_id a prov:Entity , nidm_Data: , prov:Collection ;
+niiri:data_id a prov:Entity , nidm_DataScaling: , prov:Collection ;
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "100"^^xsd:float .</pre>  

--- a/nidm/nidm-results/fsl/example001/fsl_nidm.provn
+++ b/nidm/nidm-results/fsl/example001/fsl_nidm.provn
@@ -22,7 +22,6 @@ prefix dct <http://purl.org/dc/terms/>
 prefix nidm_contrastName <http://purl.org/nidash/nidm#NIDM_0000085>
 prefix crypto <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#>
 prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
-prefix nidm_Data <http://purl.org/nidash/nidm#NIDM_0000018>
 prefix nidm_ParameterEstimateMap <http://purl.org/nidash/nidm#NIDM_0000061>
 prefix nidm_coordinateInVoxels <http://purl.org/nidash/nidm#NIDM_0000139>
 prefix nidm_isUserDefined <http://purl.org/nidash/nidm#NIDM_0000106>
@@ -73,6 +72,7 @@ prefix rdfs <http://www.w3.org/2000/01/rdf-schema#>
 prefix nidm_ContrastMap <http://purl.org/nidash/nidm#NIDM_0000002>
 prefix nidm_pValueFWER <http://purl.org/nidash/nidm#NIDM_0000115>
 prefix nidm_coordinate <http://purl.org/nidash/nidm#NIDM_0000086>
+prefix nidm_DataScaling <http://purl.org/nidash/nidm#NIDM_0000018>
 prefix nidm_hasErrorDependence <http://purl.org/nidash/nidm#NIDM_0000100>
 prefix obo_contrastweightmatrix <http://purl.obolibrary.org/obo/STATO_0000323>
 prefix nidm_clusterLabelId <http://purl.org/nidash/nidm#NIDM_0000082>

--- a/nidm/nidm-results/fsl/example001/fsl_nidm.ttl
+++ b/nidm/nidm-results/fsl/example001/fsl_nidm.ttl
@@ -31,7 +31,7 @@
 @prefix nidm_SubjectCoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000077> .
 @prefix nidm_numberOfDimensions: <http://purl.org/nidash/nidm#NIDM_0000112> .
 @prefix nidm_dimensionsInVoxels: <http://purl.org/nidash/nidm#NIDM_0000090> .
-@prefix nidm_Data: <http://purl.org/nidash/nidm#NIDM_0000018> .
+@prefix nidm_DataScaling: <http://purl.org/nidash/nidm#NIDM_0000018> .
 @prefix nidm_grandMeanScaling: <http://purl.org/nidash/nidm#NIDM_0000096> .
 @prefix nidm_targetIntensity: <http://purl.org/nidash/nidm#NIDM_0000124> .
 @prefix nidm_ContrastVarianceMap: <http://purl.org/nidash/nidm#NIDM_0000135> .
@@ -129,7 +129,7 @@ niiri:coordinate_space_id_1 a prov:Entity , nidm_CoordinateSpace: ;
 	nidm_numberOfDimensions: "3"^^xsd:int ;
 	nidm_dimensionsInVoxels: "[64, 64, 42]"^^xsd:string .
 
-niiri:data_id a prov:Entity , nidm_Data: , prov:Collection ;
+niiri:data_id a prov:Entity , nidm_DataScaling: , prov:Collection ;
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "10000"^^xsd:float .

--- a/nidm/nidm-results/fsl/fsl_results.provn
+++ b/nidm/nidm-results/fsl/fsl_results.provn
@@ -20,7 +20,6 @@ prefix dct <http://purl.org/dc/terms/>
 prefix nidm_contrastName <http://purl.org/nidash/nidm#NIDM_0000085>
 prefix crypto <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#>
 prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
-prefix nidm_Data <http://purl.org/nidash/nidm#NIDM_0000018>
 prefix nidm_ParameterEstimateMap <http://purl.org/nidash/nidm#NIDM_0000061>
 prefix nidm_coordinateInVoxels <http://purl.org/nidash/nidm#NIDM_0000139>
 prefix nidm_isUserDefined <http://purl.org/nidash/nidm#NIDM_0000106>
@@ -70,6 +69,7 @@ prefix rdfs <http://www.w3.org/2000/01/rdf-schema#>
 prefix nidm_ContrastMap <http://purl.org/nidash/nidm#NIDM_0000002>
 prefix nidm_pValueFWER <http://purl.org/nidash/nidm#NIDM_0000115>
 prefix nidm_coordinate <http://purl.org/nidash/nidm#NIDM_0000086>
+prefix nidm_DataScaling <http://purl.org/nidash/nidm#NIDM_0000018>
 prefix nidm_hasErrorDependence <http://purl.org/nidash/nidm#NIDM_0000100>
 prefix obo_contrastweightmatrix <http://purl.obolibrary.org/obo/STATO_0000323>
 prefix nidm_clusterLabelId <http://purl.org/nidash/nidm#NIDM_0000082>

--- a/nidm/nidm-results/fsl/fsl_results.ttl
+++ b/nidm/nidm-results/fsl/fsl_results.ttl
@@ -31,7 +31,7 @@
 @prefix nidm_IcbmMni152NonLinear6thGenerationCoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000047> .
 @prefix nidm_numberOfDimensions: <http://purl.org/nidash/nidm#NIDM_0000112> .
 @prefix nidm_dimensionsInVoxels: <http://purl.org/nidash/nidm#NIDM_0000090> .
-@prefix nidm_Data: <http://purl.org/nidash/nidm#NIDM_0000018> .
+@prefix nidm_DataScaling: <http://purl.org/nidash/nidm#NIDM_0000018> .
 @prefix nidm_grandMeanScaling: <http://purl.org/nidash/nidm#NIDM_0000096> .
 @prefix nidm_targetIntensity: <http://purl.org/nidash/nidm#NIDM_0000124> .
 @prefix nidm_DesignMatrix: <http://purl.org/nidash/nidm#NIDM_0000019> .
@@ -138,7 +138,7 @@ niiri:coordinate_space_id_2 a prov:Entity , nidm_CoordinateSpace: ;
 	nidm_numberOfDimensions: "3"^^xsd:int ;
 	nidm_dimensionsInVoxels: "[53,63,46]"^^xsd:string .
 
-niiri:data_id a prov:Entity , nidm_Data: , prov:Collection ;
+niiri:data_id a prov:Entity , nidm_DataScaling: , prov:Collection ;
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "10000"^^xsd:float .

--- a/nidm/nidm-results/spm/example001/example001_spm_results.provn
+++ b/nidm/nidm-results/spm/example001/example001_spm_results.provn
@@ -21,7 +21,6 @@ prefix nidm_contrastName <http://purl.org/nidash/nidm#NIDM_0000085>
 prefix crypto <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#>
 prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
 prefix nidm_heightCriticalThresholdFDR05 <http://purl.org/nidash/nidm#NIDM_0000146>
-prefix nidm_Data <http://purl.org/nidash/nidm#NIDM_0000018>
 prefix nidm_ParameterEstimateMap <http://purl.org/nidash/nidm#NIDM_0000061>
 prefix nidm_isUserDefined <http://purl.org/nidash/nidm#NIDM_0000106>
 prefix nidm_hasClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000098>
@@ -79,6 +78,7 @@ prefix rdfs <http://www.w3.org/2000/01/rdf-schema#>
 prefix nidm_ContrastMap <http://purl.org/nidash/nidm#NIDM_0000002>
 prefix nidm_pValueFWER <http://purl.org/nidash/nidm#NIDM_0000115>
 prefix nidm_coordinate <http://purl.org/nidash/nidm#NIDM_0000086>
+prefix nidm_DataScaling <http://purl.org/nidash/nidm#NIDM_0000018>
 prefix nidm_hasErrorDependence <http://purl.org/nidash/nidm#NIDM_0000100>
 prefix obo_contrastweightmatrix <http://purl.obolibrary.org/obo/STATO_0000323>
 prefix nidm_clusterLabelId <http://purl.org/nidash/nidm#NIDM_0000082>

--- a/nidm/nidm-results/spm/example001/example001_spm_results.ttl
+++ b/nidm/nidm-results/spm/example001/example001_spm_results.ttl
@@ -35,7 +35,7 @@
 @prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
 @prefix nidm_numberOfDimensions: <http://purl.org/nidash/nidm#NIDM_0000112> .
 @prefix nidm_dimensionsInVoxels: <http://purl.org/nidash/nidm#NIDM_0000090> .
-@prefix nidm_Data: <http://purl.org/nidash/nidm#NIDM_0000018> .
+@prefix nidm_DataScaling: <http://purl.org/nidash/nidm#NIDM_0000018> .
 @prefix nidm_grandMeanScaling: <http://purl.org/nidash/nidm#NIDM_0000096> .
 @prefix nidm_targetIntensity: <http://purl.org/nidash/nidm#NIDM_0000124> .
 @prefix nidm_ParameterEstimateMap: <http://purl.org/nidash/nidm#NIDM_0000061> .
@@ -192,7 +192,7 @@ niiri:coordinate_space_id_1 a prov:Entity , nidm_CoordinateSpace: ;
 	nidm_numberOfDimensions: "3"^^xsd:int ;
 	nidm_dimensionsInVoxels: "[53,63,52]"^^xsd:string .
 
-niiri:data_id a prov:Entity , nidm_Data: , prov:Collection ;
+niiri:data_id a prov:Entity , nidm_DataScaling: , prov:Collection ;
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "100"^^xsd:float .

--- a/nidm/nidm-results/spm/example002/spm_results_2contrasts.provn
+++ b/nidm/nidm-results/spm/example002/spm_results_2contrasts.provn
@@ -18,7 +18,6 @@ prefix dct <http://purl.org/dc/terms/>
 prefix nidm_contrastName <http://purl.org/nidash/nidm#NIDM_0000085>
 prefix crypto <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#>
 prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
-prefix nidm_Data <http://purl.org/nidash/nidm#NIDM_0000018>
 prefix nidm_ParameterEstimateMap <http://purl.org/nidash/nidm#NIDM_0000061>
 prefix nidm_isUserDefined <http://purl.org/nidash/nidm#NIDM_0000106>
 prefix dc <http://purl.org/dc/elements/1.1/>
@@ -58,6 +57,7 @@ prefix nidm_ContrastEstimation <http://purl.org/nidash/nidm#NIDM_0000001>
 prefix rdfs <http://www.w3.org/2000/01/rdf-schema#>
 prefix nidm_ContrastMap <http://purl.org/nidash/nidm#NIDM_0000002>
 prefix nidm_pValueFWER <http://purl.org/nidash/nidm#NIDM_0000115>
+prefix nidm_DataScaling <http://purl.org/nidash/nidm#NIDM_0000018>
 prefix nidm_hasErrorDependence <http://purl.org/nidash/nidm#NIDM_0000100>
 prefix obo_contrastweightmatrix <http://purl.obolibrary.org/obo/STATO_0000323>
 prefix nidm_ReselsPerVoxelMap <http://purl.org/nidash/nidm#NIDM_0000144>

--- a/nidm/nidm-results/spm/example002/spm_results_2contrasts.ttl
+++ b/nidm/nidm-results/spm/example002/spm_results_2contrasts.ttl
@@ -35,7 +35,7 @@
 @prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
 @prefix nidm_numberOfDimensions: <http://purl.org/nidash/nidm#NIDM_0000112> .
 @prefix nidm_dimensionsInVoxels: <http://purl.org/nidash/nidm#NIDM_0000090> .
-@prefix nidm_Data: <http://purl.org/nidash/nidm#NIDM_0000018> .
+@prefix nidm_DataScaling: <http://purl.org/nidash/nidm#NIDM_0000018> .
 @prefix nidm_grandMeanScaling: <http://purl.org/nidash/nidm#NIDM_0000096> .
 @prefix nidm_targetIntensity: <http://purl.org/nidash/nidm#NIDM_0000124> .
 @prefix nidm_ParameterEstimateMap: <http://purl.org/nidash/nidm#NIDM_0000061> .
@@ -173,7 +173,7 @@ niiri:coordinate_space_id_1 a prov:Entity , nidm_CoordinateSpace: ;
 	nidm_numberOfDimensions: "3"^^xsd:int ;
 	nidm_dimensionsInVoxels: "[53,63,46]"^^xsd:string .
 
-niiri:data_id a prov:Entity , nidm_Data: , prov:Collection ;
+niiri:data_id a prov:Entity , nidm_DataScaling: , prov:Collection ;
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "100"^^xsd:float .

--- a/nidm/nidm-results/spm/example003/spm_results_conjunction.provn
+++ b/nidm/nidm-results/spm/example003/spm_results_conjunction.provn
@@ -18,7 +18,6 @@ prefix dct <http://purl.org/dc/terms/>
 prefix nidm_contrastName <http://purl.org/nidash/nidm#NIDM_0000085>
 prefix crypto <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#>
 prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
-prefix nidm_Data <http://purl.org/nidash/nidm#NIDM_0000018>
 prefix nidm_ParameterEstimateMap <http://purl.org/nidash/nidm#NIDM_0000061>
 prefix nidm_isUserDefined <http://purl.org/nidash/nidm#NIDM_0000106>
 prefix dc <http://purl.org/dc/elements/1.1/>
@@ -57,6 +56,7 @@ prefix nidm_ContrastEstimation <http://purl.org/nidash/nidm#NIDM_0000001>
 prefix rdfs <http://www.w3.org/2000/01/rdf-schema#>
 prefix nidm_ContrastMap <http://purl.org/nidash/nidm#NIDM_0000002>
 prefix nidm_pValueFWER <http://purl.org/nidash/nidm#NIDM_0000115>
+prefix nidm_DataScaling <http://purl.org/nidash/nidm#NIDM_0000018>
 prefix nidm_hasErrorDependence <http://purl.org/nidash/nidm#NIDM_0000100>
 prefix obo_contrastweightmatrix <http://purl.obolibrary.org/obo/STATO_0000323>
 prefix nidm_ReselsPerVoxelMap <http://purl.org/nidash/nidm#NIDM_0000144>

--- a/nidm/nidm-results/spm/example003/spm_results_conjunction.ttl
+++ b/nidm/nidm-results/spm/example003/spm_results_conjunction.ttl
@@ -35,7 +35,7 @@
 @prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
 @prefix nidm_numberOfDimensions: <http://purl.org/nidash/nidm#NIDM_0000112> .
 @prefix nidm_dimensionsInVoxels: <http://purl.org/nidash/nidm#NIDM_0000090> .
-@prefix nidm_Data: <http://purl.org/nidash/nidm#NIDM_0000018> .
+@prefix nidm_DataScaling: <http://purl.org/nidash/nidm#NIDM_0000018> .
 @prefix nidm_grandMeanScaling: <http://purl.org/nidash/nidm#NIDM_0000096> .
 @prefix nidm_targetIntensity: <http://purl.org/nidash/nidm#NIDM_0000124> .
 @prefix nidm_ParameterEstimateMap: <http://purl.org/nidash/nidm#NIDM_0000061> .
@@ -164,7 +164,7 @@ niiri:coordinate_space_id_1 a prov:Entity , nidm_CoordinateSpace: ;
 	nidm_numberOfDimensions: "3"^^xsd:int ;
 	nidm_dimensionsInVoxels: "[53,63,46]"^^xsd:string .
 
-niiri:data_id a prov:Entity , nidm_Data: , prov:Collection ;
+niiri:data_id a prov:Entity , nidm_DataScaling: , prov:Collection ;
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "100"^^xsd:float .

--- a/nidm/nidm-results/spm/spm_results.provn
+++ b/nidm/nidm-results/spm/spm_results.provn
@@ -22,7 +22,6 @@ prefix nidm_contrastName <http://purl.org/nidash/nidm#NIDM_0000085>
 prefix crypto <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#>
 prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
 prefix nidm_heightCriticalThresholdFDR05 <http://purl.org/nidash/nidm#NIDM_0000146>
-prefix nidm_Data <http://purl.org/nidash/nidm#NIDM_0000018>
 prefix nidm_ParameterEstimateMap <http://purl.org/nidash/nidm#NIDM_0000061>
 prefix nidm_isUserDefined <http://purl.org/nidash/nidm#NIDM_0000106>
 prefix nidm_hasClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000098>
@@ -78,6 +77,7 @@ prefix rdfs <http://www.w3.org/2000/01/rdf-schema#>
 prefix nidm_ContrastMap <http://purl.org/nidash/nidm#NIDM_0000002>
 prefix nidm_pValueFWER <http://purl.org/nidash/nidm#NIDM_0000115>
 prefix nidm_coordinate <http://purl.org/nidash/nidm#NIDM_0000086>
+prefix nidm_DataScaling <http://purl.org/nidash/nidm#NIDM_0000018>
 prefix nidm_hasErrorDependence <http://purl.org/nidash/nidm#NIDM_0000100>
 prefix obo_contrastweightmatrix <http://purl.obolibrary.org/obo/STATO_0000323>
 prefix nidm_clusterLabelId <http://purl.org/nidash/nidm#NIDM_0000082>

--- a/nidm/nidm-results/spm/spm_results.ttl
+++ b/nidm/nidm-results/spm/spm_results.ttl
@@ -35,7 +35,7 @@
 @prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
 @prefix nidm_numberOfDimensions: <http://purl.org/nidash/nidm#NIDM_0000112> .
 @prefix nidm_dimensionsInVoxels: <http://purl.org/nidash/nidm#NIDM_0000090> .
-@prefix nidm_Data: <http://purl.org/nidash/nidm#NIDM_0000018> .
+@prefix nidm_DataScaling: <http://purl.org/nidash/nidm#NIDM_0000018> .
 @prefix nidm_grandMeanScaling: <http://purl.org/nidash/nidm#NIDM_0000096> .
 @prefix nidm_targetIntensity: <http://purl.org/nidash/nidm#NIDM_0000124> .
 @prefix nidm_MaskMap: <http://purl.org/nidash/nidm#NIDM_0000054> .
@@ -192,7 +192,7 @@ niiri:coordinate_space_id_2 a prov:Entity , nidm_CoordinateSpace: ;
 	nidm_numberOfDimensions: "3"^^xsd:int ;
 	nidm_dimensionsInVoxels: "[53,63,46]"^^xsd:string .
 
-niiri:data_id a prov:Entity , nidm_Data: , prov:Collection ;
+niiri:data_id a prov:Entity , nidm_DataScaling: , prov:Collection ;
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "100"^^xsd:float .

--- a/nidm/nidm-results/terms/README.md
+++ b/nidm/nidm-results/terms/README.md
@@ -26,11 +26,6 @@ Thank you in advance for taking part in NIDM-Results term curation!
 </tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/285">#285</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Data'"> [more] </a></td>
-    <td><b>nidm:'Data': </b>"A collection or single item of factual information, derived from measurement or research, from which conclusions may be drawn." (This definition is from NCIT)(same as: <a href=http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C25474>http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C25474</a>)</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
     <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/274">#274</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Design Matrix'"> [more] </a></td>
     <td><b>nidm:'Design Matrix': </b>A matrix of values defining the explanatory variables used in a regression model.  Each column corresponds to one explanatory variable, each row corresponds to one observation (editor: TN)</td>
 </tr>
@@ -278,13 +273,6 @@ Discussed with @afni-rickr in <a href="https://github.com/incf-nidash/nidm/pull/
 </tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/285">#285</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='grand Mean Scaling'"> [more] </a></td>
-    <td><b>nidm:'grand Mean Scaling': </b>Binary flag defining whether the data was scaled. Specifically, "grand mean scaling" refers to multipliciation of every voxel in every scan by a common value.  Grand mean scaling is essential for first-level fMRI, to transform the arbitrary MRI units, but is generally not used with second level analyses</td>
-    <td>nidm:NIDM_0000018 </td>
-    <td>xsd:boolean </td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
     <td><a href="https://github.com/incf-nidash/nidm//issues?&q='has Drift Model'"> [find issues/PR] </a></td>
     <td><b>nidm:'has Drift Model': </b>A property that associates a drift model to a design matrix (only used for first-level fMRI experiments)</td>
     <td>nidm:NIDM_0000019 </td>
@@ -310,13 +298,6 @@ Discussed with @afni-rickr in <a href="https://github.com/incf-nidash/nidm/pull/
     <td><b>nidm:'regressor Names': </b>A list of abstract names associated with each column of the design matrix (e.g. ["motor_left", "motor_right"])</td>
     <td>nidm:NIDM_0000019 </td>
     <td>xsd:string </td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/285">#285</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='target Intensity'"> [more] </a></td>
-    <td><b>nidm:'target Intensity': </b>Value to which the grand mean of the Data was scaled (applies only if grandMeanScaling is true)</td>
-    <td>nidm:NIDM_0000018 </td>
-    <td></td>
 </tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>

--- a/nidm/nidm-results/terms/examples/Data.txt
+++ b/nidm/nidm-results/terms/examples/Data.txt
@@ -1,9 +1,9 @@
-@prefix nidm_Data: <http://purl.org/nidash/nidm#NIDM_0000018> .
+@prefix nidm_DataScaling: <http://purl.org/nidash/nidm#NIDM_0000018> .
 @prefix nidm_grandMeanScaling: <http://purl.org/nidash/nidm#NIDM_0000096> .
 @prefix nidm_targetIntensity: <http://purl.org/nidash/nidm#NIDM_0000124> .
 
 
-niiri:data_id a prov:Entity , nidm_Data: , prov:Collection ;
+niiri:data_id a prov:Entity , nidm_DataScaling: , prov:Collection ;
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "100"^^xsd:float .

--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -663,13 +663,13 @@ nidm:NIDM_0000096 rdf:type owl:DatatypeProperty ;
                   
                   rdfs:label "grand Mean Scaling" ;
                   
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/285" ;
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/285" ;
                   
                   obo:IAO_0000112 "TRUE" ;
                   
-                  obo:IAO_0000115 "Binary flag defining whether the data was scaled. Specifically, \"grand mean scaling\" refers to multipliciation of every voxel in every scan by a common value.  Grand mean scaling is essential for first-level fMRI, to transform the arbitrary MRI units, but is generally not used with second level analyses." ;
+                  obo:IAO_0000115 "Binary flag defining whether the data was scaled (true for scaled). Specifically, \"grand mean scaling\" refers to multiplication of every voxel in every scan by a common (or session-specific) value." ;
                   
-                  obo:IAO_0000114 obo:IAO_0000125 ;
+                  obo:IAO_0000114 obo:IAO_0000122 ;
                   
                   rdfs:domain nidm:NIDM_0000018 ;
                   
@@ -1022,13 +1022,13 @@ nidm:NIDM_0000124 rdf:type owl:DatatypeProperty ;
                   
                   rdfs:label "target Intensity" ;
                   
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/285" ;
+                  
+                  obo:IAO_0000115 "Value to which the grand mean of the Data was scaled (applies only if grand mean scaling is true)." ;
+                  
                   obo:IAO_0000112 "100" ;
                   
-                  obo:IAO_0000115 "Value to which the grand mean of the Data was scaled (applies only if grandMeanScaling is true)." ;
-                  
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/285" ;
-                  
-                  obo:IAO_0000114 obo:IAO_0000125 ;
+                  obo:IAO_0000114 obo:IAO_0000122 ;
                   
                   rdfs:domain nidm:NIDM_0000018 ;
                   
@@ -2071,19 +2071,17 @@ nidm:NIDM_0000017 rdf:type owl:Class ;
 
 nidm:NIDM_0000018 rdf:type owl:Class ;
                   
-                  rdfs:label "Data" ;
+                  rdfs:label "Data Scaling" ;
                   
                   rdfs:subClassOf prov:Entity ;
                   
                   obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/Data.txt"^^xsd:anyURI ;
                   
-                  owl:sameAs "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C25474" ;
+                  obo:IAO_0000115 "Scaling applied to the data before parameter estimation, including specification of the target intensity." ;
                   
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/285" ;
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/285" ;
                   
-                  obo:IAO_0000115 "\"A collection or single item of factual information, derived from measurement or research, from which conclusions may be drawn.\" (This definition is from NCIT)." ;
-                  
-                  obo:IAO_0000114 obo:IAO_0000125 .
+                  obo:IAO_0000114 obo:IAO_0000122 .
 
 
 


### PR DESCRIPTION
This issue is open to curate **nidm:Data** and its attributes.

###### Proposal
We created the *nidm:Data* class a while ago, as a placeholder for the input data and were planning to provide a more precise description in a future version. Since then we had a lot of discussions on the relationship between NIDM-Results and NIDM-Workflows (e.g. in #114 and [slides](https://docs.google.com/presentation/d/1W4l_xhxE4LpKkDhQouBVab0H-W1E-299wm50ZT-j4B0/edit?usp=sharing)) and I think now would be a good time to rethink about this entity. 

As the *nidm:Data* entity is only storing information about data scaling and not data itself (cf. [example of usage](http://nidm.nidash.org/specs/nidm-results_dev.html#dfn-nidm-data)), I would like to propose to rename it to *nidm:DataScaling* with the following definition:
 - **nidm:DataScaling**: Scaling applied to the data before parameter estimation, including specification of the target intensity.

In the future, we could connect with the actual Data entities created as part of NIDM-Workflow.

###### Current definition (for reference)
*nidm:Data* is currently defined as "A collection or single item of factual information, derived from measurement or research, from which conclusions may be drawn", borrowing the definition from [ncit:data](http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C25474).
