### PR TITLE
Definition of "GrandMeanMap"

### DIFF
--- a/doc/content/specs/nidm-results_dev.html
+++ b/doc/content/specs/nidm-results_dev.html
@@ -940,7 +940,7 @@ niiri:error_model_id a prov:Entity , nidm_ErrorModel: ;
             <section id="section-nidm:'Grand Mean Map'"> 
                 <h1 label="NIDM_0000033">nidm:'Grand Mean Map'</h1>
                 <div class="glossary-ref">
-                    A <a title="NIDM_0000033"><dfn title="NIDM_0000033">nidm:'Grand Mean Map'</dfn></a> is . <a title="NIDM_0000033">nidm:'Grand Mean Map'</a> is a prov:Entity. 
+                    A <a title="NIDM_0000033"><dfn title="NIDM_0000033">nidm:'Grand Mean Map'</dfn></a> is a map whose value at each element (e.g., pixel, voxel, vertex, or face) is the mean over all observations of that element in the input maps (after any scaling of those input maps). <a title="NIDM_0000033">nidm:'Grand Mean Map'</a> is a prov:Entity. 
                 </div>
                 <p></p>
                 <div class="attributes" id="attributes-nidm:'Grand Mean Map'"> A <a title="NIDM_0000033">nidm:'Grand Mean Map'</a> has attributes:

--- a/nidm/nidm-results/terms/README.md
+++ b/nidm/nidm-results/terms/README.md
@@ -132,11 +132,6 @@ Discussed with @afni-rickr in <a href="https://github.com/incf-nidash/nidm/pull/
 </tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/288">#288</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Grand Mean Map'"> [more] </a></td>
-    <td><b>nidm:'Grand Mean Map': </b>&lt;undefined&gt;</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
     <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Hemodynamic Response Function Basis'"> [more] </a></td>
     <td><b>nidm:'Hemodynamic Response Function Basis': </b>&lt;undefined&gt;</td>
 </tr>

--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -2325,7 +2325,7 @@ nidm:NIDM_0000033 rdf:type owl:Class ;
                   
                   obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/GrandMeanMap.txt"^^xsd:anyURI ;
                   
-                  obo:IAO_0000115 "A map whose value at each element (e.g., pixel, voxel, vertex, or face) is the mean over all observations in the input maps (after any scaling of those input maps)" ;
+                  obo:IAO_0000115 "A map whose value at each element (e.g., pixel, voxel, vertex, or face) is the mean over all observations at that element in the input maps (after any scaling of those input maps)" ;
                   
                   obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/288" ;
                   

--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -2325,7 +2325,7 @@ nidm:NIDM_0000033 rdf:type owl:Class ;
                   
                   obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/GrandMeanMap.txt"^^xsd:anyURI ;
                   
-                  obo:IAO_0000115 "A map whose value at each element (e.g., pixel, voxel, vertex, or face) is the mean over all observations at that element in the input maps (after any scaling of those input maps)" ;
+                  obo:IAO_0000115 "A map whose value at each element (e.g., pixel, voxel, vertex, or face) is the mean over all observations of that element in the input maps (after any scaling of those input maps)" ;
                   
                   obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/288" ;
                   

--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -2325,9 +2325,11 @@ nidm:NIDM_0000033 rdf:type owl:Class ;
                   
                   obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/GrandMeanMap.txt"^^xsd:anyURI ;
                   
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/288" ;
+                  obo:IAO_0000115 "A map whose value at each element (e.g., pixel, voxel, vertex, or face) is the mean over all observations in the input maps (after any scaling of those input maps)" ;
                   
-                  obo:IAO_0000114 obo:IAO_0000124 .
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/288" ;
+                  
+                  obo:IAO_0000114 obo:IAO_0000122 .
 
 
 


### PR DESCRIPTION
This issue is open to curate the definition of **nidm:GrandMeanMap** and its attributes.

###### Proposal
Similarly to what we have done for other *Map* terms in #255, how about:
 - **nidm:GrandMeanMap**: A map whose value at each element is the mean of the means (i.e. the grand mean) of the input data to the activity that generated this map.
 
###### Current usage
Cf. [example of usage](http://nidm.nidash.org/specs/nidm-results_dev.html#dfn-nidm-grandmeanmap) in the specs.

@jbpoline, @nicholst: would you have suggestions to improve the definition of "grand mean"? Thank you!