### PR TITLE
Definition of 'cluster Size In Voxels' (pending final vetting)

### DIFF
--- a/nidm/nidm-results/terms/README.md
+++ b/nidm/nidm-results/terms/README.md
@@ -143,13 +143,6 @@ Thank you in advance for taking part in NIDM-Results term curation!
 </tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
-    <td><a href="https://github.com/incf-nidash/nidm//issues?&q='cluster Size In Voxels'"> [find issues/PR] </a></td>
-    <td><b>nidm:'cluster Size In Voxels': </b>Number of voxels that make up the cluster</td>
-    <td>nidm:NIDM_0000026 nidm:NIDM_0000070 </td>
-    <td>xsd:positiveInteger </td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
     <td><a href="https://github.com/incf-nidash/nidm//issues?&q='expected Number Of Clusters'"> [find issues/PR] </a></td>
     <td><b>nidm:'expected Number Of Clusters': </b>Expected number of clusters in an excursion set under the null hypothesis</td>
     <td>nidm:NIDM_0000068 </td>

--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -490,7 +490,7 @@ nidm:NIDM_0000084 rdf:type owl:DatatypeProperty ;
                   
                   obo:IAO_0000115 "Number of voxels that make up the cluster." ;
                   
-                  obo:IAO_0000114 obo:IAO_0000125 ;
+                  obo:IAO_0000114 obo:IAO_0000122 ;
                   
                   rdfs:domain nidm:NIDM_0000026 ,
                               nidm:NIDM_0000070 ;


### PR DESCRIPTION
Another definition, pending final vetting, that I think is good to go:
  - **nidm:'cluster Size In Voxels'**: Number of voxels that make up the cluster.

What do you think?