### PR TITLE
Definitions of HRF terms (current status: uncurated)

### DIFF
--- a/doc/content/specs/nidm-results_dev.html
+++ b/doc/content/specs/nidm-results_dev.html
@@ -611,7 +611,7 @@ niiri:data_id a prov:Entity , nidm_DataScaling: , prov:Collection ;
                     <li><span class="attribute" id="nidm:'Design Matrix'.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:'Design Matrix'.</li>
                      
                         <li><a title="NIDM_0000088"><dfn title="NIDM_0000088">nidm:'has Drift Model'</dfn></a></span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a property that associates a drift model to a design matrix (only used for first-level fMRI experiments).(range <a title="NIDM_0000087">nidm:'Drift Model'</a> such as <a title="LegendrePolynomialDriftModel">afni:'AFNI's Legendre Polinomial Drift Model'</a>, <a title="GaussianRunningLineDriftModel">fsl:'FSL's Gaussian Running Line Drift Model'</a>, <a title="DCTDriftModel">spm:'SPM's DCT Drift Model'</a>)</li> 
-                        <li><a title="NIDM_0000102"><dfn title="NIDM_0000102">nidm:'has HRF Basis'</dfn></a></span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> .(range <a title="NIDM_0000036">nidm:'Hemodynamic Response Function Basis'</a> such as <a title="BLOCK">afni:BLOCK</a>, <a title="CustomHRB">fsl:CustomHRB</a>, <a title="SineHRB">fsl:SineHRB</a>, <a title="NIDM_0000028">nidm:'Finite Impulse Response HRB'</a>, <a title="NIDM_0000030">nidm:'Gamma HRB'</a>, <a title="NIDM_0000037">nidm:'Hemodynamic Response Function Derivative'</a>, <a title="NIDM_0000035">nidm:'Hemodynamic Response Function'</a>, <a title="FourierHRB">spm:FourierHRB</a>)</li> 
+                        <li><a title="NIDM_0000102"><dfn title="NIDM_0000102">nidm:'has HRF Basis'</dfn></a></span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a property that associates a set of functions that, when convolved with the anticipated neural responses, yield a set of regressors to model the anticipated hemodynamic responses in a design matrix.(range <a title="NIDM_0000036">nidm:'Convolution Basis Set'</a> such as <a title="BLOCK">afni:BLOCK</a>, <a title="CustomHRB">nidm:'Custom Basis Set'</a>, <a title="NIDM_0000028">nidm:'Finite Impulse Response Basis Set'</a>, <a title="FourierHRB">nidm:'Fourier Basis Set'</a>, <a title="NIDM_0000030">nidm:'Gamma Basis Set'</a>, <a title="NIDM_0000037">nidm:'Hemodynamic Response Function Derivative'</a>, <a title="NIDM_0000035">nidm:'Hemodynamic Response Function'</a>, <a title="LinearSplineHRB">nidm:'Linear Spline Basis Set'</a>, <a title="SineHRB">nidm:'Sine Basis Set'</a>)</li> 
                         <li><a title="hasfMRIDesign"><dfn title="hasfMRIDesign">nidm:'has fMRI Design'</dfn></a></span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a property that associates an fMRI design to a design matrix in first-level fMRI analyses.(range <a title="fMRIDesign">nidm:'fMRI Design Type'</a>)</li> 
                         <li><a title="regressorNames"><dfn title="regressorNames">nidm:'regressor Names'</dfn></a></span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a list of abstract names associated with each column of the design matrix (e.g. ["motor_left", "motor_right"]).(range <a title="string" href ="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li>        
                 </ul>
@@ -647,23 +647,71 @@ niiri:design_matrix_id a prov:Entity , nidm_DesignMatrix: ;
 	rdfs:label "SPM's DCT Drift Model" ;
 	spm:driftCutoffPeriod 2 .</pre>  
             </section>
-            <!-- nidm:'Finite Impulse Response HRB' (NIDM_0000028) -->
-            <section id="section-nidm:'Finite Impulse Response HRB'"> 
-                <h1 label="NIDM_0000028">nidm:'Finite Impulse Response HRB'</h1>
+            <!-- nidm:'Custom Basis Set' (CustomHRB) -->
+            <section id="section-nidm:'Custom Basis Set'"> 
+                <h1 label="CustomHRB">nidm:'Custom Basis Set'</h1>
                 <div class="glossary-ref">
-                    A <a title="NIDM_0000028"><dfn title="NIDM_0000028">nidm:'Finite Impulse Response HRB'</dfn></a> is . <a title="NIDM_0000028">nidm:'Finite Impulse Response HRB'</a> is a prov:Entity. 
+                    A <a title="CustomHRB"><dfn title="CustomHRB">nidm:'Custom Basis Set'</dfn></a> is customised set of basis functions. <a title="CustomHRB">nidm:'Custom Basis Set'</a> is a prov:Entity. 
                 </div>
                 <p></p>
-                <div class="attributes" id="attributes-nidm:'Finite Impulse Response HRB'"> A <a title="NIDM_0000028">nidm:'Finite Impulse Response HRB'</a> has attributes:
+                <div class="attributes" id="attributes-nidm:'Custom Basis Set'"> A <a title="CustomHRB">nidm:'Custom Basis Set'</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:'Finite Impulse Response HRB'.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:'Finite Impulse Response HRB'.</li>
+                    <li><span class="attribute" id="nidm:'Custom Basis Set'.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:'Custom Basis Set'.</li>
+                      
+            </section>
+            <!-- nidm:'Fourier Basis Set' (FourierHRB) -->
+            <section id="section-nidm:'Fourier Basis Set'"> 
+                <h1 label="FourierHRB">nidm:'Fourier Basis Set'</h1>
+                <div class="glossary-ref">
+                    A <a title="FourierHRB"><dfn title="FourierHRB">nidm:'Fourier Basis Set'</dfn></a> is set of Fourier basis. <a title="FourierHRB">nidm:'Fourier Basis Set'</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:'Fourier Basis Set'"> A <a title="FourierHRB">nidm:'Fourier Basis Set'</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:'Fourier Basis Set'.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:'Fourier Basis Set'.</li>
+                      
+            </section>
+            <!-- nidm:'Gaussian HRF' (GaussianHRF) -->
+            <section id="section-nidm:'Gaussian HRF'"> 
+                <h1 label="GaussianHRF">nidm:'Gaussian HRF'</h1>
+                <div class="glossary-ref">
+                    A <a title="GaussianHRF"><dfn title="GaussianHRF">nidm:'Gaussian HRF'</dfn></a> is hemodynamic response function which is a gaussian kernel. <a title="GaussianHRF">nidm:'Gaussian HRF'</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:'Gaussian HRF'"> A <a title="GaussianHRF">nidm:'Gaussian HRF'</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:'Gaussian HRF'.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:'Gaussian HRF'.</li>
+                      
+            </section>
+            <!-- nidm:'Linear Spline Basis Set' (LinearSplineHRB) -->
+            <section id="section-nidm:'Linear Spline Basis Set'"> 
+                <h1 label="LinearSplineHRB">nidm:'Linear Spline Basis Set'</h1>
+                <div class="glossary-ref">
+                    A <a title="LinearSplineHRB"><dfn title="LinearSplineHRB">nidm:'Linear Spline Basis Set'</dfn></a> is a Linear (order 1) spline, providing an estimate that is continuous over time (in contrast to a FIR basis, which is discontinuous between each time bin). This is called TENT in AFNI's 3dDeconvolve program. <a title="LinearSplineHRB">nidm:'Linear Spline Basis Set'</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:'Linear Spline Basis Set'"> A <a title="LinearSplineHRB">nidm:'Linear Spline Basis Set'</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:'Linear Spline Basis Set'.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:'Linear Spline Basis Set'.</li>
+                      
+            </section>
+            <!-- nidm:'Finite Impulse Response Basis Set' (NIDM_0000028) -->
+            <section id="section-nidm:'Finite Impulse Response Basis Set'"> 
+                <h1 label="NIDM_0000028">nidm:'Finite Impulse Response Basis Set'</h1>
+                <div class="glossary-ref">
+                    A <a title="NIDM_0000028"><dfn title="NIDM_0000028">nidm:'Finite Impulse Response Basis Set'</dfn></a> is set of Finite impulse response (FIR) filters, with FIR the convolution kernel is represented as a set of discrete fixed-width "impulses" (definition adapted from <a href="http://fsl.fmrib.ox.ac.uk/fsl/fsl4.0/feat5/detail.html)">FSL wiki</a>. <a title="NIDM_0000028">nidm:'Finite Impulse Response Basis Set'</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:'Finite Impulse Response Basis Set'"> A <a title="NIDM_0000028">nidm:'Finite Impulse Response Basis Set'</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:'Finite Impulse Response Basis Set'.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:'Finite Impulse Response Basis Set'.</li>
                       
             </section>
             <!-- nidm:'Gamma Difference HRF' (NIDM_0000029) -->
             <section id="section-nidm:'Gamma Difference HRF'"> 
                 <h1 label="NIDM_0000029">nidm:'Gamma Difference HRF'</h1>
                 <div class="glossary-ref">
-                    A <a title="NIDM_0000029"><dfn title="NIDM_0000029">nidm:'Gamma Difference HRF'</dfn></a> is . <a title="NIDM_0000029">nidm:'Gamma Difference HRF'</a> is a prov:Entity. 
+                    A <a title="NIDM_0000029"><dfn title="NIDM_0000029">nidm:'Gamma Difference HRF'</dfn></a> is hemodynamic response function which is a difference of two gamma probability density functions. <a title="NIDM_0000029">nidm:'Gamma Difference HRF'</a> is a prov:Entity. 
                 </div>
                 <p></p>
                 <div class="attributes" id="attributes-nidm:'Gamma Difference HRF'"> A <a title="NIDM_0000029">nidm:'Gamma Difference HRF'</a> has attributes:
@@ -671,23 +719,23 @@ niiri:design_matrix_id a prov:Entity , nidm_DesignMatrix: ;
                     <li><span class="attribute" id="nidm:'Gamma Difference HRF'.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:'Gamma Difference HRF'.</li>
                       
             </section>
-            <!-- nidm:'Gamma HRB' (NIDM_0000030) -->
-            <section id="section-nidm:'Gamma HRB'"> 
-                <h1 label="NIDM_0000030">nidm:'Gamma HRB'</h1>
+            <!-- nidm:'Gamma Basis Set' (NIDM_0000030) -->
+            <section id="section-nidm:'Gamma Basis Set'"> 
+                <h1 label="NIDM_0000030">nidm:'Gamma Basis Set'</h1>
                 <div class="glossary-ref">
-                    A <a title="NIDM_0000030"><dfn title="NIDM_0000030">nidm:'Gamma HRB'</dfn></a> is . <a title="NIDM_0000030">nidm:'Gamma HRB'</a> is a prov:Entity. 
+                    A <a title="NIDM_0000030"><dfn title="NIDM_0000030">nidm:'Gamma Basis Set'</dfn></a> is set of gamma probability density functions. <a title="NIDM_0000030">nidm:'Gamma Basis Set'</a> is a prov:Entity. 
                 </div>
                 <p></p>
-                <div class="attributes" id="attributes-nidm:'Gamma HRB'"> A <a title="NIDM_0000030">nidm:'Gamma HRB'</a> has attributes:
+                <div class="attributes" id="attributes-nidm:'Gamma Basis Set'"> A <a title="NIDM_0000030">nidm:'Gamma Basis Set'</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:'Gamma HRB'.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:'Gamma HRB'.</li>
+                    <li><span class="attribute" id="nidm:'Gamma Basis Set'.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:'Gamma Basis Set'.</li>
                       
             </section>
             <!-- nidm:'Gamma HRF' (NIDM_0000031) -->
             <section id="section-nidm:'Gamma HRF'"> 
                 <h1 label="NIDM_0000031">nidm:'Gamma HRF'</h1>
                 <div class="glossary-ref">
-                    A <a title="NIDM_0000031"><dfn title="NIDM_0000031">nidm:'Gamma HRF'</dfn></a> is . <a title="NIDM_0000031">nidm:'Gamma HRF'</a> is a prov:Entity. 
+                    A <a title="NIDM_0000031"><dfn title="NIDM_0000031">nidm:'Gamma HRF'</dfn></a> is hemodynamic response function which is a gamma probability density function. <a title="NIDM_0000031">nidm:'Gamma HRF'</a> is a prov:Entity. 
                 </div>
                 <p></p>
                 <div class="attributes" id="attributes-nidm:'Gamma HRF'"> A <a title="NIDM_0000031">nidm:'Gamma HRF'</a> has attributes:
@@ -699,7 +747,7 @@ niiri:design_matrix_id a prov:Entity , nidm_DesignMatrix: ;
             <section id="section-nidm:'Hemodynamic Response Function'"> 
                 <h1 label="NIDM_0000035">nidm:'Hemodynamic Response Function'</h1>
                 <div class="glossary-ref">
-                    A <a title="NIDM_0000035"><dfn title="NIDM_0000035">nidm:'Hemodynamic Response Function'</dfn></a> is . <a title="NIDM_0000035">nidm:'Hemodynamic Response Function'</a> is a prov:Entity. 
+                    A <a title="NIDM_0000035"><dfn title="NIDM_0000035">nidm:'Hemodynamic Response Function'</dfn></a> is hemodynamic response function basis that can on its own be used to represent the idealised hemodynamic response function. <a title="NIDM_0000035">nidm:'Hemodynamic Response Function'</a> is a prov:Entity. 
                 </div>
                 <p></p>
                 <div class="attributes" id="attributes-nidm:'Hemodynamic Response Function'"> A <a title="NIDM_0000035">nidm:'Hemodynamic Response Function'</a> has attributes:
@@ -707,28 +755,40 @@ niiri:design_matrix_id a prov:Entity , nidm_DesignMatrix: ;
                     <li><span class="attribute" id="nidm:'Hemodynamic Response Function'.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:'Hemodynamic Response Function'.</li>
                       
             </section>
-            <!-- nidm:'Hemodynamic Response Function Basis' (NIDM_0000036) -->
-            <section id="section-nidm:'Hemodynamic Response Function Basis'"> 
-                <h1 label="NIDM_0000036">nidm:'Hemodynamic Response Function Basis'</h1>
+            <!-- nidm:'Convolution Basis Set' (NIDM_0000036) -->
+            <section id="section-nidm:'Convolution Basis Set'"> 
+                <h1 label="NIDM_0000036">nidm:'Convolution Basis Set'</h1>
                 <div class="glossary-ref">
-                    A <a title="NIDM_0000036"><dfn title="NIDM_0000036">nidm:'Hemodynamic Response Function Basis'</dfn></a> is . <a title="NIDM_0000036">nidm:'Hemodynamic Response Function Basis'</a> is a prov:Entity. 
+                    A <a title="NIDM_0000036"><dfn title="NIDM_0000036">nidm:'Convolution Basis Set'</dfn></a> is . <a title="NIDM_0000036">nidm:'Convolution Basis Set'</a> is a prov:Entity. 
                 </div>
                 <p></p>
-                <div class="attributes" id="attributes-nidm:'Hemodynamic Response Function Basis'"> A <a title="NIDM_0000036">nidm:'Hemodynamic Response Function Basis'</a> has attributes:
+                <div class="attributes" id="attributes-nidm:'Convolution Basis Set'"> A <a title="NIDM_0000036">nidm:'Convolution Basis Set'</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:'Hemodynamic Response Function Basis'.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:'Hemodynamic Response Function Basis'.</li>
+                    <li><span class="attribute" id="nidm:'Convolution Basis Set'.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:'Convolution Basis Set'.</li>
                       
             </section>
             <!-- nidm:'Hemodynamic Response Function Derivative' (NIDM_0000037) -->
             <section id="section-nidm:'Hemodynamic Response Function Derivative'"> 
                 <h1 label="NIDM_0000037">nidm:'Hemodynamic Response Function Derivative'</h1>
                 <div class="glossary-ref">
-                    A <a title="NIDM_0000037"><dfn title="NIDM_0000037">nidm:'Hemodynamic Response Function Derivative'</dfn></a> is . <a title="NIDM_0000037">nidm:'Hemodynamic Response Function Derivative'</a> is a prov:Entity. 
+                    A <a title="NIDM_0000037"><dfn title="NIDM_0000037">nidm:'Hemodynamic Response Function Derivative'</dfn></a> is hemodynamic response function basis which is the derivative of an hemodynamic response function. <a title="NIDM_0000037">nidm:'Hemodynamic Response Function Derivative'</a> is a prov:Entity. 
                 </div>
                 <p></p>
                 <div class="attributes" id="attributes-nidm:'Hemodynamic Response Function Derivative'"> A <a title="NIDM_0000037">nidm:'Hemodynamic Response Function Derivative'</a> has attributes:
                 <ul>
                     <li><span class="attribute" id="nidm:'Hemodynamic Response Function Derivative'.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:'Hemodynamic Response Function Derivative'.</li>
+                      
+            </section>
+            <!-- nidm:'Sine Basis Set' (SineHRB) -->
+            <section id="section-nidm:'Sine Basis Set'"> 
+                <h1 label="SineHRB">nidm:'Sine Basis Set'</h1>
+                <div class="glossary-ref">
+                    A <a title="SineHRB"><dfn title="SineHRB">nidm:'Sine Basis Set'</dfn></a> is a set of Sine waves of differing frequencies (definition adapted from <a href="http://fsl.fmrib.ox.ac.uk/fsl/fsl4.0/feat5/detail.html)">FSL wiki</a>. <a title="SineHRB">nidm:'Sine Basis Set'</a> is a prov:Entity. 
+                </div>
+                <p></p>
+                <div class="attributes" id="attributes-nidm:'Sine Basis Set'"> A <a title="SineHRB">nidm:'Sine Basis Set'</a> has attributes:
+                <ul>
+                    <li><span class="attribute" id="nidm:'Sine Basis Set'.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:'Sine Basis Set'.</li>
                       
             </section>
             <!-- nidm:'fMRI Design Type' (fMRIDesign) -->

--- a/nidm/nidm-results/terms/README.md
+++ b/nidm/nidm-results/terms/README.md
@@ -26,6 +26,11 @@ Thank you in advance for taking part in NIDM-Results term curation!
 </tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
+    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Custom Basis Set'"> [more] </a></td>
+    <td><b>nidm:'Custom Basis Set': </b>Customised set of basis functions</td>
+</tr>
+<tr>
+    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
     <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/274">#274</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Design Matrix'"> [more] </a></td>
     <td><b>nidm:'Design Matrix': </b>A matrix of values defining the explanatory variables used in a regression model.  Each column corresponds to one explanatory variable, each row corresponds to one observation (editor: TN)</td>
 </tr>
@@ -33,6 +38,56 @@ Thank you in advance for taking part in NIDM-Results term curation!
     <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
     <td><a href="https://github.com/incf-nidash/nidm//issues?&q='Drift Model'"> [find issues/PR] </a></td>
     <td><b>nidm:'Drift Model': </b>A model used to compensate for low frequency baseline drifts when analyzing functional MRI data at the subject level</td>
+</tr>
+<tr>
+    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
+    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Finite Impulse Response Basis Set'"> [more] </a></td>
+    <td><b>nidm:'Finite Impulse Response Basis Set': </b>Set of Finite impulse response (FIR) filters, with FIR the convolution kernel is represented as a set of discrete fixed-width "impulses" (definition adapted from [FSL wiki](http://fsl.fmrib.ox.ac.uk/fsl/fsl4.0/feat5/detail.html))</td>
+</tr>
+<tr>
+    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
+    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Fourier Basis Set'"> [more] </a></td>
+    <td><b>nidm:'Fourier Basis Set': </b>Set of Fourier basis</td>
+</tr>
+<tr>
+    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
+    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Gamma Basis Set'"> [more] </a></td>
+    <td><b>nidm:'Gamma Basis Set': </b>Set of gamma probability density functions</td>
+</tr>
+<tr>
+    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
+    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Gamma Difference HRF'"> [more] </a></td>
+    <td><b>nidm:'Gamma Difference HRF': </b>Hemodynamic response function which is a difference of two gamma probability density functions</td>
+</tr>
+<tr>
+    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
+    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Gamma HRF'"> [more] </a></td>
+    <td><b>nidm:'Gamma HRF': </b>Hemodynamic response function which is a gamma probability density function</td>
+</tr>
+<tr>
+    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
+    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Gaussian HRF'"> [more] </a></td>
+    <td><b>nidm:'Gaussian HRF': </b>Hemodynamic response function which is a gaussian kernel</td>
+</tr>
+<tr>
+    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
+    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Hemodynamic Response Function Derivative'"> [more] </a></td>
+    <td><b>nidm:'Hemodynamic Response Function Derivative': </b>Hemodynamic response function basis which is the derivative of an hemodynamic response function</td>
+</tr>
+<tr>
+    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
+    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Hemodynamic Response Function'"> [more] </a></td>
+    <td><b>nidm:'Hemodynamic Response Function': </b>Hemodynamic response function basis that can on its own be used to represent the idealised hemodynamic response function</td>
+</tr>
+<tr>
+    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
+    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Linear Spline Basis Set'"> [more] </a></td>
+    <td><b>nidm:'Linear Spline Basis Set': </b>A Linear (order 1) spline, providing an estimate that is continuous over time (in contrast to a FIR basis, which is discontinuous between each time bin). This is called TENT in AFNI's 3dDeconvolve program</td>
+</tr>
+<tr>
+    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
+    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Sine Basis Set'"> [more] </a></td>
+    <td><b>nidm:'Sine Basis Set': </b>A set of Sine waves of differing frequencies (definition adapted from [FSL wiki](http://fsl.fmrib.ox.ac.uk/fsl/fsl4.0/feat5/detail.html))</td>
 </tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
@@ -46,99 +101,8 @@ Thank you in advance for taking part in NIDM-Results term curation!
 </tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q=FiniteImpulseResponseHRB"> [more] </a></td>
-    <td><b>afni:FiniteImpulseResponseHRB: </b>&lt;undefined&gt;</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a>
-Discussed with @afni-rickr in <a href="https://github.com/incf-nidash/nidm/pull/248">#248</a>: supported via GAM<br/><a href="https://github.com/incf-nidash/nidm//issues?&q=GammaHRF"> [more] </a></td>
-    <td><b>afni:GammaHRF: </b>&lt;undefined&gt;</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q=CustomHRB"> [more] </a></td>
-    <td><b>fsl:CustomHRB: </b>&lt;undefined&gt;</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q=FiniteImpulseResponseHRB"> [more] </a></td>
-    <td><b>fsl:FiniteImpulseResponseHRB: </b>&lt;undefined&gt;</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q=GammaDifferenceHRF"> [more] </a></td>
-    <td><b>fsl:GammaDifferenceHRF: </b>&lt;undefined&gt;</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q=GammaHRB"> [more] </a></td>
-    <td><b>fsl:GammaHRB: </b>&lt;undefined&gt;</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q=GammaHRF"> [more] </a></td>
-    <td><b>fsl:GammaHRF: </b>&lt;undefined&gt;</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q=GaussianHRF"> [more] </a></td>
-    <td><b>fsl:GaussianHRF: </b>&lt;undefined&gt;</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q=NoHRF"> [more] </a></td>
-    <td><b>fsl:NoHRF: </b>&lt;undefined&gt;</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q=SineHRB"> [more] </a></td>
-    <td><b>fsl:SineHRB: </b>&lt;undefined&gt;</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q=TemporalDerivative"> [more] </a></td>
-    <td><b>fsl:TemporalDerivative: </b>&lt;undefined&gt;</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
     <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/137">#137</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='FSL Results'"> [more] </a></td>
     <td><b>nidm:'FSL Results': </b>&lt;undefined&gt;</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Finite Impulse Response HRB'"> [more] </a></td>
-    <td><b>nidm:'Finite Impulse Response HRB': </b>&lt;undefined&gt;</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Gamma Difference HRF'"> [more] </a></td>
-    <td><b>nidm:'Gamma Difference HRF': </b>&lt;undefined&gt;</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Gamma HRB'"> [more] </a></td>
-    <td><b>nidm:'Gamma HRB': </b>&lt;undefined&gt;</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Gamma HRF'"> [more] </a></td>
-    <td><b>nidm:'Gamma HRF': </b>&lt;undefined&gt;</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Hemodynamic Response Function Basis'"> [more] </a></td>
-    <td><b>nidm:'Hemodynamic Response Function Basis': </b>&lt;undefined&gt;</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Hemodynamic Response Function Derivative'"> [more] </a></td>
-    <td><b>nidm:'Hemodynamic Response Function Derivative': </b>&lt;undefined&gt;</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Hemodynamic Response Function'"> [more] </a></td>
-    <td><b>nidm:'Hemodynamic Response Function': </b>&lt;undefined&gt;</td>
 </tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
@@ -154,36 +118,6 @@ Discussed with @afni-rickr in <a href="https://github.com/incf-nidash/nidm/pull/
     <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
     <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/284">#284</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='World Coordinate System'"> [more] </a></td>
     <td><b>nidm:'World Coordinate System': </b>&lt;undefined&gt;</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q=DispersionDerivative"> [more] </a></td>
-    <td><b>spm:DispersionDerivative: </b>&lt;undefined&gt;</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q=FiniteImpulseResponseHRB"> [more] </a></td>
-    <td><b>spm:FiniteImpulseResponseHRB: </b>&lt;undefined&gt;</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q=FourierHRB"> [more] </a></td>
-    <td><b>spm:FourierHRB: </b>&lt;undefined&gt;</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q=GammaDifferenceHRF"> [more] </a></td>
-    <td><b>spm:GammaDifferenceHRF: </b>&lt;undefined&gt;</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q=GammaHRB"> [more] </a></td>
-    <td><b>spm:GammaHRB: </b>&lt;undefined&gt;</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q=TemporalDerivative"> [more] </a></td>
-    <td><b>spm:TemporalDerivative: </b>&lt;undefined&gt;</td>
 </tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/yellow.png?raw=true"/>  </td>
@@ -280,6 +214,13 @@ Discussed with @afni-rickr in <a href="https://github.com/incf-nidash/nidm/pull/
 </tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
+    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='has HRF Basis'"> [more] </a></td>
+    <td><b>nidm:'has HRF Basis': </b>A property that associates a set of functions that, when convolved with the anticipated neural responses, yield a set of regressors to model the anticipated hemodynamic responses in a design matrix</td>
+    <td>nidm:NIDM_0000019 </td>
+    <td>nidm:NIDM_0000036 </td>
+</tr>
+<tr>
+    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
     <td>Discussed at <a href="https://github.com/incf-nidash/nidm/pull/299">#299</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='has fMRI Design'"> [find issues/PR] </a></td>
     <td><b>nidm:'has fMRI Design': </b>A property that associates an fMRI design to a design matrix in first-level fMRI analyses</td>
     <td>nidm:NIDM_0000019 </td>
@@ -355,13 +296,6 @@ Discussed with @afni-rickr in <a href="https://github.com/incf-nidash/nidm/pull/
     <td><b>nidm:'global Null Degree': </b>&lt;undefined&gt;</td>
     <td>spm:KConjunctionInference </td>
     <td>xsd:int </td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='has HRF Basis'"> [more] </a></td>
-    <td><b>nidm:'has HRF Basis': </b>&lt;undefined&gt;</td>
-    <td>nidm:NIDM_0000019 </td>
-    <td>nidm:NIDM_0000036 </td>
 </tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
@@ -513,6 +447,42 @@ Discussed with @afni-rickr in <a href="https://github.com/incf-nidash/nidm/pull/
 </table><h2>Individuals</h2>
 <table>
 <tr><th>Curation Status</th><th>Issue/PR</th><th>Term</th><th>Type</th></tr>
+<tr>
+    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
+    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a> and discussed in <a href="https://github.com/incf-nidash/nidm/pull/248">#248</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='AFNI's Gamma HRF'"> [more] </a></td>
+    <td><b>afni:'AFNI's Gamma HRF': </b>Hemodynamic response function which is a fixed gamma probability density function. This is the default in AFNI (-GAM option to 3ddeconvolve, or implied via afni_proc.py)</td>
+    <td>nidm:NIDM_0000031</td>
+</tr>
+<tr>
+    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
+    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='FSL's Gamma Difference HRF'"> [more] </a></td>
+    <td><b>fsl:'FSL's Gamma Difference HRF': </b>Hemodynamic response function which is a fixed difference of two gamma probability density functions - a standard positive function at normal lag, and a small, delayed, negated gamma probability density function, which attempts to model the late undershoot (definition adapted [FSL wiki](http://fsl.fmrib.ox.ac.uk/fsl/fsl4.0/feat5/detail.html)). This is the default in FSL</td>
+    <td>nidm:NIDM_0000029</td>
+</tr>
+<tr>
+    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
+    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='FSL's Temporal Derivative'"> [more] </a></td>
+    <td><b>fsl:'FSL's Temporal Derivative': </b>Hemodynamic response function basis that is the derivative with respect to time of the FSL's Gamma Difference heamodynamic response function</td>
+    <td>nidm:NIDM_0000037</td>
+</tr>
+<tr>
+    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
+    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='SPM's Canonical HRF'"> [more] </a></td>
+    <td><b>spm:'SPM's Canonical HRF': </b>Hemodynamic response function which is a fixed difference of two gamma probability density functions and is denoted by "canonical HRF" in SPM. This is the default in SPM</td>
+    <td>nidm:NIDM_0000029</td>
+</tr>
+<tr>
+    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
+    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='SPM's Dispersion Derivative'"> [more] </a></td>
+    <td><b>spm:'SPM's Dispersion Derivative': </b>Hemodynamic response function basis that is the derivative with respect to spatial dispersion of the SPM's Canonical heamodynamic response function</td>
+    <td>nidm:NIDM_0000037</td>
+</tr>
+<tr>
+    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
+    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='SPM's Temporal Derivative'"> [more] </a></td>
+    <td><b>spm:'SPM's Temporal Derivative': </b>Hemodynamic response function basis that is the derivative with respect to time of the SPM's Canonical heamodynamic response function</td>
+    <td>nidm:NIDM_0000037</td>
+</tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/orange.png?raw=true"/>  </td>
     <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/284">#284</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Colin27 Coordinate System'"> [more] </a></td>

--- a/nidm/nidm-results/terms/README.md
+++ b/nidm/nidm-results/terms/README.md
@@ -26,11 +26,6 @@ Thank you in advance for taking part in NIDM-Results term curation!
 </tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Custom Basis Set'"> [more] </a></td>
-    <td><b>nidm:'Custom Basis Set': </b>Customised set of basis functions</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
     <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/274">#274</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Design Matrix'"> [more] </a></td>
     <td><b>nidm:'Design Matrix': </b>A matrix of values defining the explanatory variables used in a regression model.  Each column corresponds to one explanatory variable, each row corresponds to one observation (editor: TN)</td>
 </tr>
@@ -41,63 +36,18 @@ Thank you in advance for taking part in NIDM-Results term curation!
 </tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Finite Impulse Response Basis Set'"> [more] </a></td>
-    <td><b>nidm:'Finite Impulse Response Basis Set': </b>Set of Finite impulse response (FIR) filters, with FIR the convolution kernel is represented as a set of discrete fixed-width "impulses" (definition adapted from [FSL wiki](http://fsl.fmrib.ox.ac.uk/fsl/fsl4.0/feat5/detail.html))</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Fourier Basis Set'"> [more] </a></td>
-    <td><b>nidm:'Fourier Basis Set': </b>Set of Fourier basis</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Gamma Basis Set'"> [more] </a></td>
-    <td><b>nidm:'Gamma Basis Set': </b>Set of gamma probability density functions</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Gamma Difference HRF'"> [more] </a></td>
-    <td><b>nidm:'Gamma Difference HRF': </b>Hemodynamic response function which is a difference of two gamma probability density functions</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Gamma HRF'"> [more] </a></td>
-    <td><b>nidm:'Gamma HRF': </b>Hemodynamic response function which is a gamma probability density function</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Gaussian HRF'"> [more] </a></td>
-    <td><b>nidm:'Gaussian HRF': </b>Hemodynamic response function which is a gaussian kernel</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Hemodynamic Response Function Derivative'"> [more] </a></td>
-    <td><b>nidm:'Hemodynamic Response Function Derivative': </b>Hemodynamic response function basis which is the derivative of an hemodynamic response function</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Hemodynamic Response Function'"> [more] </a></td>
-    <td><b>nidm:'Hemodynamic Response Function': </b>Hemodynamic response function basis that can on its own be used to represent the idealised hemodynamic response function</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Linear Spline Basis Set'"> [more] </a></td>
-    <td><b>nidm:'Linear Spline Basis Set': </b>A Linear (order 1) spline, providing an estimate that is continuous over time (in contrast to a FIR basis, which is discontinuous between each time bin). This is called TENT in AFNI's 3dDeconvolve program</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Sine Basis Set'"> [more] </a></td>
-    <td><b>nidm:'Sine Basis Set': </b>A set of Sine waves of differing frequencies (definition adapted from [FSL wiki](http://fsl.fmrib.ox.ac.uk/fsl/fsl4.0/feat5/detail.html))</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
     <td><a href="https://github.com/incf-nidash/nidm//issues?&q='SPM's DCT Drift Model'"> [find issues/PR] </a></td>
     <td><b>spm:'SPM's DCT Drift Model': </b>A drift model in which the drifts are modeled by a Discrete Cosine Transform basis added to regression model</td>
 </tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q=BLOCK"> [more] </a></td>
+    <td>Discussed at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q=BLOCK"> [find issues/PR] </a></td>
     <td><b>afni:BLOCK: </b>&lt;undefined&gt;</td>
+</tr>
+<tr>
+    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
+    <td>Discussed at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Convolution Basis Set'"> [find issues/PR] </a></td>
+    <td><b>nidm:'Convolution Basis Set': </b>&lt;undefined&gt;</td>
 </tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
@@ -449,27 +399,9 @@ Thank you in advance for taking part in NIDM-Results term curation!
 <tr><th>Curation Status</th><th>Issue/PR</th><th>Term</th><th>Type</th></tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a> and discussed in <a href="https://github.com/incf-nidash/nidm/pull/248">#248</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='AFNI's Gamma HRF'"> [more] </a></td>
-    <td><b>afni:'AFNI's Gamma HRF': </b>Hemodynamic response function which is a fixed gamma probability density function. This is the default in AFNI (-GAM option to 3ddeconvolve, or implied via afni_proc.py)</td>
-    <td>nidm:NIDM_0000031</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='FSL's Gamma Difference HRF'"> [more] </a></td>
-    <td><b>fsl:'FSL's Gamma Difference HRF': </b>Hemodynamic response function which is a fixed difference of two gamma probability density functions - a standard positive function at normal lag, and a small, delayed, negated gamma probability density function, which attempts to model the late undershoot (definition adapted [FSL wiki](http://fsl.fmrib.ox.ac.uk/fsl/fsl4.0/feat5/detail.html)). This is the default in FSL</td>
-    <td>nidm:NIDM_0000029</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
     <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='FSL's Temporal Derivative'"> [more] </a></td>
     <td><b>fsl:'FSL's Temporal Derivative': </b>Hemodynamic response function basis that is the derivative with respect to time of the FSL's Gamma Difference heamodynamic response function</td>
     <td>nidm:NIDM_0000037</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='SPM's Canonical HRF'"> [more] </a></td>
-    <td><b>spm:'SPM's Canonical HRF': </b>Hemodynamic response function which is a fixed difference of two gamma probability density functions and is denoted by "canonical HRF" in SPM. This is the default in SPM</td>
-    <td>nidm:NIDM_0000029</td>
 </tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>

--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -2318,11 +2318,11 @@ nidm:NIDM_0000036 rdf:type owl:Class ;
                   
                   rdfs:subClassOf prov:Entity ;
                   
-                  rdfs:isDefinedBy "A basis function, part of a set of functions that is convolved with the anticipated neural responses to obtain the anticipated hemodynamic responses."^^xsd:string ;
+                  rdfs:isDefinedBy "A set of functions that, when convolved with the anticipated neural responses, yield a set of regressors to model the anticipated hemodynamic responses."^^xsd:string ;
                   
                   obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
                   
-                  obo:IAO_0000114 obo:IAO_0000125 .
+                  obo:IAO_0000114 obo:IAO_0000122 .
 
 
 

--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -3437,7 +3437,7 @@ spm:GammaDifferenceHRF rdf:type nidm:NIDM_0000029 ,
                        
                        rdfs:label "SPM's Gamma Difference HRF" ;
                        
-                       obo:IAO_0000115 "Hemodynamic response function which is a fixed difference of two gamma functions and is denoted by \"canonical HRF\" in SPM. This is the default in SPM" ;
+                       obo:IAO_0000115 "Hemodynamic response function which is a fixed difference of two gamma distribution functions and is denoted by \"canonical HRF\" in SPM. This is the default in SPM" ;
                        
                        obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
                        

--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -1668,7 +1668,7 @@ afni:BLOCK rdf:type owl:Class ;
            
            prov:editorialNote "We will have to determine if afni:BLOCK is child of a more specific nidm HRFBasis sub-class."^^xsd:string ;
            
-           obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
+           obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/281" ;
            
            obo:IAO_0000114 obo:IAO_0000124 .
 
@@ -1712,9 +1712,9 @@ nidm:CustomHRB rdf:type owl:Class ;
                
                obo:IAO_0000115 "Customised set of basis functions." ;
                
-               obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
+               obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/281" ;
                
-               obo:IAO_0000114 obo:IAO_0000125 .
+               obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -1726,11 +1726,11 @@ nidm:FourierHRB rdf:type owl:Class ;
                 
                 rdfs:subClassOf nidm:NIDM_0000036 ;
                 
-                obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
+                obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/281" ;
                 
                 obo:IAO_0000115 "Set of Fourier basis." ;
                 
-                obo:IAO_0000114 obo:IAO_0000125 .
+                obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -1742,11 +1742,11 @@ nidm:GaussianHRF rdf:type owl:Class ;
                  
                  rdfs:subClassOf nidm:NIDM_0000035 ;
                  
-                 obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
+                 obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/281" ;
                  
                  obo:IAO_0000115 "Hemodynamic response function which is a gaussian kernel." ;
                  
-                 obo:IAO_0000114 obo:IAO_0000125 .
+                 obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -1760,9 +1760,9 @@ nidm:LinearSplineHRB rdf:type owl:Class ;
                      
                      obo:IAO_0000115 "A Linear (order 1) spline, providing an estimate that is continuous over time (in contrast to a FIR basis, which is discontinuous between each time bin). This is called TENT in AFNI's 3dDeconvolve program." ;
                      
-                     obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
+                     obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/281" ;
                      
-                     obo:IAO_0000114 obo:IAO_0000125 .
+                     obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -2188,9 +2188,9 @@ nidm:NIDM_0000028 rdf:type owl:Class ;
                   
                   obo:IAO_0000115 "Set of Finite impulse response (FIR) filters, with FIR the convolution kernel is represented as a set of discrete fixed-width \"impulses\" (definition adapted from [FSL wiki](http://fsl.fmrib.ox.ac.uk/fsl/fsl4.0/feat5/detail.html))" ;
                   
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/281" ;
                   
-                  obo:IAO_0000114 obo:IAO_0000125 .
+                  obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -2202,11 +2202,11 @@ nidm:NIDM_0000029 rdf:type owl:Class ;
                   
                   rdfs:subClassOf nidm:NIDM_0000035 ;
                   
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
-                  
                   obo:IAO_0000115 "Hemodynamic response function which is a difference of two gamma probability density functions." ;
                   
-                  obo:IAO_0000114 obo:IAO_0000125 .
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/281" ;
+                  
+                  obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -2220,9 +2220,9 @@ nidm:NIDM_0000030 rdf:type owl:Class ;
                   
                   obo:IAO_0000115 "Set of gamma probability density functions." ;
                   
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/281" ;
                   
-                  obo:IAO_0000114 obo:IAO_0000125 .
+                  obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -2234,11 +2234,11 @@ nidm:NIDM_0000031 rdf:type owl:Class ;
                   
                   rdfs:subClassOf nidm:NIDM_0000035 ;
                   
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/281" ;
                   
                   obo:IAO_0000115 "Hemodynamic response function which is a gamma probability density function." ;
                   
-                  obo:IAO_0000114 obo:IAO_0000125 .
+                  obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -2302,11 +2302,11 @@ nidm:NIDM_0000035 rdf:type owl:Class ;
                   
                   rdfs:subClassOf nidm:NIDM_0000036 ;
                   
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/281" ;
                   
                   obo:IAO_0000115 "Hemodynamic response function basis that can on its own be used to represent the idealised hemodynamic response function." ;
                   
-                  obo:IAO_0000114 obo:IAO_0000125 .
+                  obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -2320,9 +2320,9 @@ nidm:NIDM_0000036 rdf:type owl:Class ;
                   
                   rdfs:isDefinedBy "A set of functions that, when convolved with the anticipated neural responses, yield a set of regressors to model the anticipated hemodynamic responses."^^xsd:string ;
                   
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/281" ;
                   
-                  obo:IAO_0000114 obo:IAO_0000122 .
+                  obo:IAO_0000114 obo:IAO_0000124 .
 
 
 
@@ -2334,11 +2334,11 @@ nidm:NIDM_0000037 rdf:type owl:Class ;
                   
                   rdfs:subClassOf nidm:NIDM_0000036 ;
                   
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
-                  
                   obo:IAO_0000115 "Hemodynamic response function basis which is the derivative of an hemodynamic response function." ;
                   
-                  obo:IAO_0000114 obo:IAO_0000125 .
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/281" ;
+                  
+                  obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -2945,6 +2945,22 @@ nidm:NIDM_0000144 rdf:type owl:Class ;
 
 
 
+###  http://purl.org/nidash/nidm#SineHRB
+
+nidm:SineHRB rdf:type owl:Class ;
+             
+             rdfs:label "Sine Basis Set" ;
+             
+             rdfs:subClassOf nidm:NIDM_0000036 ;
+             
+             obo:IAO_0000115 "A set of Sine waves of differing frequencies (definition adapted from [FSL wiki](http://fsl.fmrib.ox.ac.uk/fsl/fsl4.0/feat5/detail.html))." ;
+             
+             obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/281" ;
+             
+             obo:IAO_0000114 obo:IAO_0000122 .
+
+
+
 ###  http://purl.org/nidash/nidm#fMRIDesign
 
 nidm:fMRIDesign rdf:type owl:Class ;
@@ -2958,20 +2974,6 @@ nidm:fMRIDesign rdf:type owl:Class ;
                 obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/299" ;
                 
                 obo:IAO_0000114 obo:IAO_0000122 .
-
-###  http://purl.org/nidash/nidm#SineHRB
-
-nidm:SineHRB rdf:type owl:Class ;
-             
-             rdfs:label "Sine Basis Set" ;
-             
-             rdfs:subClassOf nidm:NIDM_0000036 ;
-             
-             obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
-             
-             obo:IAO_0000115 "A set of Sine waves of differing frequencies (definition adapted from [FSL wiki](http://fsl.fmrib.ox.ac.uk/fsl/fsl4.0/feat5/detail.html))." ;
-             
-             obo:IAO_0000114 obo:IAO_0000125 .
 
 
 
@@ -3019,11 +3021,11 @@ afni:GammaHRF rdf:type nidm:NIDM_0000031 ,
               
               rdfs:label "AFNI's Gamma HRF" ;
               
-              obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281 and discussed in https://github.com/incf-nidash/nidm/pull/248" ;
-              
               obo:IAO_0000115 "Hemodynamic response function which is a fixed gamma probability density function. This is the default in AFNI (-GAM option to 3ddeconvolve, or implied via afni_proc.py)." ;
               
-              obo:IAO_0000114 obo:IAO_0000125 .
+              obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/281 and discussed in https://github.com/incf-nidash/nidm/pull/248" ;
+              
+              obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -3034,11 +3036,11 @@ fsl:GammaDifferenceHRF rdf:type nidm:NIDM_0000029 ,
                        
                        rdfs:label "FSL's Gamma Difference HRF" ;
                        
-                       obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
+                       obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/281" ;
                        
                        obo:IAO_0000115 "Hemodynamic response function which is a fixed difference of two gamma probability density functions - a standard positive function at normal lag, and a small, delayed, negated gamma probability density function, which attempts to model the late undershoot (definition adapted [FSL wiki](http://fsl.fmrib.ox.ac.uk/fsl/fsl4.0/feat5/detail.html)). This is the default in FSL." ;
                        
-                       obo:IAO_0000114 obo:IAO_0000125 .
+                       obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -3439,9 +3441,9 @@ spm:GammaDifferenceHRF rdf:type nidm:NIDM_0000029 ,
                        
                        obo:IAO_0000115 "Hemodynamic response function which is a fixed difference of two gamma probability density functions and is denoted by \"canonical HRF\" in SPM. This is the default in SPM" ;
                        
-                       obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
+                       obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/281" ;
                        
-                       obo:IAO_0000114 obo:IAO_0000125 .
+                       obo:IAO_0000114 obo:IAO_0000122 .
 
 
 

--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -187,7 +187,7 @@ nidm:NIDM_0000102 rdf:type owl:ObjectProperty ;
                   
                   obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
                   
-                  obo:IAO_0000115 "A property that associates a set of functions that, when convolved with the anticipated neural responses, yield a set of regressors to model the anticipated hemodynamic responses with a design matrix." ;
+                  obo:IAO_0000115 "A property that associates a set of functions that, when convolved with the anticipated neural responses, yield a set of regressors to model the anticipated hemodynamic responses in a design matrix." ;
                   
                   obo:IAO_0000114 obo:IAO_0000125 ;
                   

--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -1750,6 +1750,22 @@ nidm:GaussianHRF rdf:type owl:Class ;
 
 
 
+###  http://purl.org/nidash/nidm#LinearSplineHRB
+
+nidm:LinearSplineHRB rdf:type owl:Class ;
+                     
+                     rdfs:label "Linear Spline HRB" ;
+                     
+                     rdfs:subClassOf nidm:NIDM_0000036 ;
+                     
+                     obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
+                     
+                     obo:IAO_0000115 "Hemodynamic response function basis which is a linear (order 1) spline, providing a HRF estimate that is continuous over time (in contrast to a FIR basis, which is discontinuous between each time bin). This is called TENT in AFNI's 3dDeconvolve program." ;
+                     
+                     obo:IAO_0000114 obo:IAO_0000125 .
+
+
+
 ###  http://purl.org/nidash/nidm#NIDM_0000001
 
 nidm:NIDM_0000001 rdf:type owl:Class ;

--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -2218,7 +2218,7 @@ nidm:NIDM_0000030 rdf:type owl:Class ;
                   
                   rdfs:subClassOf nidm:NIDM_0000036 ;
                   
-                  obo:IAO_0000115 "Hemodynamic response function basis which is a set of Gamma functions, also denoted by \"FLOBS\" in FSL." ;
+                  obo:IAO_0000115 "Hemodynamic response function basis which is a set of gamma probability distribution functions, also denoted by \"FLOBS\" in FSL." ;
                   
                   obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
                   
@@ -3020,7 +3020,7 @@ afni:GammaHRF rdf:type nidm:NIDM_0000031 ,
               rdfs:label "AFNI's Gamma HRF" ;
               
               obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281 and discussed in https://github.com/incf-nidash/nidm/pull/248" ;
-              obo:IAO_0000115 "Hemodynamic response function which is a fixed gamma probability distribution. This is the default in AFNI (-GAM option to 3ddeconvolve, or implied via afni_proc.py)." ;
+              obo:IAO_0000115 "Hemodynamic response function which is a fixed gamma probability distribution function. This is the default in AFNI (-GAM option to 3ddeconvolve, or implied via afni_proc.py)." ;
               
               
               obo:IAO_0000114 obo:IAO_0000125 .
@@ -3036,7 +3036,7 @@ fsl:GammaDifferenceHRF rdf:type nidm:NIDM_0000029 ,
                        
                        obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
                        
-                       obo:IAO_0000115 "Hemodynamic response function which is a fixed difference of two gamma probability distribution functions - a standard positive function at normal lag, and a small, delayed, negated gamma, which attempts to model the late undershoot (definition adapted [FSL wiki](http://fsl.fmrib.ox.ac.uk/fsl/fsl4.0/feat5/detail.html)). This is the default in FSL." ;
+                       obo:IAO_0000115 "Hemodynamic response function which is a fixed difference of two gamma probability distribution functions - a standard positive function at normal lag, and a small, delayed, negated gamma probability distribution function, which attempts to model the late undershoot (definition adapted [FSL wiki](http://fsl.fmrib.ox.ac.uk/fsl/fsl4.0/feat5/detail.html)). This is the default in FSL." ;
                        
                        obo:IAO_0000114 obo:IAO_0000125 .
 
@@ -3422,7 +3422,7 @@ spm:DispersionDerivative rdf:type nidm:NIDM_0000037 ,
                          
                          rdfs:label "SPM's Dispersion Derivative" ;
                          
-                         obo:IAO_0000115 "Hemodynamic response function basis that is the derivative with respect to spatial dispersion of the SPM's Gamma Difference heamodynamic response function." ;
+                         obo:IAO_0000115 "Hemodynamic response function basis that is the derivative with respect to spatial dispersion of the SPM's Canonical heamodynamic response function." ;
                          
                          obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
                          
@@ -3437,7 +3437,7 @@ spm:GammaDifferenceHRF rdf:type nidm:NIDM_0000029 ,
                        
                        rdfs:label "SPM's Canonical HRF" ;
                        
-                       obo:IAO_0000115 "Hemodynamic response function which is a fixed difference of two gamma distribution functions and is denoted by \"canonical HRF\" in SPM. This is the default in SPM" ;
+                       obo:IAO_0000115 "Hemodynamic response function which is a fixed difference of two gamma probability distribution functions and is denoted by \"canonical HRF\" in SPM. This is the default in SPM" ;
                        
                        obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
                        
@@ -3452,7 +3452,7 @@ spm:TemporalDerivative rdf:type nidm:NIDM_0000037 ,
                        
                        rdfs:label "SPM's Temporal Derivative" ;
                        
-                       obo:IAO_0000115 "Hemodynamic response function basis that is the derivative with respect to time of the SPM's Gamma Difference heamodynamic response function." ;
+                       obo:IAO_0000115 "Hemodynamic response function basis that is the derivative with respect to time of the SPM's Canonical heamodynamic response function." ;
                        
                        obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
                        

--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -2204,7 +2204,7 @@ nidm:NIDM_0000029 rdf:type owl:Class ;
                   
                   obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
                   
-                  obo:IAO_0000115 "Hemodynamic response function which is a difference of two gamma probability distribution functions." ;
+                  obo:IAO_0000115 "Hemodynamic response function which is a difference of two gamma probability density functions." ;
                   
                   obo:IAO_0000114 obo:IAO_0000125 .
 
@@ -2218,7 +2218,7 @@ nidm:NIDM_0000030 rdf:type owl:Class ;
                   
                   rdfs:subClassOf nidm:NIDM_0000036 ;
                   
-                  obo:IAO_0000115 "Set of gamma probability distribution functions, also denoted by \"FLOBS\" in FSL." ;
+                  obo:IAO_0000115 "Set of gamma probability density functions, also denoted by \"FLOBS\" in FSL." ;
                   
                   obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
                   
@@ -2236,7 +2236,7 @@ nidm:NIDM_0000031 rdf:type owl:Class ;
                   
                   obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
                   
-                  obo:IAO_0000115 "Hemodynamic response function which is a gamma probability distribution function." ;
+                  obo:IAO_0000115 "Hemodynamic response function which is a gamma probability density function." ;
                   
                   obo:IAO_0000114 obo:IAO_0000125 .
 
@@ -3021,7 +3021,7 @@ afni:GammaHRF rdf:type nidm:NIDM_0000031 ,
               
               obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281 and discussed in https://github.com/incf-nidash/nidm/pull/248" ;
               
-              obo:IAO_0000115 "Hemodynamic response function which is a fixed gamma probability distribution function. This is the default in AFNI (-GAM option to 3ddeconvolve, or implied via afni_proc.py)." ;
+              obo:IAO_0000115 "Hemodynamic response function which is a fixed gamma probability density function. This is the default in AFNI (-GAM option to 3ddeconvolve, or implied via afni_proc.py)." ;
               
               obo:IAO_0000114 obo:IAO_0000125 .
 
@@ -3036,7 +3036,7 @@ fsl:GammaDifferenceHRF rdf:type nidm:NIDM_0000029 ,
                        
                        obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
                        
-                       obo:IAO_0000115 "Hemodynamic response function which is a fixed difference of two gamma probability distribution functions - a standard positive function at normal lag, and a small, delayed, negated gamma probability distribution function, which attempts to model the late undershoot (definition adapted [FSL wiki](http://fsl.fmrib.ox.ac.uk/fsl/fsl4.0/feat5/detail.html)). This is the default in FSL." ;
+                       obo:IAO_0000115 "Hemodynamic response function which is a fixed difference of two gamma probability density functions - a standard positive function at normal lag, and a small, delayed, negated gamma probability density function, which attempts to model the late undershoot (definition adapted [FSL wiki](http://fsl.fmrib.ox.ac.uk/fsl/fsl4.0/feat5/detail.html)). This is the default in FSL." ;
                        
                        obo:IAO_0000114 obo:IAO_0000125 .
 
@@ -3437,7 +3437,7 @@ spm:GammaDifferenceHRF rdf:type nidm:NIDM_0000029 ,
                        
                        rdfs:label "SPM's Canonical HRF" ;
                        
-                       obo:IAO_0000115 "Hemodynamic response function which is a fixed difference of two gamma probability distribution functions and is denoted by \"canonical HRF\" in SPM. This is the default in SPM" ;
+                       obo:IAO_0000115 "Hemodynamic response function which is a fixed difference of two gamma probability density functions and is denoted by \"canonical HRF\" in SPM. This is the default in SPM" ;
                        
                        obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
                        

--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -187,7 +187,7 @@ nidm:NIDM_0000102 rdf:type owl:ObjectProperty ;
                   
                   obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
                   
-                  obo:IAO_0000115 "Hemodynamic response function basis used to model the anticipated hemodynamic response." ;
+                  obo:IAO_0000115 "A property that associates a set of functions that, when convolved with the anticipated neural responses, yield a set of regressors to model the anticipated hemodynamic responses with a design matrix." ;
                   
                   obo:IAO_0000114 obo:IAO_0000125 ;
                   
@@ -1706,13 +1706,13 @@ fsl:GaussianRunningLineDriftModel rdf:type owl:Class ;
 
 nidm:CustomHRB rdf:type owl:Class ;
                
-               rdfs:label "Custom HRB" ;
+               rdfs:label "Custom Basis Set" ;
                
                rdfs:subClassOf nidm:NIDM_0000036 ;
                
-               obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
+               obo:IAO_0000115 "Customised set of basis functions." ;
                
-               obo:IAO_0000115 "Hemodynamic response function basis which is a customised set of basis functions." ;
+               obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
                
                obo:IAO_0000114 obo:IAO_0000125 .
 
@@ -1722,13 +1722,13 @@ nidm:CustomHRB rdf:type owl:Class ;
 
 nidm:FourierHRB rdf:type owl:Class ;
                 
-                rdfs:label "Fourier HRB" ;
+                rdfs:label "Fourier Basis Set" ;
                 
                 rdfs:subClassOf nidm:NIDM_0000036 ;
                 
                 obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
                 
-                obo:IAO_0000115 "Hemodynamic response function basis which is a set of Fourier basis." ;
+                obo:IAO_0000115 "Set of Fourier basis." ;
                 
                 obo:IAO_0000114 obo:IAO_0000125 .
 
@@ -1737,7 +1737,7 @@ nidm:FourierHRB rdf:type owl:Class ;
 ###  http://purl.org/nidash/nidm#GaussianHRF
 
 nidm:GaussianHRF rdf:type owl:Class ;
-
+                 
                  rdfs:label "Gaussian HRF" ;
                  
                  rdfs:subClassOf nidm:NIDM_0000035 ;
@@ -1754,13 +1754,13 @@ nidm:GaussianHRF rdf:type owl:Class ;
 
 nidm:LinearSplineHRB rdf:type owl:Class ;
                      
-                     rdfs:label "Linear Spline HRB" ;
+                     rdfs:label "Linear Spline Basis Set" ;
                      
                      rdfs:subClassOf nidm:NIDM_0000036 ;
                      
-                     obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
+                     obo:IAO_0000115 "A Linear (order 1) spline, providing an estimate that is continuous over time (in contrast to a FIR basis, which is discontinuous between each time bin). This is called TENT in AFNI's 3dDeconvolve program." ;
                      
-                     obo:IAO_0000115 "Hemodynamic response function basis which is a linear (order 1) spline, providing a HRF estimate that is continuous over time (in contrast to a FIR basis, which is discontinuous between each time bin). This is called TENT in AFNI's 3dDeconvolve program." ;
+                     obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
                      
                      obo:IAO_0000114 obo:IAO_0000125 .
 
@@ -2182,11 +2182,11 @@ nidm:NIDM_0000027 rdf:type owl:Class ;
 
 nidm:NIDM_0000028 rdf:type owl:Class ;
                   
-                  rdfs:label "Finite Impulse Response HRB" ;
+                  rdfs:label "Finite Impulse Response Basis Set" ;
                   
                   rdfs:subClassOf nidm:NIDM_0000036 ;
                   
-                  obo:IAO_0000115 "Hemodynamic response function basis which is a set of Finite impulse response (FIR) filters, with FIR the convolution kernel is represented as a set of discrete fixed-width \"impulses\" (definition adapted from [FSL wiki](http://fsl.fmrib.ox.ac.uk/fsl/fsl4.0/feat5/detail.html))" ;
+                  obo:IAO_0000115 "Set of Finite impulse response (FIR) filters, with FIR the convolution kernel is represented as a set of discrete fixed-width \"impulses\" (definition adapted from [FSL wiki](http://fsl.fmrib.ox.ac.uk/fsl/fsl4.0/feat5/detail.html))" ;
                   
                   obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
                   
@@ -2214,11 +2214,11 @@ nidm:NIDM_0000029 rdf:type owl:Class ;
 
 nidm:NIDM_0000030 rdf:type owl:Class ;
                   
-                  rdfs:label "Gamma HRB" ;
+                  rdfs:label "Gamma Basis Set" ;
                   
                   rdfs:subClassOf nidm:NIDM_0000036 ;
                   
-                  obo:IAO_0000115 "Hemodynamic response function basis which is a set of gamma probability distribution functions, also denoted by \"FLOBS\" in FSL." ;
+                  obo:IAO_0000115 "Set of gamma probability distribution functions, also denoted by \"FLOBS\" in FSL." ;
                   
                   obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
                   
@@ -2314,7 +2314,7 @@ nidm:NIDM_0000035 rdf:type owl:Class ;
 
 nidm:NIDM_0000036 rdf:type owl:Class ;
                   
-                  rdfs:label "Hemodynamic Response Function Basis" ;
+                  rdfs:label "Convolution Basis Set" ;
                   
                   rdfs:subClassOf prov:Entity ;
                   
@@ -2963,13 +2963,13 @@ nidm:fMRIDesign rdf:type owl:Class ;
 
 nidm:SineHRB rdf:type owl:Class ;
              
-             rdfs:label "Sine HRB" ;
+             rdfs:label "Sine Basis Set" ;
              
              rdfs:subClassOf nidm:NIDM_0000036 ;
              
              obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
              
-             obo:IAO_0000115 "Hemodynamic response function basis which is a set of Sine waves of differing frequencies (definition adapted from [FSL wiki](http://fsl.fmrib.ox.ac.uk/fsl/fsl4.0/feat5/detail.html))." ;
+             obo:IAO_0000115 "A set of Sine waves of differing frequencies (definition adapted from [FSL wiki](http://fsl.fmrib.ox.ac.uk/fsl/fsl4.0/feat5/detail.html))." ;
              
              obo:IAO_0000114 obo:IAO_0000125 .
 
@@ -3020,8 +3020,8 @@ afni:GammaHRF rdf:type nidm:NIDM_0000031 ,
               rdfs:label "AFNI's Gamma HRF" ;
               
               obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281 and discussed in https://github.com/incf-nidash/nidm/pull/248" ;
-              obo:IAO_0000115 "Hemodynamic response function which is a fixed gamma probability distribution function. This is the default in AFNI (-GAM option to 3ddeconvolve, or implied via afni_proc.py)." ;
               
+              obo:IAO_0000115 "Hemodynamic response function which is a fixed gamma probability distribution function. This is the default in AFNI (-GAM option to 3ddeconvolve, or implied via afni_proc.py)." ;
               
               obo:IAO_0000114 obo:IAO_0000125 .
 

--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -187,7 +187,9 @@ nidm:NIDM_0000102 rdf:type owl:ObjectProperty ;
                   
                   obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
                   
-                  obo:IAO_0000114 obo:IAO_0000124 ;
+                  obo:IAO_0000115 "Hemodynamic response function basis used to model the anticipated hemodynamic response." ;
+                  
+                  obo:IAO_0000114 obo:IAO_0000125 ;
                   
                   rdfs:domain nidm:NIDM_0000019 ;
                   
@@ -1672,31 +1674,6 @@ afni:BLOCK rdf:type owl:Class ;
 
 
 
-###  http://purl.org/nidash/afni#FiniteImpulseResponseHRB
-
-afni:FiniteImpulseResponseHRB rdf:type owl:Class ;
-                              
-                              rdfs:subClassOf nidm:NIDM_0000028 ;
-                              
-                              rdfs:comment "Discussed with @afni-rickr in https://github.com/incf-nidash/nidm/pull/248: in AFNI, FIR is supported via the TENT basis function set."^^xsd:string ;
-                              
-                              obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
-                              
-                              obo:IAO_0000114 obo:IAO_0000124 .
-
-
-
-###  http://purl.org/nidash/afni#GammaHRF
-
-afni:GammaHRF rdf:type owl:Class ;
-              
-              rdfs:subClassOf nidm:NIDM_0000031 ;
-              
-              obo:IAO_0000116 """Under discussion at https://github.com/incf-nidash/nidm/issues/281
-Discussed with @afni-rickr in https://github.com/incf-nidash/nidm/pull/248: supported via GAM""" .
-
-
-
 ###  http://purl.org/nidash/afni#LegendrePolynomialDriftModel
 
 afni:LegendrePolynomialDriftModel rdf:type owl:Class ;
@@ -1708,76 +1685,6 @@ afni:LegendrePolynomialDriftModel rdf:type owl:Class ;
                                   obo:IAO_0000115 "A drift model in which the drifts are modeled by a Legendre orthogonal polynomial basis added to the regression model" ;
                                   
                                   obo:IAO_0000114 obo:IAO_0000125 .
-
-
-
-###  http://purl.org/nidash/fsl#CustomHRB
-
-fsl:CustomHRB rdf:type owl:Class ;
-              
-              rdfs:subClassOf nidm:NIDM_0000036 ;
-              
-              obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
-              
-              obo:IAO_0000114 obo:IAO_0000124 .
-
-
-
-###  http://purl.org/nidash/fsl#FiniteImpulseResponseHRB
-
-fsl:FiniteImpulseResponseHRB rdf:type owl:Class ;
-                             
-                             rdfs:subClassOf nidm:NIDM_0000028 ;
-                             
-                             obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
-                             
-                             obo:IAO_0000114 obo:IAO_0000124 .
-
-
-
-###  http://purl.org/nidash/fsl#GammaDifferenceHRF
-
-fsl:GammaDifferenceHRF rdf:type owl:Class ;
-                       
-                       rdfs:subClassOf nidm:NIDM_0000029 ;
-                       
-                       obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
-                       
-                       obo:IAO_0000114 obo:IAO_0000124 .
-
-
-
-###  http://purl.org/nidash/fsl#GammaHRB
-
-fsl:GammaHRB rdf:type owl:Class ;
-             
-             rdfs:subClassOf nidm:NIDM_0000030 ;
-             
-             obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" .
-
-
-
-###  http://purl.org/nidash/fsl#GammaHRF
-
-fsl:GammaHRF rdf:type owl:Class ;
-             
-             rdfs:subClassOf nidm:NIDM_0000031 ;
-             
-             obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
-             
-             obo:IAO_0000114 obo:IAO_0000124 .
-
-
-
-###  http://purl.org/nidash/fsl#GaussianHRF
-
-fsl:GaussianHRF rdf:type owl:Class ;
-                
-                rdfs:subClassOf nidm:NIDM_0000035 ;
-                
-                obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
-                
-                obo:IAO_0000114 obo:IAO_0000124 .
 
 
 
@@ -1795,39 +1702,51 @@ fsl:GaussianRunningLineDriftModel rdf:type owl:Class ;
 
 
 
-###  http://purl.org/nidash/fsl#NoHRF
+###  http://purl.org/nidash/nidm#CustomHRB
 
-fsl:NoHRF rdf:type owl:Class ;
-          
-          rdfs:subClassOf nidm:NIDM_0000035 ;
-          
-          obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
-          
-          obo:IAO_0000114 obo:IAO_0000124 .
-
-
-
-###  http://purl.org/nidash/fsl#SineHRB
-
-fsl:SineHRB rdf:type owl:Class ;
-            
-            rdfs:subClassOf nidm:NIDM_0000036 ;
-            
-            obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
-            
-            obo:IAO_0000114 obo:IAO_0000124 .
+nidm:CustomHRB rdf:type owl:Class ;
+               
+               rdfs:label "Custom HRB" ;
+               
+               rdfs:subClassOf nidm:NIDM_0000036 ;
+               
+               obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
+               
+               obo:IAO_0000115 "Hemodynamic response function basis which is a customised set of basis functions." ;
+               
+               obo:IAO_0000114 obo:IAO_0000125 .
 
 
 
-###  http://purl.org/nidash/fsl#TemporalDerivative
+###  http://purl.org/nidash/nidm#FourierHRB
 
-fsl:TemporalDerivative rdf:type owl:Class ;
-                       
-                       rdfs:subClassOf nidm:NIDM_0000037 ;
-                       
-                       obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
-                       
-                       obo:IAO_0000114 obo:IAO_0000124 .
+nidm:FourierHRB rdf:type owl:Class ;
+                
+                rdfs:label "Fourier HRB" ;
+                
+                rdfs:subClassOf nidm:NIDM_0000036 ;
+                
+                obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
+                
+                obo:IAO_0000115 "Hemodynamic response function basis which is a set of Fourier basis." ;
+                
+                obo:IAO_0000114 obo:IAO_0000125 .
+
+
+
+###  http://purl.org/nidash/nidm#GaussianHRF
+
+nidm:GaussianHRF rdf:type owl:Class ;
+
+                 rdfs:label "Gaussian HRF" ;
+                 
+                 rdfs:subClassOf nidm:NIDM_0000035 ;
+                 
+                 obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
+                 
+                 obo:IAO_0000115 "Hemodynamic response function which is a gaussian kernel." ;
+                 
+                 obo:IAO_0000114 obo:IAO_0000125 .
 
 
 
@@ -2251,9 +2170,11 @@ nidm:NIDM_0000028 rdf:type owl:Class ;
                   
                   rdfs:subClassOf nidm:NIDM_0000036 ;
                   
+                  obo:IAO_0000115 "Hemodynamic response function basis which is a set of Finite impulse response (FIR) filters, with FIR the convolution kernel is represented as a set of discrete fixed-width \"impulses\" (definition adapted from [FSL wiki](http://fsl.fmrib.ox.ac.uk/fsl/fsl4.0/feat5/detail.html))" ;
+                  
                   obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
                   
-                  obo:IAO_0000114 obo:IAO_0000124 .
+                  obo:IAO_0000114 obo:IAO_0000125 .
 
 
 
@@ -2267,7 +2188,9 @@ nidm:NIDM_0000029 rdf:type owl:Class ;
                   
                   obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
                   
-                  obo:IAO_0000114 obo:IAO_0000124 .
+                  obo:IAO_0000115 "Hemodynamic response function which is a linear combination of two gamma functions." ;
+                  
+                  obo:IAO_0000114 obo:IAO_0000125 .
 
 
 
@@ -2279,9 +2202,11 @@ nidm:NIDM_0000030 rdf:type owl:Class ;
                   
                   rdfs:subClassOf nidm:NIDM_0000036 ;
                   
+                  obo:IAO_0000115 "Hemodynamic response function basis which is a set of Gamma functions, also denoted by \"FLOBS\" in FSL." ;
+                  
                   obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
                   
-                  obo:IAO_0000114 obo:IAO_0000124 .
+                  obo:IAO_0000114 obo:IAO_0000125 .
 
 
 
@@ -2293,7 +2218,11 @@ nidm:NIDM_0000031 rdf:type owl:Class ;
                   
                   rdfs:subClassOf nidm:NIDM_0000035 ;
                   
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" .
+                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
+                  
+                  obo:IAO_0000115 "Hemodynamic response function which is a gamma function." ;
+                  
+                  obo:IAO_0000114 obo:IAO_0000125 .
 
 
 
@@ -2359,7 +2288,9 @@ nidm:NIDM_0000035 rdf:type owl:Class ;
                   
                   obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
                   
-                  obo:IAO_0000114 obo:IAO_0000124 .
+                  obo:IAO_0000115 "Hemodynamic response function basis that can on its own be used to represent the idealised hemodynamic response function." ;
+                  
+                  obo:IAO_0000114 obo:IAO_0000125 .
 
 
 
@@ -2371,11 +2302,11 @@ nidm:NIDM_0000036 rdf:type owl:Class ;
                   
                   rdfs:subClassOf prov:Entity ;
                   
-                  rdfs:isDefinedBy "The set of functions to convolve anticipated neural responses to obtain anticipated hemodynamic responses."^^xsd:string ;
+                  rdfs:isDefinedBy "A basis function, part of a set of functions that is convolved with the anticipated neural responses to obtain the anticipated hemodynamic responses."^^xsd:string ;
                   
                   obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
                   
-                  obo:IAO_0000114 obo:IAO_0000124 .
+                  obo:IAO_0000114 obo:IAO_0000125 .
 
 
 
@@ -2389,7 +2320,9 @@ nidm:NIDM_0000037 rdf:type owl:Class ;
                   
                   obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
                   
-                  obo:IAO_0000114 obo:IAO_0000124 .
+                  obo:IAO_0000115 "Hemodynamic response function basis which is the derivative of an hemodynamic response function." ;
+                  
+                  obo:IAO_0000114 obo:IAO_0000125 .
 
 
 
@@ -3010,6 +2943,20 @@ nidm:fMRIDesign rdf:type owl:Class ;
                 
                 obo:IAO_0000114 obo:IAO_0000122 .
 
+###  http://purl.org/nidash/nidm#SineHRB
+
+nidm:SineHRB rdf:type owl:Class ;
+             
+             rdfs:label "Sine HRB" ;
+             
+             rdfs:subClassOf nidm:NIDM_0000036 ;
+             
+             obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
+             
+             obo:IAO_0000115 "Hemodynamic response function basis which is a set of Sine waves of differing frequencies (definition adapted from [FSL wiki](http://fsl.fmrib.ox.ac.uk/fsl/fsl4.0/feat5/detail.html))." ;
+             
+             obo:IAO_0000114 obo:IAO_0000125 .
+
 
 
 ###  http://purl.org/nidash/spm#DCTDriftModel
@@ -3023,66 +2970,6 @@ spm:DCTDriftModel rdf:type owl:Class ;
                   obo:IAO_0000115 "A drift model in which the drifts are modeled by a Discrete Cosine Transform basis added to regression model" ;
                   
                   obo:IAO_0000114 obo:IAO_0000125 .
-
-
-
-###  http://purl.org/nidash/spm#DispersionDerivative
-
-spm:DispersionDerivative rdf:type owl:Class ;
-                         
-                         rdfs:subClassOf nidm:NIDM_0000037 ;
-                         
-                         obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
-                         
-                         obo:IAO_0000114 obo:IAO_0000124 .
-
-
-
-###  http://purl.org/nidash/spm#FiniteImpulseResponseHRB
-
-spm:FiniteImpulseResponseHRB rdf:type owl:Class ;
-                             
-                             rdfs:subClassOf nidm:NIDM_0000028 ;
-                             
-                             obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
-                             
-                             obo:IAO_0000114 obo:IAO_0000124 .
-
-
-
-###  http://purl.org/nidash/spm#FourierHRB
-
-spm:FourierHRB rdf:type owl:Class ;
-               
-               rdfs:subClassOf nidm:NIDM_0000036 ;
-               
-               obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
-               
-               obo:IAO_0000114 obo:IAO_0000124 .
-
-
-
-###  http://purl.org/nidash/spm#GammaDifferenceHRF
-
-spm:GammaDifferenceHRF rdf:type owl:Class ;
-                       
-                       rdfs:subClassOf nidm:NIDM_0000029 ;
-                       
-                       obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
-                       
-                       obo:IAO_0000114 obo:IAO_0000124 .
-
-
-
-###  http://purl.org/nidash/spm#GammaHRB
-
-spm:GammaHRB rdf:type owl:Class ;
-             
-             rdfs:subClassOf nidm:NIDM_0000030 ;
-             
-             obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
-             
-             obo:IAO_0000114 obo:IAO_0000124 .
 
 
 
@@ -3100,17 +2987,57 @@ spm:KConjunctionInference rdf:type owl:Class ;
 
 
 
-###  http://purl.org/nidash/spm#TemporalDerivative
 
-spm:TemporalDerivative rdf:type owl:Class ;
+
+#################################################################
+#
+#    Individuals
+#
+#################################################################
+
+
+###  http://purl.org/nidash/afni#GammaHRF
+
+afni:GammaHRF rdf:type nidm:NIDM_0000031 ,
+                       owl:NamedIndividual ;
+              
+              rdfs:label "AFNI's Gamma HRF" ;
+              
+              obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281 and discussed in https://github.com/incf-nidash/nidm/pull/248" ;
+              
+              obo:IAO_0000115 "Hemodynamic response function which is a pre-defined gamma function. This is the default in AFNI (-GAM option to 3ddeconvolve, or implied via afni_proc.py)." ;
+              
+              obo:IAO_0000114 obo:IAO_0000125 .
+
+
+
+###  http://purl.org/nidash/fsl#GammaDifferenceHRF
+
+fsl:GammaDifferenceHRF rdf:type nidm:NIDM_0000029 ,
+                                owl:NamedIndividual ;
                        
-                       rdfs:subClassOf nidm:NIDM_0000037 ;
+                       rdfs:label "FSL's Gamma Difference HRF" ;
                        
                        obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
                        
-                       obo:IAO_0000114 obo:IAO_0000124 .
+                       obo:IAO_0000115 "Hemodynamic response function which is a mixture of two gamma functions - a standard positive function at normal lag, and a small, delayed, inverted gamma, which attempts to model the late undershoot (definition adapted from [FSL wiki](http://fsl.fmrib.ox.ac.uk/fsl/fsl4.0/feat5/detail.html)). This is the default in FSL." ;
+                       
+                       obo:IAO_0000114 obo:IAO_0000125 .
 
 
+
+###  http://purl.org/nidash/fsl#TemporalDerivative
+
+fsl:TemporalDerivative rdf:type nidm:NIDM_0000037 ,
+                                owl:NamedIndividual ;
+                       
+                       rdfs:label "FSL's Temporal Derivative" ;
+                       
+                       obo:IAO_0000115 "Hemodynamic response function basis that is the derivative with respect to time of the FSL's Gamma Difference heamodynamic response function." ;
+                       
+                       obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
+                       
+                       obo:IAO_0000114 obo:IAO_0000125 .
 
 
 
@@ -3469,6 +3396,51 @@ nidm:NIDM_0000130 rdf:type nidm:NIDM_0000080 ,
                   obo:IAO_0000115 "A pair of voxels are 6-Connected if they share a face." ;
                   
                   obo:IAO_0000114 obo:IAO_0000122 .
+
+
+
+###  http://purl.org/nidash/spm#DispersionDerivative
+
+spm:DispersionDerivative rdf:type nidm:NIDM_0000037 ,
+                                  owl:NamedIndividual ;
+                         
+                         rdfs:label "SPM's Dispersion Derivative" ;
+                         
+                         obo:IAO_0000115 "Hemodynamic response function basis that is the derivative with respect to spatial dispersion of the SPM's Gamma Difference heamodynamic response function." ;
+                         
+                         obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
+                         
+                         obo:IAO_0000114 obo:IAO_0000125 .
+
+
+
+###  http://purl.org/nidash/spm#GammaDifferenceHRF
+
+spm:GammaDifferenceHRF rdf:type nidm:NIDM_0000029 ,
+                                owl:NamedIndividual ;
+                       
+                       rdfs:label "SPM's Gamma Difference HRF" ;
+                       
+                       obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
+                       
+                       obo:IAO_0000115 "Hemodynamic response function which is a linear combination two gamma functions and is denoted by \"canonical HRF\" in SPM. This is the default in SPM." ;
+                       
+                       obo:IAO_0000114 obo:IAO_0000125 .
+
+
+
+###  http://purl.org/nidash/spm#TemporalDerivative
+
+spm:TemporalDerivative rdf:type nidm:NIDM_0000037 ,
+                                owl:NamedIndividual ;
+                       
+                       rdfs:label "SPM's Temporal Derivative" ;
+                       
+                       obo:IAO_0000115 "Hemodynamic response function basis that is the derivative with respect to time of the SPM's Gamma Difference heamodynamic response function." ;
+                       
+                       obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
+                       
+                       obo:IAO_0000114 obo:IAO_0000125 .
 
 
 

--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -3020,7 +3020,7 @@ afni:GammaHRF rdf:type nidm:NIDM_0000031 ,
               rdfs:label "AFNI's Gamma HRF" ;
               
               obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281 and discussed in https://github.com/incf-nidash/nidm/pull/248" ;
-              obo:IAO_0000115 "Hemodynamic response function which is a pre-defined gamma probability distribution. This is the default in AFNI (-GAM option to 3ddeconvolve, or implied via afni_proc.py)." ;
+              obo:IAO_0000115 "Hemodynamic response function which is a fixed gamma probability distribution. This is the default in AFNI (-GAM option to 3ddeconvolve, or implied via afni_proc.py)." ;
               
               
               obo:IAO_0000114 obo:IAO_0000125 .

--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -2218,7 +2218,7 @@ nidm:NIDM_0000030 rdf:type owl:Class ;
                   
                   rdfs:subClassOf nidm:NIDM_0000036 ;
                   
-                  obo:IAO_0000115 "Set of gamma probability density functions, also denoted by \"FLOBS\" in FSL." ;
+                  obo:IAO_0000115 "Set of gamma probability density functions." ;
                   
                   obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
                   

--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -2188,7 +2188,7 @@ nidm:NIDM_0000029 rdf:type owl:Class ;
                   
                   obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
                   
-                  obo:IAO_0000115 "Hemodynamic response function which is a linear combination of two gamma functions." ;
+                  obo:IAO_0000115 "Hemodynamic response function which is a difference of two gamma probability distribution functions." ;
                   
                   obo:IAO_0000114 obo:IAO_0000125 .
 
@@ -2220,7 +2220,7 @@ nidm:NIDM_0000031 rdf:type owl:Class ;
                   
                   obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
                   
-                  obo:IAO_0000115 "Hemodynamic response function which is a gamma function." ;
+                  obo:IAO_0000115 "Hemodynamic response function which is a gamma probability distribution function." ;
                   
                   obo:IAO_0000114 obo:IAO_0000125 .
 
@@ -3004,8 +3004,8 @@ afni:GammaHRF rdf:type nidm:NIDM_0000031 ,
               rdfs:label "AFNI's Gamma HRF" ;
               
               obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281 and discussed in https://github.com/incf-nidash/nidm/pull/248" ;
+              obo:IAO_0000115 "Hemodynamic response function which is a pre-defined gamma probability distribution. This is the default in AFNI (-GAM option to 3ddeconvolve, or implied via afni_proc.py)." ;
               
-              obo:IAO_0000115 "Hemodynamic response function which is a pre-defined gamma function. This is the default in AFNI (-GAM option to 3ddeconvolve, or implied via afni_proc.py)." ;
               
               obo:IAO_0000114 obo:IAO_0000125 .
 
@@ -3020,7 +3020,7 @@ fsl:GammaDifferenceHRF rdf:type nidm:NIDM_0000029 ,
                        
                        obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
                        
-                       obo:IAO_0000115 "Hemodynamic response function which is a mixture of two gamma functions - a standard positive function at normal lag, and a small, delayed, inverted gamma, which attempts to model the late undershoot (definition adapted from [FSL wiki](http://fsl.fmrib.ox.ac.uk/fsl/fsl4.0/feat5/detail.html)). This is the default in FSL." ;
+                       obo:IAO_0000115 "Hemodynamic response function which is a fixed difference of two gamma probability distribution functions - a standard positive function at normal lag, and a small, delayed, negated gamma, which attempts to model the late undershoot (definition adapted [FSL wiki](http://fsl.fmrib.ox.ac.uk/fsl/fsl4.0/feat5/detail.html)). This is the default in FSL." ;
                        
                        obo:IAO_0000114 obo:IAO_0000125 .
 
@@ -3421,9 +3421,9 @@ spm:GammaDifferenceHRF rdf:type nidm:NIDM_0000029 ,
                        
                        rdfs:label "SPM's Gamma Difference HRF" ;
                        
-                       obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
+                       obo:IAO_0000115 "Hemodynamic response function which is a fixed difference of two gamma functions and is denoted by \"canonical HRF\" in SPM. This is the default in SPM" ;
                        
-                       obo:IAO_0000115 "Hemodynamic response function which is a linear combination two gamma functions and is denoted by \"canonical HRF\" in SPM. This is the default in SPM." ;
+                       obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/281" ;
                        
                        obo:IAO_0000114 obo:IAO_0000125 .
 

--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -3435,7 +3435,7 @@ spm:DispersionDerivative rdf:type nidm:NIDM_0000037 ,
 spm:GammaDifferenceHRF rdf:type nidm:NIDM_0000029 ,
                                 owl:NamedIndividual ;
                        
-                       rdfs:label "SPM's Gamma Difference HRF" ;
+                       rdfs:label "SPM's Canonical HRF" ;
                        
                        obo:IAO_0000115 "Hemodynamic response function which is a fixed difference of two gamma distribution functions and is denoted by \"canonical HRF\" in SPM. This is the default in SPM" ;
                        


### PR DESCRIPTION
Following #248, this issue is open to discuss the definitions of the terms used to model the hemodynamic response function (HRF):

First, let's define the parent class and its associated object property:
 - **nidm:HemodynamicResponseFunctionBasis**: A basis function, part of a set of functions that is convolved with the anticipated neural responses to obtain the anticipated hemodynamic responses. (adapted from the definition suggested by @jbpoline in #248).
 - **nidm:hasHRFBasis**: Hemodynamic response function basis used to model the anticipated hemodynamic response.

Definitions for children of *nidm:HemodynamicResponseFunctionBasis*:
- **nidm:HemodynamicResponseFunction**: Hemodynamic response function basis that can on its own be used to represent the idealised hemodynamic response function.
 - **nidm:GammaDifferenceHRF**: Hemodynamic response function which is a linear combination of two Gamma functions.
   - **fsl:GammaDifferenceHRF**:  Hemodynamic response function which is a mixture of two Gamma functions - a standard positive function at normal lag, and a small, delayed, inverted Gamma, which attempts to model the late undershoot (definition adapted from http://fsl.fmrib.ox.ac.uk/fsl/fsl4.0/feat5/detail.html). This is the default in FSL.
    - **spm:GammaDifferenceHRF**: Hemodynamic response function which is a linear combination two Gamma functions and is denoted by "canonical HRF" in SPM. This is the default in SPM.
 - **nidm:GammaHRF**: Hemodynamic response function which is a Gamma function.
   - **afni:GammaHRF**: Hemodynamic response function which is a pre-defined Gamma function. This is the default in AFNI (-GAM option to 3ddeconvolve, or implied via afni_proc.py).
    - ~~**fsl:GammaHRF**: Hemodynamic response function basis that is a Gamma variate (in fact a normalisation of the probability density function of the Gamma function); width and lag can be altered (definition adapted from http://fsl.fmrib.ox.ac.uk/fsl/fsl4.0/feat5/detail.html).~~
 - **nidm:GaussianHRF** ~~**fsl:GaussianHRF**~~: Hemodynamic response function which is a gaussian kernel.
 - ~~fsl:NoHRF~~: 

- **nidm:HemodynamicResponseFunctionDerivative**: Hemodynamic response function basis which is the derivative of an hemodynamic response function.
 - **fsl:TemporalDerivative**: Hemodynamic response function basis that is the derivative with respect to time of the FSL's Gamma Difference heamodynamic response function.
 - **spm:DispersionDerivative**: Hemodynamic response function basis that is the derivative with respect to spatial dispersion of the SPM's Gamma Difference heamodynamic response function.
 - **spm:TemporalDerivative**: Hemodynamic response function basis that is the derivative with respect to time of the SPM's Gamma Difference heamodynamic response function.

- **nidm:FiniteImpulseResponseHRB** Hemodynamic response function basis which is a set of Finite impulse response (FIR) filters, with FIR the convolution kernel is represented as a set of discrete fixed-width "impulses" (definition adapted from http://fsl.fmrib.ox.ac.uk/fsl/fsl4.0/feat5/detail.html), denoted by TENT in AFNI.
 - ~~afni:FiniteImpulseResponseHRB~~
 - ~~fsl:FiniteImpulseResponseHRB~~
 - ~~spm:FiniteImpulseResponseHRB~~
- **nidm:GammaHRB**: Hemodynamic response function basis which is a set of Gamma functions, also denoted by "FLOBS" in FSL.
 - ~~**fsl:GammaHRB**: Hemodynamic response function basis which is a set of Gamma variates of different widths and lags, also denoted by "FLOBS" in FSL (definition adapted from http://fsl.fmrib.ox.ac.uk/fsl/fsl4.0/feat5/detail.html).~~
 - ~~**spm:GammaHRB**: Hemodynamic response function basis which is a set of Gamma functions; window length and order can be altered.~~


- **nidm:FourierHRB**: Hemodynamic response function basis which is a set of Fourier basis.
  - ~~**spm:FourierHRB**: Hemodynamic response function basis which is a set of Fourier basis; window length and order can be altered.~~

- **nidm:CustomHRB**: Hemodynamic response function basis which is a customised set of basis functions.
  - ~~**fsl:CustomHRB**: Hemodynamic response function basis which is a customised set of basis functions, setup in a plain text file with one column for each basis function, sampled at the temporal resolution of 0.05s  (definition adapted from http://fsl.fmrib.ox.ac.uk/fsl/fsl4.0/feat5/detail.html).~~
- **nidm:SineHRB** ~~**fsl:SineHRB**~~: Hemodynamic response function basis which is a set of Sine waves of differing frequencies (definition adapted from http://fsl.fmrib.ox.ac.uk/fsl/fsl4.0/feat5/detail.html).

(Not sure about **afni:BLOCK**)

As presented above, I am proposing to reserve spm- fsl- and afni-specific terms for pre-defined functions (e.g. SPM canonical HRF, FSL double gamma, afni GAM), these will be defined as individuals.

How do you feel about those definitions?