### PR TITLE
Definition of "noise spatial model" terms

### DIFF
--- a/doc/content/specs/nidm-results_dev.html
+++ b/doc/content/specs/nidm-results_dev.html
@@ -741,76 +741,76 @@ niiri:design_matrix_id a prov:Entity , nidm_DesignMatrix: ;
                 <ul>
                     <li><span class="attribute" id="nidm:'Error Model'.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:'Error Model'.</li>
                      
-                        <li><a title="NIDM_0000089"><dfn title="NIDM_0000089">nidm:'dependence Spatial Model'</dfn></a></span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME.(range <a title="NIDM_0000071">nidm:'Spatial Model'</a> such as <a title="NIDM_0000072">nidm:'Spatially Global Model'</a>, <a title="NIDM_0000073">nidm:'Spatially Local Model'</a>, <a title="NIDM_0000074">nidm:'Spatially Regularized Model'</a>)</li> 
+                        <li><a title="NIDM_0000089"><dfn title="NIDM_0000089">nidm:'dependence Map-Wise Dependence'</dfn></a></span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property that associates an Error Parameter Map-Wise Dependence to the dependence of an error model.(range <a title="NIDM_0000071">nidm:'Error Parameter Map-Wise Dependence'</a> such as <a title="NIDM_0000072">nidm:'Constant Parameter'</a>, <a title="NIDM_0000073">nidm:'Independent Parameter'</a>, <a title="NIDM_0000074">nidm:'Regularized Parameter'</a>)</li> 
                         <li><a title="NIDM_0000094"><dfn title="NIDM_0000094">nidm:'error Variance Homogeneous'</dfn></a></span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> a boolean value reflecting how the variance of the error is modeled during parameter estimation; TRUE for constant variance over all observations in the model, FALSE for heterogeneous variance.(range <a title="boolean" href ="http://www.w3.org/2001/XMLSchema#boolean">xsd:boolean</a>)</li> 
                         <li><a title="NIDM_0000100"><dfn title="NIDM_0000100">nidm:'has Error Dependence'</dfn></a></span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property that associates an ErrorDependence with an ErrorModel.(range <a title="NIDM_0000021">nidm:'Error Dependence'</a> such as <a title="NIDM_0000003">nidm:'Arbitrarily Correlated Error'</a>, <a title="NIDM_0000010">nidm:'Compound Symmetric Error'</a>, <a title="NIDM_0000024">nidm:'Exchangeable Error'</a>, <a title="NIDM_0000048">nidm:'Independent Error'</a>, <a title="NIDM_0000069">nidm:'Serially Correlated Error'</a>)</li> 
                         <li><a title="NIDM_0000101"><dfn title="NIDM_0000101">nidm:'has Error Distribution'</dfn></a></span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property that associates an ErrorDistribution with an ErrorModel.(range <a title="NIDM_0000022">nidm:'Error Distribution'</a> such as <a title="NIDM_0000005">nidm:'Binomial Distribution'</a>, <a title="NIDM_0000032">nidm:'Gaussian Distribution'</a>, <a title="NIDM_0000058">nidm:'Non Parametric Distribution'</a>, <a title="NIDM_0000059">nidm:'Non Parametric Symmetric Distribution'</a>, <a title="NIDM_0000065">nidm:'Poisson Distribution'</a>)</li> 
-                        <li><a title="NIDM_0000126"><dfn title="NIDM_0000126">nidm:'variance Spatial Model'</dfn></a></span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME.(range <a title="NIDM_0000071">nidm:'Spatial Model'</a> such as <a title="NIDM_0000072">nidm:'Spatially Global Model'</a>, <a title="NIDM_0000073">nidm:'Spatially Local Model'</a>, <a title="NIDM_0000074">nidm:'Spatially Regularized Model'</a>)</li>        
+                        <li><a title="NIDM_0000126"><dfn title="NIDM_0000126">nidm:'variance Map-Wise Dependence'</dfn></a></span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property that associates an Error Parameter Map-Wise Dependence to the variance of an error model.(range <a title="NIDM_0000071">nidm:'Error Parameter Map-Wise Dependence'</a> such as <a title="NIDM_0000072">nidm:'Constant Parameter'</a>, <a title="NIDM_0000073">nidm:'Independent Parameter'</a>, <a title="NIDM_0000074">nidm:'Regularized Parameter'</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>@prefix nidm_ErrorModel: &lt;http://purl.org/nidash/nidm#NIDM_0000023&gt; .
 @prefix nidm_hasErrorDistribution: &lt;http://purl.org/nidash/nidm#NIDM_0000101&gt; .
 @prefix nidm_GaussianDistribution: &lt;http://purl.org/nidash/nidm#NIDM_0000032&gt; .
 @prefix nidm_errorVarianceHomogeneous: &lt;http://purl.org/nidash/nidm#NIDM_0000094&gt; .
-@prefix nidm_varianceSpatialModel: &lt;http://purl.org/nidash/nidm#NIDM_0000126&gt; .
-@prefix nidm_SpatiallyLocalModel: &lt;http://purl.org/nidash/nidm#NIDM_0000073&gt; .
+@prefix nidm_varianceMapWiseDependence: &lt;http://purl.org/nidash/nidm#NIDM_0000126&gt; .
+@prefix nidm_IndependentParameter: &lt;http://purl.org/nidash/nidm#NIDM_0000073&gt; .
 @prefix nidm_hasErrorDependence: &lt;http://purl.org/nidash/nidm#NIDM_0000100&gt; .
 @prefix nidm_IndependentError: &lt;http://purl.org/nidash/nidm#NIDM_0000048&gt; .
-@prefix nidm_dependenceSpatialModel: &lt;http://purl.org/nidash/nidm#NIDM_0000089&gt; .
+@prefix nidm_dependenceMapWiseDependence: &lt;http://purl.org/nidash/nidm#NIDM_0000089&gt; .
 
 
 niiri:error_model_id a prov:Entity , nidm_ErrorModel: ;
     nidm_hasErrorDistribution: nidm_GaussianDistribution: ;
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
-    nidm_varianceSpatialModel: nidm_SpatiallyLocalModel: ;
+    nidm_varianceMapWiseDependence: nidm_IndependentParameter: ;
     nidm_hasErrorDependence: nidm_IndependentError: ;
-    nidm_dependenceSpatialModel: nidm_SpatiallyLocalModel: .</pre>
-            <!-- nidm:'Spatial Model' (NIDM_0000071) -->
-            <section id="section-nidm:'Spatial Model'"> 
-                <h1 label="NIDM_0000071">nidm:'Spatial Model'</h1>
+    nidm_dependenceMapWiseDependence: nidm_IndependentParameter: .</pre>
+            <!-- nidm:'Error Parameter Map-Wise Dependence' (NIDM_0000071) -->
+            <section id="section-nidm:'Error Parameter Map-Wise Dependence'"> 
+                <h1 label="NIDM_0000071">nidm:'Error Parameter Map-Wise Dependence'</h1>
                 <div class="glossary-ref">
-                    A <a title="NIDM_0000071"><dfn title="NIDM_0000071">nidm:'Spatial Model'</dfn></a> is fIXME. <a title="NIDM_0000071">nidm:'Spatial Model'</a> is a prov:Entity. 
+                    A <a title="NIDM_0000071"><dfn title="NIDM_0000071">nidm:'Error Parameter Map-Wise Dependence'</dfn></a> is map-wise dependence structure of a parameter in the error model (i.e. variance or dependence parameter). For example, whether a temporal autocorrelation parameter is estimated at each element separately, estimated using data in a local neighbourhood, or estimated using all elements in the map. <a title="NIDM_0000071">nidm:'Error Parameter Map-Wise Dependence'</a> is a prov:Entity. 
                 </div>
                 <p></p>
-                <div class="attributes" id="attributes-nidm:'Spatial Model'"> A <a title="NIDM_0000071">nidm:'Spatial Model'</a> has attributes:
+                <div class="attributes" id="attributes-nidm:'Error Parameter Map-Wise Dependence'"> A <a title="NIDM_0000071">nidm:'Error Parameter Map-Wise Dependence'</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:'Spatial Model'.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:'Spatial Model'.</li>
+                    <li><span class="attribute" id="nidm:'Error Parameter Map-Wise Dependence'.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:'Error Parameter Map-Wise Dependence'.</li>
                       
             </section>
-            <!-- nidm:'Spatially Global Model' (NIDM_0000072) -->
-            <section id="section-nidm:'Spatially Global Model'"> 
-                <h1 label="NIDM_0000072">nidm:'Spatially Global Model'</h1>
+            <!-- nidm:'Constant Parameter' (NIDM_0000072) -->
+            <section id="section-nidm:'Constant Parameter'"> 
+                <h1 label="NIDM_0000072">nidm:'Constant Parameter'</h1>
                 <div class="glossary-ref">
-                    A <a title="NIDM_0000072"><dfn title="NIDM_0000072">nidm:'Spatially Global Model'</dfn></a> is fIXME. <a title="NIDM_0000072">nidm:'Spatially Global Model'</a> is a prov:Entity. 
+                    A <a title="NIDM_0000072"><dfn title="NIDM_0000072">nidm:'Constant Parameter'</dfn></a> is parameter estimated as constant over a entire set of elements considered (e.g. those in the analysis mask). <a title="NIDM_0000072">nidm:'Constant Parameter'</a> is a prov:Entity. 
                 </div>
                 <p></p>
-                <div class="attributes" id="attributes-nidm:'Spatially Global Model'"> A <a title="NIDM_0000072">nidm:'Spatially Global Model'</a> has attributes:
+                <div class="attributes" id="attributes-nidm:'Constant Parameter'"> A <a title="NIDM_0000072">nidm:'Constant Parameter'</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:'Spatially Global Model'.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:'Spatially Global Model'.</li>
+                    <li><span class="attribute" id="nidm:'Constant Parameter'.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:'Constant Parameter'.</li>
                       
             </section>
-            <!-- nidm:'Spatially Local Model' (NIDM_0000073) -->
-            <section id="section-nidm:'Spatially Local Model'"> 
-                <h1 label="NIDM_0000073">nidm:'Spatially Local Model'</h1>
+            <!-- nidm:'Independent Parameter' (NIDM_0000073) -->
+            <section id="section-nidm:'Independent Parameter'"> 
+                <h1 label="NIDM_0000073">nidm:'Independent Parameter'</h1>
                 <div class="glossary-ref">
-                    A <a title="NIDM_0000073"><dfn title="NIDM_0000073">nidm:'Spatially Local Model'</dfn></a> is fIXME. <a title="NIDM_0000073">nidm:'Spatially Local Model'</a> is a prov:Entity. 
+                    A <a title="NIDM_0000073"><dfn title="NIDM_0000073">nidm:'Independent Parameter'</dfn></a> is parameter whose estimation at a given element does not depend on any other element. <a title="NIDM_0000073">nidm:'Independent Parameter'</a> is a prov:Entity. 
                 </div>
                 <p></p>
-                <div class="attributes" id="attributes-nidm:'Spatially Local Model'"> A <a title="NIDM_0000073">nidm:'Spatially Local Model'</a> has attributes:
+                <div class="attributes" id="attributes-nidm:'Independent Parameter'"> A <a title="NIDM_0000073">nidm:'Independent Parameter'</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:'Spatially Local Model'.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:'Spatially Local Model'.</li>
+                    <li><span class="attribute" id="nidm:'Independent Parameter'.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:'Independent Parameter'.</li>
                       
             </section>
-            <!-- nidm:'Spatially Regularized Model' (NIDM_0000074) -->
-            <section id="section-nidm:'Spatially Regularized Model'"> 
-                <h1 label="NIDM_0000074">nidm:'Spatially Regularized Model'</h1>
+            <!-- nidm:'Regularized Parameter' (NIDM_0000074) -->
+            <section id="section-nidm:'Regularized Parameter'"> 
+                <h1 label="NIDM_0000074">nidm:'Regularized Parameter'</h1>
                 <div class="glossary-ref">
-                    A <a title="NIDM_0000074"><dfn title="NIDM_0000074">nidm:'Spatially Regularized Model'</dfn></a> is fIXME. <a title="NIDM_0000074">nidm:'Spatially Regularized Model'</a> is a prov:Entity. 
+                    A <a title="NIDM_0000074"><dfn title="NIDM_0000074">nidm:'Regularized Parameter'</dfn></a> is parameter whose estimation at a given element depends on a local neighborhood of elements. <a title="NIDM_0000074">nidm:'Regularized Parameter'</a> is a prov:Entity. 
                 </div>
                 <p></p>
-                <div class="attributes" id="attributes-nidm:'Spatially Regularized Model'"> A <a title="NIDM_0000074">nidm:'Spatially Regularized Model'</a> has attributes:
+                <div class="attributes" id="attributes-nidm:'Regularized Parameter'"> A <a title="NIDM_0000074">nidm:'Regularized Parameter'</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="nidm:'Spatially Regularized Model'.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:'Spatially Regularized Model'.</li>
+                    <li><span class="attribute" id="nidm:'Regularized Parameter'.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:'Regularized Parameter'.</li>
                       
             </section>
             <!-- nidm:'Arbitrarily Correlated Error' (NIDM_0000003) -->

--- a/nidm/nidm-results/fsl/example001/fsl_nidm.provn
+++ b/nidm/nidm-results/fsl/example001/fsl_nidm.provn
@@ -1,10 +1,11 @@
 document
-prefix nidm_SpatiallyRegularizedModel <http://purl.org/nidash/nidm#NIDM_0000074>
 prefix nidm_ExtentThreshold <http://purl.org/nidash/nidm#NIDM_0000026>
 prefix obo <http://purl.obolibrary.org/obo/>
 prefix pre_0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 prefix nidm_effectDegreesOfFreedom <http://purl.org/nidash/nidm#NIDM_0000091>
+prefix nidm_dependenceMapWiseDependence <http://purl.org/nidash/nidm#NIDM_0000089>
 prefix nidm_grandMeanScaling <http://purl.org/nidash/nidm#NIDM_0000096>
+prefix nidm_RegularizedParameter <http://purl.org/nidash/nidm#NIDM_0000074>
 prefix nidm_voxel26connected <http://purl.org/nidash/nidm#NIDM_0000129>
 prefix xsd <http://www.w3.org/2001/XMLSchema>
 prefix nidm_PeakDefinitionCriteria <http://purl.org/nidash/nidm#NIDM_0000063>
@@ -33,7 +34,6 @@ prefix nidm_SignificantCluster <http://purl.org/nidash/nidm#NIDM_0000070>
 prefix nidm_ContrastStandardErrorMap <http://purl.org/nidash/nidm#NIDM_0000013>
 prefix nidm_Inference <http://purl.org/nidash/nidm#NIDM_0000049>
 prefix nidm_DisplayMaskMap <http://purl.org/nidash/nidm#NIDM_0000020>
-prefix nidm_varianceSpatialModel <http://purl.org/nidash/nidm#NIDM_0000126>
 prefix obo_Zstatistic <http://purl.obolibrary.org/obo/STATO_0000376>
 prefix nidm_version <http://purl.org/nidash/nidm#NIDM_0000127>
 prefix nidm_withEstimationMethod <http://purl.org/nidash/nidm#NIDM_0000134>
@@ -72,7 +72,6 @@ prefix rdfs <http://www.w3.org/2000/01/rdf-schema#>
 prefix nidm_ContrastMap <http://purl.org/nidash/nidm#NIDM_0000002>
 prefix nidm_pValueFWER <http://purl.org/nidash/nidm#NIDM_0000115>
 prefix nidm_coordinate <http://purl.org/nidash/nidm#NIDM_0000086>
-prefix nidm_SpatiallyLocalModel <http://purl.org/nidash/nidm#NIDM_0000073>
 prefix nidm_hasErrorDependence <http://purl.org/nidash/nidm#NIDM_0000100>
 prefix nidm_clusterLabelId <http://purl.org/nidash/nidm#NIDM_0000082>
 prefix nidm_ContrastVarianceMap <http://purl.org/nidash/nidm#NIDM_0000135>
@@ -82,12 +81,13 @@ prefix nidm_OneTailedTest <http://purl.org/nidash/nidm#NIDM_0000060>
 prefix nidm_MaskMap <http://purl.org/nidash/nidm#NIDM_0000054>
 prefix nidm_voxelSize <http://purl.org/nidash/nidm#NIDM_0000131>
 prefix nidm_GrandMeanMap <http://purl.org/nidash/nidm#NIDM_0000033>
+prefix nidm_IndependentParameter <http://purl.org/nidash/nidm#NIDM_0000073>
 prefix nidm_randomFieldStationarity <http://purl.org/nidash/nidm#NIDM_0000120>
 prefix nidm_hasDriftModel <http://purl.org/nidash/nidm#NIDM_0000088>
 prefix nidm_SeriallyCorrelatedError <http://purl.org/nidash/nidm#NIDM_0000069>
-prefix nidm_dependenceSpatialModel <http://purl.org/nidash/nidm#NIDM_0000089>
 prefix nidm_voxelUnits <http://purl.org/nidash/nidm#NIDM_0000133>
 prefix nidm_ContrastWeights <http://purl.org/nidash/nidm#NIDM_0000014>
+prefix nidm_varianceMapWiseDependence <http://purl.org/nidash/nidm#NIDM_0000126>
 prefix nidm_userSpecifiedThresholdType <http://purl.org/nidash/nidm#NIDM_0000125>
 prefix nidm_SubjectCoordinateSystem <http://purl.org/nidash/nidm#NIDM_0000077>
 prefix nidm_ErrorModel <http://purl.org/nidash/nidm#NIDM_0000023>

--- a/nidm/nidm-results/fsl/example001/fsl_nidm.ttl
+++ b/nidm/nidm-results/fsl/example001/fsl_nidm.ttl
@@ -44,12 +44,12 @@
 @prefix nidm_hasErrorDistribution: <http://purl.org/nidash/nidm#NIDM_0000101> .
 @prefix nidm_GaussianDistribution: <http://purl.org/nidash/nidm#NIDM_0000032> .
 @prefix nidm_errorVarianceHomogeneous: <http://purl.org/nidash/nidm#NIDM_0000094> .
-@prefix nidm_varianceSpatialModel: <http://purl.org/nidash/nidm#NIDM_0000126> .
-@prefix nidm_SpatiallyLocalModel: <http://purl.org/nidash/nidm#NIDM_0000073> .
+@prefix nidm_varianceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000126> .
+@prefix nidm_IndependentParameter: <http://purl.org/nidash/nidm#NIDM_0000073> .
 @prefix nidm_hasErrorDependence: <http://purl.org/nidash/nidm#NIDM_0000100> .
 @prefix nidm_SeriallyCorrelatedError: <http://purl.org/nidash/nidm#NIDM_0000069> .
-@prefix nidm_dependenceSpatialModel: <http://purl.org/nidash/nidm#NIDM_0000089> .
-@prefix nidm_SpatiallyRegularizedModel: <http://purl.org/nidash/nidm#NIDM_0000074> .
+@prefix nidm_dependenceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000089> .
+@prefix nidm_RegularizedParameter: <http://purl.org/nidash/nidm#NIDM_0000074> .
 @prefix nidm_ClusterCenterOfGravity: <http://purl.org/nidash/nidm#NIDM_0000140> .
 @prefix nidm_ContrastMap: <http://purl.org/nidash/nidm#NIDM_0000002> .
 @prefix nidm_Coordinate: <http://purl.org/nidash/nidm#NIDM_0000015> .
@@ -163,9 +163,9 @@ niiri:display_map_id_1 a prov:Entity , nidm_DisplayMaskMap: ;
 niiri:error_model_id a prov:Entity , nidm_ErrorModel: ;
     nidm_hasErrorDistribution: nidm_GaussianDistribution: ;
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
-    nidm_varianceSpatialModel: nidm_SpatiallyLocalModel: ;
+    nidm_varianceMapWiseDependence: nidm_IndependentParameter: ;
     nidm_hasErrorDependence: nidm_SeriallyCorrelatedError: ;
-    nidm_dependenceSpatialModel: nidm_SpatiallyRegularizedModel: .
+    nidm_dependenceMapWiseDependence: nidm_RegularizedParameter: .
 
 niiri:center_of_gravity_1 a prov:Entity , nidm_ClusterCenterOfGravity: ;
 	rdfs:label "Center of gravity 1" ;

--- a/nidm/nidm-results/fsl/fsl_results.provn
+++ b/nidm/nidm-results/fsl/fsl_results.provn
@@ -3,6 +3,7 @@ prefix nidm_ExtentThreshold <http://purl.org/nidash/nidm#NIDM_0000026>
 prefix obo <http://purl.obolibrary.org/obo/>
 prefix pre_0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 prefix nidm_effectDegreesOfFreedom <http://purl.org/nidash/nidm#NIDM_0000091>
+prefix nidm_dependenceMapWiseDependence <http://purl.org/nidash/nidm#NIDM_0000089>
 prefix nidm_grandMeanScaling <http://purl.org/nidash/nidm#NIDM_0000096>
 prefix xsd <http://www.w3.org/2001/XMLSchema>
 prefix nidm_PeakDefinitionCriteria <http://purl.org/nidash/nidm#NIDM_0000063>
@@ -31,7 +32,6 @@ prefix nidm_SignificantCluster <http://purl.org/nidash/nidm#NIDM_0000070>
 prefix nidm_ContrastStandardErrorMap <http://purl.org/nidash/nidm#NIDM_0000013>
 prefix nidm_Inference <http://purl.org/nidash/nidm#NIDM_0000049>
 prefix nidm_DisplayMaskMap <http://purl.org/nidash/nidm#NIDM_0000020>
-prefix nidm_varianceSpatialModel <http://purl.org/nidash/nidm#NIDM_0000126>
 prefix obo_Zstatistic <http://purl.obolibrary.org/obo/STATO_0000376>
 prefix nidm_version <http://purl.org/nidash/nidm#NIDM_0000127>
 prefix nidm_withEstimationMethod <http://purl.org/nidash/nidm#NIDM_0000134>
@@ -70,7 +70,6 @@ prefix rdfs <http://www.w3.org/2000/01/rdf-schema#>
 prefix nidm_ContrastMap <http://purl.org/nidash/nidm#NIDM_0000002>
 prefix nidm_pValueFWER <http://purl.org/nidash/nidm#NIDM_0000115>
 prefix nidm_coordinate <http://purl.org/nidash/nidm#NIDM_0000086>
-prefix nidm_SpatiallyLocalModel <http://purl.org/nidash/nidm#NIDM_0000073>
 prefix nidm_hasErrorDependence <http://purl.org/nidash/nidm#NIDM_0000100>
 prefix nidm_clusterLabelId <http://purl.org/nidash/nidm#NIDM_0000082>
 prefix nidm_voxel18connected <http://purl.org/nidash/nidm#NIDM_0000128>
@@ -82,12 +81,13 @@ prefix nidm_MaskMap <http://purl.org/nidash/nidm#NIDM_0000054>
 prefix nidm_voxelSize <http://purl.org/nidash/nidm#NIDM_0000131>
 prefix obo_ordinaryleastsquaresestimation <http://purl.obolibrary.org/obo/STATO_0000370>
 prefix nidm_GrandMeanMap <http://purl.org/nidash/nidm#NIDM_0000033>
+prefix nidm_IndependentParameter <http://purl.org/nidash/nidm#NIDM_0000073>
 prefix nidm_IndependentError <http://purl.org/nidash/nidm#NIDM_0000048>
 prefix nidm_randomFieldStationarity <http://purl.org/nidash/nidm#NIDM_0000120>
-prefix nidm_dependenceSpatialModel <http://purl.org/nidash/nidm#NIDM_0000089>
 prefix nidm_voxelUnits <http://purl.org/nidash/nidm#NIDM_0000133>
 prefix nidm_ContrastWeights <http://purl.org/nidash/nidm#NIDM_0000014>
 prefix nidm_userSpecifiedThresholdType <http://purl.org/nidash/nidm#NIDM_0000125>
+prefix nidm_varianceMapWiseDependence <http://purl.org/nidash/nidm#NIDM_0000126>
 prefix nidm_ErrorModel <http://purl.org/nidash/nidm#NIDM_0000023>
 prefix nidm_maskedMedian <http://purl.org/nidash/nidm#NIDM_0000107>
 prefix nidm_hasErrorDistribution <http://purl.org/nidash/nidm#NIDM_0000101>

--- a/nidm/nidm-results/fsl/fsl_results.ttl
+++ b/nidm/nidm-results/fsl/fsl_results.ttl
@@ -41,11 +41,11 @@
 @prefix nidm_hasErrorDistribution: <http://purl.org/nidash/nidm#NIDM_0000101> .
 @prefix nidm_GaussianDistribution: <http://purl.org/nidash/nidm#NIDM_0000032> .
 @prefix nidm_errorVarianceHomogeneous: <http://purl.org/nidash/nidm#NIDM_0000094> .
-@prefix nidm_varianceSpatialModel: <http://purl.org/nidash/nidm#NIDM_0000126> .
-@prefix nidm_SpatiallyLocalModel: <http://purl.org/nidash/nidm#NIDM_0000073> .
+@prefix nidm_varianceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000126> .
+@prefix nidm_IndependentParameter: <http://purl.org/nidash/nidm#NIDM_0000073> .
 @prefix nidm_hasErrorDependence: <http://purl.org/nidash/nidm#NIDM_0000100> .
 @prefix nidm_IndependentError: <http://purl.org/nidash/nidm#NIDM_0000048> .
-@prefix nidm_dependenceSpatialModel: <http://purl.org/nidash/nidm#NIDM_0000089> .
+@prefix nidm_dependenceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000089> .
 @prefix nidm_ClusterCenterOfGravity: <http://purl.org/nidash/nidm#NIDM_0000140> .
 @prefix nidm_ContrastMap: <http://purl.org/nidash/nidm#NIDM_0000002> .
 @prefix nidm_Coordinate: <http://purl.org/nidash/nidm#NIDM_0000015> .
@@ -162,9 +162,9 @@ niiri:display_map_id a prov:Entity , nidm_DisplayMaskMap: ;
 niiri:error_model_id a prov:Entity , nidm_ErrorModel: ;
     nidm_hasErrorDistribution: nidm_GaussianDistribution: ;
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
-    nidm_varianceSpatialModel: nidm_SpatiallyLocalModel: ;
+    nidm_varianceMapWiseDependence: nidm_IndependentParameter: ;
     nidm_hasErrorDependence: nidm_IndependentError: ;
-    nidm_dependenceSpatialModel: nidm_SpatiallyLocalModel: .
+    nidm_dependenceMapWiseDependence: nidm_IndependentParameter: .
 
 niiri:center_of_gravity_1 a prov:Entity , nidm_ClusterCenterOfGravity: ;
 	rdfs:label "Center of gravity 1" ;

--- a/nidm/nidm-results/spm/example001/example001_spm_results.provn
+++ b/nidm/nidm-results/spm/example001/example001_spm_results.provn
@@ -3,6 +3,7 @@ prefix nidm_ExtentThreshold <http://purl.org/nidash/nidm#NIDM_0000026>
 prefix obo <http://purl.obolibrary.org/obo/>
 prefix pre_0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 prefix nidm_effectDegreesOfFreedom <http://purl.org/nidash/nidm#NIDM_0000091>
+prefix nidm_dependenceMapWiseDependence <http://purl.org/nidash/nidm#NIDM_0000089>
 prefix nidm_grandMeanScaling <http://purl.org/nidash/nidm#NIDM_0000096>
 prefix xsd <http://www.w3.org/2001/XMLSchema>
 prefix nidm_PeakDefinitionCriteria <http://purl.org/nidash/nidm#NIDM_0000063>
@@ -30,7 +31,6 @@ prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
 prefix nidm_SignificantCluster <http://purl.org/nidash/nidm#NIDM_0000070>
 prefix nidm_ContrastStandardErrorMap <http://purl.org/nidash/nidm#NIDM_0000013>
 prefix nidm_Inference <http://purl.org/nidash/nidm#NIDM_0000049>
-prefix nidm_varianceSpatialModel <http://purl.org/nidash/nidm#NIDM_0000126>
 prefix nidm_version <http://purl.org/nidash/nidm#NIDM_0000127>
 prefix nidm_withEstimationMethod <http://purl.org/nidash/nidm#NIDM_0000134>
 prefix nidm_StatisticMap <http://purl.org/nidash/nidm#NIDM_0000076>
@@ -63,6 +63,7 @@ prefix nidm_errorVarianceHomogeneous <http://purl.org/nidash/nidm#NIDM_0000094>
 prefix neurolex <http://neurolex.org/wiki/>
 prefix nidm_objectModel <http://purl.org/nidash/nidm#NIDM_0000113>
 prefix nidm_maxNumberOfPeaksPerCluster <http://purl.org/nidash/nidm#NIDM_0000108>
+prefix nidm_ConstantParameter <http://purl.org/nidash/nidm#NIDM_0000072>
 prefix nidm_pValue <http://purl.org/nidash/nidm#NIDM_0000114>
 prefix nidm_ExcursionSetMap <http://purl.org/nidash/nidm#NIDM_0000025>
 prefix spm <http://purl.org/nidash/spm#>
@@ -77,7 +78,6 @@ prefix rdfs <http://www.w3.org/2000/01/rdf-schema#>
 prefix nidm_ContrastMap <http://purl.org/nidash/nidm#NIDM_0000002>
 prefix nidm_pValueFWER <http://purl.org/nidash/nidm#NIDM_0000115>
 prefix nidm_coordinate <http://purl.org/nidash/nidm#NIDM_0000086>
-prefix nidm_SpatiallyLocalModel <http://purl.org/nidash/nidm#NIDM_0000073>
 prefix nidm_hasErrorDependence <http://purl.org/nidash/nidm#NIDM_0000100>
 prefix nidm_clusterLabelId <http://purl.org/nidash/nidm#NIDM_0000082>
 prefix nidm_ReselsPerVoxelMap <http://purl.org/nidash/nidm#NIDM_0000144>
@@ -89,14 +89,14 @@ prefix nidm_OneTailedTest <http://purl.org/nidash/nidm#NIDM_0000060>
 prefix nidm_voxelSize <http://purl.org/nidash/nidm#NIDM_0000131>
 prefix nidm_MaskMap <http://purl.org/nidash/nidm#NIDM_0000054>
 prefix nidm_GrandMeanMap <http://purl.org/nidash/nidm#NIDM_0000033>
+prefix nidm_IndependentParameter <http://purl.org/nidash/nidm#NIDM_0000073>
 prefix nidm_MNICoordinateSystem <http://purl.org/nidash/nidm#NIDM_0000051>
 prefix nidm_randomFieldStationarity <http://purl.org/nidash/nidm#NIDM_0000120>
 prefix nidm_hasDriftModel <http://purl.org/nidash/nidm#NIDM_0000088>
 prefix nidm_SeriallyCorrelatedError <http://purl.org/nidash/nidm#NIDM_0000069>
-prefix nidm_dependenceSpatialModel <http://purl.org/nidash/nidm#NIDM_0000089>
-prefix nidm_SpatiallyGlobalModel <http://purl.org/nidash/nidm#NIDM_0000072>
 prefix nidm_voxelUnits <http://purl.org/nidash/nidm#NIDM_0000133>
 prefix nidm_ContrastWeights <http://purl.org/nidash/nidm#NIDM_0000014>
+prefix nidm_varianceMapWiseDependence <http://purl.org/nidash/nidm#NIDM_0000126>
 prefix nidm_userSpecifiedThresholdType <http://purl.org/nidash/nidm#NIDM_0000125>
 prefix nidm_ErrorModel <http://purl.org/nidash/nidm#NIDM_0000023>
 prefix nidm_maskedMedian <http://purl.org/nidash/nidm#NIDM_0000107>

--- a/nidm/nidm-results/spm/example001/example001_spm_results.ttl
+++ b/nidm/nidm-results/spm/example001/example001_spm_results.ttl
@@ -51,12 +51,12 @@
 @prefix nidm_hasErrorDistribution: <http://purl.org/nidash/nidm#NIDM_0000101> .
 @prefix nidm_GaussianDistribution: <http://purl.org/nidash/nidm#NIDM_0000032> .
 @prefix nidm_errorVarianceHomogeneous: <http://purl.org/nidash/nidm#NIDM_0000094> .
-@prefix nidm_varianceSpatialModel: <http://purl.org/nidash/nidm#NIDM_0000126> .
-@prefix nidm_SpatiallyLocalModel: <http://purl.org/nidash/nidm#NIDM_0000073> .
+@prefix nidm_varianceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000126> .
+@prefix nidm_IndependentParameter: <http://purl.org/nidash/nidm#NIDM_0000073> .
 @prefix nidm_hasErrorDependence: <http://purl.org/nidash/nidm#NIDM_0000100> .
 @prefix nidm_SeriallyCorrelatedError: <http://purl.org/nidash/nidm#NIDM_0000069> .
-@prefix nidm_dependenceSpatialModel: <http://purl.org/nidash/nidm#NIDM_0000089> .
-@prefix nidm_SpatiallyGlobalModel: <http://purl.org/nidash/nidm#NIDM_0000072> .
+@prefix nidm_dependenceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000089> .
+@prefix nidm_ConstantParameter: <http://purl.org/nidash/nidm#NIDM_0000072> .
 @prefix nidm_ExcursionSetMap: <http://purl.org/nidash/nidm#NIDM_0000025> .
 @prefix nidm_hasClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000098> .
 @prefix nidm_hasMaximumIntensityProjection: <http://purl.org/nidash/nidm#NIDM_0000138> .
@@ -258,9 +258,9 @@ niiri:design_matrix_id a prov:Entity , nidm_DesignMatrix: ;
 niiri:error_model_id a prov:Entity , nidm_ErrorModel: ;
     nidm_hasErrorDistribution: nidm_GaussianDistribution: ;
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
-    nidm_varianceSpatialModel: nidm_SpatiallyLocalModel: ;
+    nidm_varianceMapWiseDependence: nidm_IndependentParameter: ;
     nidm_hasErrorDependence: nidm_SeriallyCorrelatedError: ;
-    nidm_dependenceSpatialModel: nidm_SpatiallyGlobalModel: .
+    nidm_dependenceMapWiseDependence: nidm_ConstantParameter: .
 
 niiri:excursion_set_map_id a prov:Entity , nidm_ExcursionSetMap: ;
 	rdfs:label "Excursion Set Map" ;

--- a/nidm/nidm-results/spm/example002/spm_results_2contrasts.provn
+++ b/nidm/nidm-results/spm/example002/spm_results_2contrasts.provn
@@ -3,6 +3,7 @@ prefix nidm_ExtentThreshold <http://purl.org/nidash/nidm#NIDM_0000026>
 prefix obo <http://purl.obolibrary.org/obo/>
 prefix pre_0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 prefix nidm_effectDegreesOfFreedom <http://purl.org/nidash/nidm#NIDM_0000091>
+prefix nidm_dependenceMapWiseDependence <http://purl.org/nidash/nidm#NIDM_0000089>
 prefix nidm_grandMeanScaling <http://purl.org/nidash/nidm#NIDM_0000096>
 prefix xsd <http://www.w3.org/2001/XMLSchema>
 prefix nidm_PeakDefinitionCriteria <http://purl.org/nidash/nidm#NIDM_0000063>
@@ -26,7 +27,6 @@ prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
 prefix nidm_ContrastStandardErrorMap <http://purl.org/nidash/nidm#NIDM_0000013>
 prefix nidm_DisplayMaskMap <http://purl.org/nidash/nidm#NIDM_0000020>
 prefix nidm_Inference <http://purl.org/nidash/nidm#NIDM_0000049>
-prefix nidm_varianceSpatialModel <http://purl.org/nidash/nidm#NIDM_0000126>
 prefix nidm_version <http://purl.org/nidash/nidm#NIDM_0000127>
 prefix nidm_withEstimationMethod <http://purl.org/nidash/nidm#NIDM_0000134>
 prefix nidm_StatisticMap <http://purl.org/nidash/nidm#NIDM_0000076>
@@ -58,7 +58,6 @@ prefix nidm_ContrastEstimation <http://purl.org/nidash/nidm#NIDM_0000001>
 prefix rdfs <http://www.w3.org/2000/01/rdf-schema#>
 prefix nidm_ContrastMap <http://purl.org/nidash/nidm#NIDM_0000002>
 prefix nidm_pValueFWER <http://purl.org/nidash/nidm#NIDM_0000115>
-prefix nidm_SpatiallyLocalModel <http://purl.org/nidash/nidm#NIDM_0000073>
 prefix nidm_hasErrorDependence <http://purl.org/nidash/nidm#NIDM_0000100>
 prefix nidm_ReselsPerVoxelMap <http://purl.org/nidash/nidm#NIDM_0000144>
 prefix nidm_voxel18connected <http://purl.org/nidash/nidm#NIDM_0000128>
@@ -68,11 +67,12 @@ prefix nidm_voxelSize <http://purl.org/nidash/nidm#NIDM_0000131>
 prefix nidm_MaskMap <http://purl.org/nidash/nidm#NIDM_0000054>
 prefix obo_ordinaryleastsquaresestimation <http://purl.obolibrary.org/obo/STATO_0000370>
 prefix nidm_GrandMeanMap <http://purl.org/nidash/nidm#NIDM_0000033>
+prefix nidm_IndependentParameter <http://purl.org/nidash/nidm#NIDM_0000073>
 prefix nidm_IndependentError <http://purl.org/nidash/nidm#NIDM_0000048>
 prefix nidm_MNICoordinateSystem <http://purl.org/nidash/nidm#NIDM_0000051>
-prefix nidm_dependenceSpatialModel <http://purl.org/nidash/nidm#NIDM_0000089>
 prefix nidm_voxelUnits <http://purl.org/nidash/nidm#NIDM_0000133>
 prefix nidm_ContrastWeights <http://purl.org/nidash/nidm#NIDM_0000014>
+prefix nidm_varianceMapWiseDependence <http://purl.org/nidash/nidm#NIDM_0000126>
 prefix nidm_userSpecifiedThresholdType <http://purl.org/nidash/nidm#NIDM_0000125>
 prefix nidm_ErrorModel <http://purl.org/nidash/nidm#NIDM_0000023>
 prefix nidm_maskedMedian <http://purl.org/nidash/nidm#NIDM_0000107>

--- a/nidm/nidm-results/spm/example002/spm_results_2contrasts.ttl
+++ b/nidm/nidm-results/spm/example002/spm_results_2contrasts.ttl
@@ -48,11 +48,11 @@
 @prefix nidm_hasErrorDistribution: <http://purl.org/nidash/nidm#NIDM_0000101> .
 @prefix nidm_GaussianDistribution: <http://purl.org/nidash/nidm#NIDM_0000032> .
 @prefix nidm_errorVarianceHomogeneous: <http://purl.org/nidash/nidm#NIDM_0000094> .
-@prefix nidm_varianceSpatialModel: <http://purl.org/nidash/nidm#NIDM_0000126> .
-@prefix nidm_SpatiallyLocalModel: <http://purl.org/nidash/nidm#NIDM_0000073> .
+@prefix nidm_varianceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000126> .
+@prefix nidm_IndependentParameter: <http://purl.org/nidash/nidm#NIDM_0000073> .
 @prefix nidm_hasErrorDependence: <http://purl.org/nidash/nidm#NIDM_0000100> .
 @prefix nidm_IndependentError: <http://purl.org/nidash/nidm#NIDM_0000048> .
-@prefix nidm_dependenceSpatialModel: <http://purl.org/nidash/nidm#NIDM_0000089> .
+@prefix nidm_dependenceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000089> .
 @prefix nidm_ExtentThreshold: <http://purl.org/nidash/nidm#NIDM_0000026> .
 @prefix nidm_clusterSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000084> .
 @prefix nidm_pValueUncorrected: <http://purl.org/nidash/nidm#NIDM_0000116> .
@@ -268,9 +268,9 @@ niiri:display_map_id_3 a prov:Entity , nidm_DisplayMaskMap: ;
 niiri:error_model_id a prov:Entity , nidm_ErrorModel: ;
     nidm_hasErrorDistribution: nidm_GaussianDistribution: ;
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
-    nidm_varianceSpatialModel: nidm_SpatiallyLocalModel: ;
+    nidm_varianceMapWiseDependence: nidm_IndependentParameter: ;
     nidm_hasErrorDependence: nidm_IndependentError: ;
-    nidm_dependenceSpatialModel: nidm_SpatiallyLocalModel: .
+    nidm_dependenceMapWiseDependence: nidm_IndependentParameter: .
 
 niiri:extent_threshold_id a prov:Entity , nidm_ExtentThreshold: ;
 	rdfs:label "Extent Threshold: k>=0" ;

--- a/nidm/nidm-results/spm/example003/spm_results_conjunction.provn
+++ b/nidm/nidm-results/spm/example003/spm_results_conjunction.provn
@@ -3,6 +3,7 @@ prefix nidm_ExtentThreshold <http://purl.org/nidash/nidm#NIDM_0000026>
 prefix obo <http://purl.obolibrary.org/obo/>
 prefix pre_0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 prefix nidm_effectDegreesOfFreedom <http://purl.org/nidash/nidm#NIDM_0000091>
+prefix nidm_dependenceMapWiseDependence <http://purl.org/nidash/nidm#NIDM_0000089>
 prefix nidm_grandMeanScaling <http://purl.org/nidash/nidm#NIDM_0000096>
 prefix xsd <http://www.w3.org/2001/XMLSchema>
 prefix nidm_PeakDefinitionCriteria <http://purl.org/nidash/nidm#NIDM_0000063>
@@ -25,7 +26,6 @@ prefix nidm_pValueUncorrected <http://purl.org/nidash/nidm#NIDM_0000116>
 prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
 prefix nidm_ContrastStandardErrorMap <http://purl.org/nidash/nidm#NIDM_0000013>
 prefix nidm_DisplayMaskMap <http://purl.org/nidash/nidm#NIDM_0000020>
-prefix nidm_varianceSpatialModel <http://purl.org/nidash/nidm#NIDM_0000126>
 prefix nidm_version <http://purl.org/nidash/nidm#NIDM_0000127>
 prefix nidm_withEstimationMethod <http://purl.org/nidash/nidm#NIDM_0000134>
 prefix nidm_StatisticMap <http://purl.org/nidash/nidm#NIDM_0000076>
@@ -57,7 +57,6 @@ prefix nidm_ContrastEstimation <http://purl.org/nidash/nidm#NIDM_0000001>
 prefix rdfs <http://www.w3.org/2000/01/rdf-schema#>
 prefix nidm_ContrastMap <http://purl.org/nidash/nidm#NIDM_0000002>
 prefix nidm_pValueFWER <http://purl.org/nidash/nidm#NIDM_0000115>
-prefix nidm_SpatiallyLocalModel <http://purl.org/nidash/nidm#NIDM_0000073>
 prefix nidm_hasErrorDependence <http://purl.org/nidash/nidm#NIDM_0000100>
 prefix nidm_ReselsPerVoxelMap <http://purl.org/nidash/nidm#NIDM_0000144>
 prefix nidm_voxel18connected <http://purl.org/nidash/nidm#NIDM_0000128>
@@ -67,11 +66,12 @@ prefix nidm_voxelSize <http://purl.org/nidash/nidm#NIDM_0000131>
 prefix nidm_MaskMap <http://purl.org/nidash/nidm#NIDM_0000054>
 prefix obo_ordinaryleastsquaresestimation <http://purl.obolibrary.org/obo/STATO_0000370>
 prefix nidm_GrandMeanMap <http://purl.org/nidash/nidm#NIDM_0000033>
+prefix nidm_IndependentParameter <http://purl.org/nidash/nidm#NIDM_0000073>
 prefix nidm_IndependentError <http://purl.org/nidash/nidm#NIDM_0000048>
 prefix nidm_MNICoordinateSystem <http://purl.org/nidash/nidm#NIDM_0000051>
-prefix nidm_dependenceSpatialModel <http://purl.org/nidash/nidm#NIDM_0000089>
 prefix nidm_voxelUnits <http://purl.org/nidash/nidm#NIDM_0000133>
 prefix nidm_ContrastWeights <http://purl.org/nidash/nidm#NIDM_0000014>
+prefix nidm_varianceMapWiseDependence <http://purl.org/nidash/nidm#NIDM_0000126>
 prefix nidm_userSpecifiedThresholdType <http://purl.org/nidash/nidm#NIDM_0000125>
 prefix nidm_ErrorModel <http://purl.org/nidash/nidm#NIDM_0000023>
 prefix nidm_maskedMedian <http://purl.org/nidash/nidm#NIDM_0000107>

--- a/nidm/nidm-results/spm/example003/spm_results_conjunction.ttl
+++ b/nidm/nidm-results/spm/example003/spm_results_conjunction.ttl
@@ -48,11 +48,11 @@
 @prefix nidm_hasErrorDistribution: <http://purl.org/nidash/nidm#NIDM_0000101> .
 @prefix nidm_GaussianDistribution: <http://purl.org/nidash/nidm#NIDM_0000032> .
 @prefix nidm_errorVarianceHomogeneous: <http://purl.org/nidash/nidm#NIDM_0000094> .
-@prefix nidm_varianceSpatialModel: <http://purl.org/nidash/nidm#NIDM_0000126> .
-@prefix nidm_SpatiallyLocalModel: <http://purl.org/nidash/nidm#NIDM_0000073> .
+@prefix nidm_varianceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000126> .
+@prefix nidm_IndependentParameter: <http://purl.org/nidash/nidm#NIDM_0000073> .
 @prefix nidm_hasErrorDependence: <http://purl.org/nidash/nidm#NIDM_0000100> .
 @prefix nidm_IndependentError: <http://purl.org/nidash/nidm#NIDM_0000048> .
-@prefix nidm_dependenceSpatialModel: <http://purl.org/nidash/nidm#NIDM_0000089> .
+@prefix nidm_dependenceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000089> .
 @prefix nidm_ExtentThreshold: <http://purl.org/nidash/nidm#NIDM_0000026> .
 @prefix nidm_clusterSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000084> .
 @prefix nidm_pValueUncorrected: <http://purl.org/nidash/nidm#NIDM_0000116> .
@@ -243,9 +243,9 @@ niiri:display_map_id a prov:Entity , nidm_DisplayMaskMap: ;
 niiri:error_model_id a prov:Entity , nidm_ErrorModel: ;
     nidm_hasErrorDistribution: nidm_GaussianDistribution: ;
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
-    nidm_varianceSpatialModel: nidm_SpatiallyLocalModel: ;
+    nidm_varianceMapWiseDependence: nidm_IndependentParameter: ;
     nidm_hasErrorDependence: nidm_IndependentError: ;
-    nidm_dependenceSpatialModel: nidm_SpatiallyLocalModel: .
+    nidm_dependenceMapWiseDependence: nidm_IndependentParameter: .
 
 niiri:extent_threshold_id a prov:Entity , nidm_ExtentThreshold: ;
 	rdfs:label "Extent Threshold: k>=10" ;

--- a/nidm/nidm-results/spm/spm_results.provn
+++ b/nidm/nidm-results/spm/spm_results.provn
@@ -3,6 +3,7 @@ prefix nidm_ExtentThreshold <http://purl.org/nidash/nidm#NIDM_0000026>
 prefix obo <http://purl.obolibrary.org/obo/>
 prefix pre_0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 prefix nidm_effectDegreesOfFreedom <http://purl.org/nidash/nidm#NIDM_0000091>
+prefix nidm_dependenceMapWiseDependence <http://purl.org/nidash/nidm#NIDM_0000089>
 prefix nidm_grandMeanScaling <http://purl.org/nidash/nidm#NIDM_0000096>
 prefix xsd <http://www.w3.org/2001/XMLSchema>
 prefix nidm_PeakDefinitionCriteria <http://purl.org/nidash/nidm#NIDM_0000063>
@@ -32,7 +33,6 @@ prefix nidm_SignificantCluster <http://purl.org/nidash/nidm#NIDM_0000070>
 prefix nidm_ContrastStandardErrorMap <http://purl.org/nidash/nidm#NIDM_0000013>
 prefix nidm_DisplayMaskMap <http://purl.org/nidash/nidm#NIDM_0000020>
 prefix nidm_Inference <http://purl.org/nidash/nidm#NIDM_0000049>
-prefix nidm_varianceSpatialModel <http://purl.org/nidash/nidm#NIDM_0000126>
 prefix nidm_version <http://purl.org/nidash/nidm#NIDM_0000127>
 prefix nidm_withEstimationMethod <http://purl.org/nidash/nidm#NIDM_0000134>
 prefix nidm_StatisticMap <http://purl.org/nidash/nidm#NIDM_0000076>
@@ -78,7 +78,6 @@ prefix rdfs <http://www.w3.org/2000/01/rdf-schema#>
 prefix nidm_ContrastMap <http://purl.org/nidash/nidm#NIDM_0000002>
 prefix nidm_pValueFWER <http://purl.org/nidash/nidm#NIDM_0000115>
 prefix nidm_coordinate <http://purl.org/nidash/nidm#NIDM_0000086>
-prefix nidm_SpatiallyLocalModel <http://purl.org/nidash/nidm#NIDM_0000073>
 prefix nidm_hasErrorDependence <http://purl.org/nidash/nidm#NIDM_0000100>
 prefix nidm_clusterLabelId <http://purl.org/nidash/nidm#NIDM_0000082>
 prefix nidm_ReselsPerVoxelMap <http://purl.org/nidash/nidm#NIDM_0000144>
@@ -91,12 +90,13 @@ prefix nidm_voxelSize <http://purl.org/nidash/nidm#NIDM_0000131>
 prefix nidm_MaskMap <http://purl.org/nidash/nidm#NIDM_0000054>
 prefix obo_ordinaryleastsquaresestimation <http://purl.obolibrary.org/obo/STATO_0000370>
 prefix nidm_GrandMeanMap <http://purl.org/nidash/nidm#NIDM_0000033>
+prefix nidm_IndependentParameter <http://purl.org/nidash/nidm#NIDM_0000073>
 prefix nidm_IndependentError <http://purl.org/nidash/nidm#NIDM_0000048>
 prefix nidm_MNICoordinateSystem <http://purl.org/nidash/nidm#NIDM_0000051>
 prefix nidm_randomFieldStationarity <http://purl.org/nidash/nidm#NIDM_0000120>
-prefix nidm_dependenceSpatialModel <http://purl.org/nidash/nidm#NIDM_0000089>
 prefix nidm_voxelUnits <http://purl.org/nidash/nidm#NIDM_0000133>
 prefix nidm_ContrastWeights <http://purl.org/nidash/nidm#NIDM_0000014>
+prefix nidm_varianceMapWiseDependence <http://purl.org/nidash/nidm#NIDM_0000126>
 prefix nidm_userSpecifiedThresholdType <http://purl.org/nidash/nidm#NIDM_0000125>
 prefix nidm_ErrorModel <http://purl.org/nidash/nidm#NIDM_0000023>
 prefix nidm_maskedMedian <http://purl.org/nidash/nidm#NIDM_0000107>

--- a/nidm/nidm-results/spm/spm_results.ttl
+++ b/nidm/nidm-results/spm/spm_results.ttl
@@ -51,11 +51,11 @@
 @prefix nidm_hasErrorDistribution: <http://purl.org/nidash/nidm#NIDM_0000101> .
 @prefix nidm_GaussianDistribution: <http://purl.org/nidash/nidm#NIDM_0000032> .
 @prefix nidm_errorVarianceHomogeneous: <http://purl.org/nidash/nidm#NIDM_0000094> .
-@prefix nidm_varianceSpatialModel: <http://purl.org/nidash/nidm#NIDM_0000126> .
-@prefix nidm_SpatiallyLocalModel: <http://purl.org/nidash/nidm#NIDM_0000073> .
+@prefix nidm_varianceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000126> .
+@prefix nidm_IndependentParameter: <http://purl.org/nidash/nidm#NIDM_0000073> .
 @prefix nidm_hasErrorDependence: <http://purl.org/nidash/nidm#NIDM_0000100> .
 @prefix nidm_IndependentError: <http://purl.org/nidash/nidm#NIDM_0000048> .
-@prefix nidm_dependenceSpatialModel: <http://purl.org/nidash/nidm#NIDM_0000089> .
+@prefix nidm_dependenceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000089> .
 @prefix nidm_ExcursionSetMap: <http://purl.org/nidash/nidm#NIDM_0000025> .
 @prefix nidm_hasClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000098> .
 @prefix nidm_hasMaximumIntensityProjection: <http://purl.org/nidash/nidm#NIDM_0000138> .
@@ -313,9 +313,9 @@ niiri:display_map_id a prov:Entity , nidm_DisplayMaskMap: ;
 niiri:error_model_id a prov:Entity , nidm_ErrorModel: ;
     nidm_hasErrorDistribution: nidm_GaussianDistribution: ;
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
-    nidm_varianceSpatialModel: nidm_SpatiallyLocalModel: ;
+    nidm_varianceMapWiseDependence: nidm_IndependentParameter: ;
     nidm_hasErrorDependence: nidm_IndependentError: ;
-    nidm_dependenceSpatialModel: nidm_SpatiallyLocalModel: .
+    nidm_dependenceMapWiseDependence: nidm_IndependentParameter: .
 
 niiri:excursion_set_map_id a prov:Entity , nidm_ExcursionSetMap: ;
 	rdfs:label "Excursion Set Map" ;

--- a/nidm/nidm-results/terms/README.md
+++ b/nidm/nidm-results/terms/README.md
@@ -162,26 +162,6 @@ Discussed with @afni-rickr in <a href="https://github.com/incf-nidash/nidm/pull/
 </tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/194">#194</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Spatial Model'"> [more] </a></td>
-    <td><b>nidm:'Spatial Model': </b>FIXME</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/194">#194</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Spatially Global Model'"> [more] </a></td>
-    <td><b>nidm:'Spatially Global Model': </b>FIXME</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/194">#194</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Spatially Local Model'"> [more] </a></td>
-    <td><b>nidm:'Spatially Local Model': </b>FIXME</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/194">#194</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Spatially Regularized Model'"> [more] </a></td>
-    <td><b>nidm:'Spatially Regularized Model': </b>FIXME</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
     <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/284">#284</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='World Coordinate System'"> [more] </a></td>
     <td><b>nidm:'World Coordinate System': </b>&lt;undefined&gt;</td>
 </tr>
@@ -397,13 +377,6 @@ Range: Vector of integers not found.<br/><a href="https://github.com/incf-nidash
 </tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/194">#194</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='dependence Spatial Model'"> [more] </a></td>
-    <td><b>nidm:'dependence Spatial Model': </b>FIXME</td>
-    <td>nidm:NIDM_0000023 </td>
-    <td>nidm:NIDM_0000071 </td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
     <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/294">#294</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='global Null Degree'"> [more] </a></td>
     <td><b>nidm:'global Null Degree': </b>&lt;undefined&gt;</td>
     <td>spm:KConjunctionInference </td>
@@ -436,13 +409,6 @@ Range: Vector of integers not found.<br/><a href="https://github.com/incf-nidash
     <td><b>nidm:'search Volume In Voxels': </b>Total number of voxels within the search volume</td>
     <td>nidm:NIDM_0000068 </td>
     <td>xsd:positiveInteger </td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/194">#194</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='variance Spatial Model'"> [more] </a></td>
-    <td><b>nidm:'variance Spatial Model': </b>FIXME</td>
-    <td>nidm:NIDM_0000023 </td>
-    <td>nidm:NIDM_0000071 </td>
 </tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>

--- a/nidm/nidm-results/terms/examples/ErrorModel.txt
+++ b/nidm/nidm-results/terms/examples/ErrorModel.txt
@@ -2,16 +2,16 @@
 @prefix nidm_hasErrorDistribution: <http://purl.org/nidash/nidm#NIDM_0000101> .
 @prefix nidm_GaussianDistribution: <http://purl.org/nidash/nidm#NIDM_0000032> .
 @prefix nidm_errorVarianceHomogeneous: <http://purl.org/nidash/nidm#NIDM_0000094> .
-@prefix nidm_varianceSpatialModel: <http://purl.org/nidash/nidm#NIDM_0000126> .
-@prefix nidm_SpatiallyLocalModel: <http://purl.org/nidash/nidm#NIDM_0000073> .
+@prefix nidm_varianceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000126> .
+@prefix nidm_IndependentParameter: <http://purl.org/nidash/nidm#NIDM_0000073> .
 @prefix nidm_hasErrorDependence: <http://purl.org/nidash/nidm#NIDM_0000100> .
 @prefix nidm_IndependentError: <http://purl.org/nidash/nidm#NIDM_0000048> .
-@prefix nidm_dependenceSpatialModel: <http://purl.org/nidash/nidm#NIDM_0000089> .
+@prefix nidm_dependenceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000089> .
 
 
 niiri:error_model_id a prov:Entity , nidm_ErrorModel: ;
     nidm_hasErrorDistribution: nidm_GaussianDistribution: ;
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
-    nidm_varianceSpatialModel: nidm_SpatiallyLocalModel: ;
+    nidm_varianceMapWiseDependence: nidm_IndependentParameter: ;
     nidm_hasErrorDependence: nidm_IndependentError: ;
-    nidm_dependenceSpatialModel: nidm_SpatiallyLocalModel: .
+    nidm_dependenceMapWiseDependence: nidm_IndependentParameter: .

--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -76,11 +76,13 @@ nidm:NIDM_0000088 rdf:type owl:ObjectProperty ;
 
 nidm:NIDM_0000089 rdf:type owl:ObjectProperty ;
                   
-                  rdfs:label "dependence Spatial Model" ;
+                  rdfs:label "dependence Map-Wise Dependence" ;
                   
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/194" ;
+                  obo:IAO_0000115 "Property that associates an Error Parameter Map-Wise Dependence to the dependence of an error model." ;
                   
-                  obo:IAO_0000115 "FIXME" ;
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/194" ;
+                  
+                  obo:IAO_0000114 obo:IAO_0000122 ;
                   
                   rdfs:domain nidm:NIDM_0000023 ;
                   
@@ -288,11 +290,13 @@ nidm:NIDM_0000123 rdf:type owl:ObjectProperty ;
 
 nidm:NIDM_0000126 rdf:type owl:ObjectProperty ;
                   
-                  rdfs:label "variance Spatial Model" ;
+                  rdfs:label "variance Map-Wise Dependence" ;
                   
-                  obo:IAO_0000115 "FIXME" ;
+                  obo:IAO_0000115 "Property that associates an Error Parameter Map-Wise Dependence to the variance of an error model" ;
                   
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/194" ;
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/194" ;
+                  
+                  obo:IAO_0000114 obo:IAO_0000122 ;
                   
                   rdfs:domain nidm:NIDM_0000023 ;
                   
@@ -2764,13 +2768,15 @@ nidm:NIDM_0000070 rdf:type owl:Class ;
 
 nidm:NIDM_0000071 rdf:type owl:Class ;
                   
-                  rdfs:label "Spatial Model" ;
+                  rdfs:label "Error Parameter Map-Wise Dependence" ;
                   
                   rdfs:subClassOf prov:Entity ;
                   
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/194" ;
+                  obo:IAO_0000115 "Map-wise dependence structure of a parameter in the error model (i.e. variance or dependence parameter). For example, whether a temporal autocorrelation parameter is estimated at each element separately, estimated using data in a local neighbourhood, or estimated using all elements in the map." ;
                   
-                  obo:IAO_0000115 "FIXME" .
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/194" ;
+                  
+                  obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -2778,13 +2784,15 @@ nidm:NIDM_0000071 rdf:type owl:Class ;
 
 nidm:NIDM_0000072 rdf:type owl:Class ;
                   
-                  rdfs:label "Spatially Global Model" ;
+                  rdfs:label "Constant Parameter" ;
                   
                   rdfs:subClassOf nidm:NIDM_0000071 ;
                   
-                  obo:IAO_0000115 "FIXME" ;
+                  obo:IAO_0000115 "Parameter estimated as constant over a entire set of elements considered (e.g. those in the analysis mask)." ;
                   
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/194" .
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/194" ;
+                  
+                  obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -2792,13 +2800,15 @@ nidm:NIDM_0000072 rdf:type owl:Class ;
 
 nidm:NIDM_0000073 rdf:type owl:Class ;
                   
-                  rdfs:label "Spatially Local Model" ;
+                  rdfs:label "Independent Parameter" ;
                   
                   rdfs:subClassOf nidm:NIDM_0000071 ;
                   
-                  obo:IAO_0000115 "FIXME" ;
+                  obo:IAO_0000115 "Parameter whose estimation at a given element does not depend on any other element." ;
                   
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/194" .
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/194" ;
+                  
+                  obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -2806,13 +2816,15 @@ nidm:NIDM_0000073 rdf:type owl:Class ;
 
 nidm:NIDM_0000074 rdf:type owl:Class ;
                   
-                  rdfs:label "Spatially Regularized Model" ;
+                  rdfs:label "Regularized Parameter" ;
                   
                   rdfs:subClassOf nidm:NIDM_0000071 ;
                   
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/194" ;
+                  obo:IAO_0000115 "Parameter whose estimation at a given element depends on a local neighborhood of elements" ;
                   
-                  obo:IAO_0000115 "FIXME" .
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/194" ;
+                  
+                  obo:IAO_0000114 obo:IAO_0000122 .
 
 
 


### PR DESCRIPTION
This issue is a companion for #176 to define the terms created to model noise spatial models, namely:
- `nidm:varianceSpatialModel`
- `nidm:dependenceSpatialModel`
- `nidm:SpatialModel`
- `nidm:SpatiallyLocalModel`
- `nidm:SpatiallyGlobalModel`
- `nidm:SpatiallyRegularisedModel`

Proposed definitions:
 - **nidm:SpatialModel**: "Spatial model of the Noise Model variance or dependence"
 - **nidm:varianceSpatialModel**: "Property that associates a Spatial Model to the variance of a noise model".
 - **nidm:dependenceSpatialModel**: "Property that associates a Spatial Model to the dependence of a noise model".
 - **nidm:SpatiallyLocalModel**: "Model defined independently for each element".
 - **nidm:SpatiallyGlobalModel**: "Model defined globally for all elements".
 - **nidm:SpatiallyRegularizedModel**: "Model defined as a smooth function across neighbouring elements."

Please let me know what you think. @nicholst: would you like to comment on those definitions?