### PR TITLE
Definition of "Drift Model" terms

### DIFF
--- a/nidm/nidm-results/terms/README.md
+++ b/nidm/nidm-results/terms/README.md
@@ -16,28 +16,8 @@ Thank you in advance for taking part in NIDM-Results term curation!
 <tr><th>Curation Status</th><th>Issue/PR</th><th>Term</th></tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
-    <td><a href="https://github.com/incf-nidash/nidm//issues?&q='AFNI's Legendre Polinomial Drift Model'"> [find issues/PR] </a></td>
-    <td><b>afni:'AFNI's Legendre Polinomial Drift Model': </b>A drift model in which the drifts are modeled by a Legendre orthogonal polynomial basis added to the regression model</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
-    <td><a href="https://github.com/incf-nidash/nidm//issues?&q='FSL's Gaussian Running Line Drift Model'"> [find issues/PR] </a></td>
-    <td><b>fsl:'FSL's Gaussian Running Line Drift Model': </b>A drift model in which the drifts are modeled with a Gaussian-weighted running line smoother, fit to and subtracted from the data and each column of the design matrix</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
     <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/274">#274</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Design Matrix'"> [more] </a></td>
     <td><b>nidm:'Design Matrix': </b>A matrix of values defining the explanatory variables used in a regression model.  Each column corresponds to one explanatory variable, each row corresponds to one observation (editor: TN)</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
-    <td><a href="https://github.com/incf-nidash/nidm//issues?&q='Drift Model'"> [find issues/PR] </a></td>
-    <td><b>nidm:'Drift Model': </b>A model used to compensate for low frequency baseline drifts when analyzing functional MRI data at the subject level</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
-    <td><a href="https://github.com/incf-nidash/nidm//issues?&q='SPM's DCT Drift Model'"> [find issues/PR] </a></td>
-    <td><b>spm:'SPM's DCT Drift Model': </b>A drift model in which the drifts are modeled by a Discrete Cosine Transform basis added to regression model</td>
 </tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
@@ -124,20 +104,6 @@ Thank you in advance for taking part in NIDM-Results term curation!
 <tr><th>Curation Status</th><th>Issue/PR</th><th>Term</th><th>Domain</th><th>Range</th></tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
-    <td><a href="https://github.com/incf-nidash/nidm//issues?&q='AFNI's drift Basis Order'"> [find issues/PR] </a></td>
-    <td><b>afni:'AFNI's drift Basis Order': </b>The number of basis in the drift model</td>
-    <td>afni:LegendrePolynomialDriftModel </td>
-    <td>xsd:int </td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
-    <td><a href="https://github.com/incf-nidash/nidm//issues?&q='FSL's Drift Cut-off Period'"> [find issues/PR] </a></td>
-    <td><b>fsl:'FSL's Drift Cut-off Period': </b>Full Width at Half Maximum in seconds of the Gaussian weight function used in the running line smoother</td>
-    <td>fsl:GaussianRunningLineDriftModel </td>
-    <td>xsd:float </td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
     <td><a href="https://github.com/incf-nidash/nidm//issues?&q='expected Number Of Clusters'"> [find issues/PR] </a></td>
     <td><b>nidm:'expected Number Of Clusters': </b>Expected number of clusters in an excursion set under the null hypothesis</td>
     <td>nidm:NIDM_0000068 </td>
@@ -156,13 +122,6 @@ Thank you in advance for taking part in NIDM-Results term curation!
     <td><b>nidm:'expected Number Of Voxels Per Cluster': </b>Expected number of voxels in a cluster under the null hypothesis</td>
     <td>nidm:NIDM_0000068 </td>
     <td></td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
-    <td><a href="https://github.com/incf-nidash/nidm//issues?&q='has Drift Model'"> [find issues/PR] </a></td>
-    <td><b>nidm:'has Drift Model': </b>A property that associates a drift model to a design matrix (only used for first-level fMRI experiments)</td>
-    <td>nidm:NIDM_0000019 </td>
-    <td>nidm:NIDM_0000087 </td>
 </tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
@@ -191,13 +150,6 @@ Thank you in advance for taking part in NIDM-Results term curation!
     <td><b>nidm:'regressor Names': </b>A list of abstract names associated with each column of the design matrix (e.g. ["motor_left", "motor_right"])</td>
     <td>nidm:NIDM_0000019 </td>
     <td>xsd:string </td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
-    <td><a href="https://github.com/incf-nidash/nidm//issues?&q='SPM's Drift Cut-off Period'"> [find issues/PR] </a></td>
-    <td><b>spm:'SPM's Drift Cut-off Period': </b>Discrete Cosine Transform basis cut-off, specified as period length in seconds and ensures that all basis elements will have period of this duration or longer</td>
-    <td>spm:DCTDriftModel </td>
-    <td>xsd:float </td>
 </tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/orange.png?raw=true"/>  </td>

--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -62,9 +62,11 @@ nidm:NIDM_0000088 rdf:type owl:ObjectProperty ;
                   
                   rdfs:label "has Drift Model" ;
                   
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/298" ;
+                  
                   obo:IAO_0000115 "A property that associates a drift model to a design matrix (only used for first-level fMRI experiments)." ;
                   
-                  obo:IAO_0000114 obo:IAO_0000125 ;
+                  obo:IAO_0000114 obo:IAO_0000122 ;
                   
                   rdfs:domain nidm:NIDM_0000019 ;
                   
@@ -393,31 +395,17 @@ dct:format rdf:type owl:DatatypeProperty ;
 
 
 
-###  http://purl.org/nidash/afni#driftBasisOrder
-
-afni:driftBasisOrder rdf:type owl:DatatypeProperty ;
-                     
-                     rdfs:label "AFNI's drift Basis Order" ;
-                     
-                     obo:IAO_0000115 "The number of basis in the drift model." ;
-                     
-                     obo:IAO_0000114 obo:IAO_0000125 ;
-                     
-                     rdfs:domain afni:LegendrePolynomialDriftModel ;
-                     
-                     rdfs:range xsd:int .
-
-
-
 ###  http://purl.org/nidash/fsl#driftCutoffPeriod
 
 fsl:driftCutoffPeriod rdf:type owl:DatatypeProperty ;
                       
                       rdfs:label "FSL's Drift Cut-off Period" ;
                       
+                      obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/298" ;
+                      
                       obo:IAO_0000115 "Full Width at Half Maximum in seconds of the Gaussian weight function used in the running line smoother." ;
                       
-                      obo:IAO_0000114 obo:IAO_0000125 ;
+                      obo:IAO_0000114 obo:IAO_0000122 ;
                       
                       rdfs:domain fsl:GaussianRunningLineDriftModel ;
                       
@@ -438,6 +426,24 @@ fsl:featVersion rdf:type owl:DatatypeProperty ;
                 obo:IAO_0000114 obo:IAO_0000122 ;
                 
                 rdfs:range xsd:string .
+
+
+
+###  http://purl.org/nidash/nidm#LegendrePolynomialOrder
+
+nidm:LegendrePolynomialOrder rdf:type owl:DatatypeProperty ;
+                             
+                             rdfs:label "Legendre Polynomial Order" ;
+                             
+                             obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/298" ;
+                             
+                             obo:IAO_0000115 "The number of basis in the drift model (1 = linear, 2 = quadratic, etc.)" ;
+                             
+                             obo:IAO_0000114 obo:IAO_0000122 ;
+                             
+                             rdfs:domain afni:LegendrePolynomialDriftModel ;
+                             
+                             rdfs:range xsd:int .
 
 
 
@@ -1443,7 +1449,9 @@ spm:driftCutoffPeriod rdf:type owl:DatatypeProperty ;
                       
                       obo:IAO_0000115 "Discrete Cosine Transform basis cut-off, specified as period length in seconds and ensures that all basis elements will have period of this duration or longer." ;
                       
-                      obo:IAO_0000114 obo:IAO_0000125 ;
+                      obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/298" ;
+                      
+                      obo:IAO_0000114 obo:IAO_0000122 ;
                       
                       rdfs:domain spm:DCTDriftModel ;
                       
@@ -1704,7 +1712,9 @@ afni:LegendrePolynomialDriftModel rdf:type owl:Class ;
                                   
                                   obo:IAO_0000115 "A drift model in which the drifts are modeled by a Legendre orthogonal polynomial basis added to the regression model" ;
                                   
-                                  obo:IAO_0000114 obo:IAO_0000125 .
+                                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/298" ;
+                                  
+                                  obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -1718,7 +1728,9 @@ fsl:GaussianRunningLineDriftModel rdf:type owl:Class ;
                                   
                                   obo:IAO_0000115 "A drift model in which the drifts are modeled with a Gaussian-weighted running line smoother, fit to and subtracted from the data and each column of the design matrix." ;
                                   
-                                  obo:IAO_0000114 obo:IAO_0000125 .
+                                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/298" ;
+                                  
+                                  obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -2907,9 +2919,11 @@ nidm:NIDM_0000087 rdf:type owl:Class ;
                   obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/FSL_DriftModel.txt"^^xsd:anyURI ,
                                   "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/SPM_DriftModel.txt"^^xsd:anyURI ;
                   
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/298" ;
+                  
                   obo:IAO_0000115 "A model used to compensate for low frequency baseline drifts when analyzing functional MRI data at the subject level." ;
                   
-                  obo:IAO_0000114 obo:IAO_0000125 .
+                  obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -3007,7 +3021,9 @@ spm:DCTDriftModel rdf:type owl:Class ;
                   
                   obo:IAO_0000115 "A drift model in which the drifts are modeled by a Discrete Cosine Transform basis added to regression model" ;
                   
-                  obo:IAO_0000114 obo:IAO_0000125 .
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/298" ;
+                  
+                  obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -3077,13 +3093,6 @@ fsl:TemporalDerivative rdf:type nidm:NIDM_0000037 ,
                        
                        obo:IAO_0000114 obo:IAO_0000125 .
 
-
-
-#################################################################
-#
-#    Individuals
-#
-#################################################################
 
 
 ###  http://purl.org/nidash/nidm#BlockBasedDesign


### PR DESCRIPTION
Following #261, this issue is open to curate the definition of the "Drift Model" terms (cf. [example of usage](http://htmlpreview.github.io/?https://raw.githubusercontent.com/incf-nidash/nidm/9cd873495390d9dcc8fb42697ddb9fe937fa6f23/doc/content/specs/nidm-results_dev.html#dfn-nidm-designmatrix) in the spec).

Classes:
 - **nidm:DriftModel**: A model used to compensate for low frequency baseline drifts when analyzing functional MRI data at the subject level
  - **afni:LegendrePolynomialDriftModel**: A drift model in which the drifts are modeled by a Legendre orthogonal polynomial basis added to the regression model
  - **fsl:GaussianRunningLineDriftModel**: A drift model in which the drifts are modeled with a Gaussian-weighted running line smoother, fit to and subtracted from the data and each column of the design matrix
  - **spm:DCTDriftModel**: A drift model in which the drifts are modeled by a Discrete Cosine Transform basis added to regression model

Properties:
 - **nidm:hasDriftModel**: A property that associates a drift model to a design matrix (only used for first-level fMRI experiments)
 - **afni:driftBasisOrder**: The number of basis in the drift model.
 - **fsl:driftCutoffPeriod**: Full Width at Half Maximum in seconds of the Gaussian weight function used in the running line smoother
 - **spm:driftCutoffPeriod**: Discrete Cosine Transform basis cut-off, specified as period length in seconds and ensures that all basis elements will have period of this duration or longer