### PR TITLE
Definition of "coordinate system" terms

### DIFF
--- a/doc/content/specs/nidm-results_dev.html
+++ b/doc/content/specs/nidm-results_dev.html
@@ -363,7 +363,7 @@
                     <li><span class="attribute" id="nidm:'Coordinate Space'.label">rdfs:label</span>: an                     <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> human readable description                     of the nidm:'Coordinate Space'.</li>
                      
                         <li><a title="NIDM_0000090"><dfn title="NIDM_0000090">nidm:'dimensions In Voxels'</dfn></a></span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> number of voxels in each of the dimensions of the data array. For example, "91 109 91" indicates there are 91 voxels in the first dimension, 109 in the second dimension, and 91 in the third dimension.(range <a title="string" href ="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li> 
-                        <li><a title="NIDM_0000105"><dfn title="NIDM_0000105">nidm:'in World Coordinate System'</dfn></a></span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> type of coordinate system.(range <a title="NIDM_0000081">nidm:'World Coordinate System'</a> such as <a title="NIDM_0000075">nidm:'Standardized Coordinate System'</a>, <a title="NIDM_0000077">nidm:'Subject Coordinate System'</a>)</li> 
+                        <li><a title="NIDM_0000105"><dfn title="NIDM_0000105">nidm:'in World Coordinate System'</dfn></a></span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> property that associates a world coordinate system to the coordinate space.(range <a title="NIDM_0000081">nidm:'World Coordinate System'</a> such as <a title="NIDM_0000075">nidm:'Standardized Coordinate System'</a>, <a title="NIDM_0000077">nidm:'Subject Coordinate System'</a>)</li> 
                         <li><a title="NIDM_0000112"><dfn title="NIDM_0000112">nidm:'number Of Dimensions'</dfn></a></span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> number of dimensions of the data matrix (e.g. 3 for volumetric data).(range <a title="positiveInteger" href ="http://www.w3.org/2001/XMLSchema#positiveInteger">xsd:positiveInteger</a>)</li> 
                         <li><a title="NIDM_0000131"><dfn title="NIDM_0000131">nidm:'voxel Size'</dfn></a></span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> 3D size of a voxel measured in voxel units (e.g. [2, 2, 4]).(range <a title="string" href ="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li> 
                         <li><a title="NIDM_0000132"><dfn title="NIDM_0000132">nidm:'voxel To World Mapping'</dfn></a></span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> homogeneous transformation matrix to map from voxel coordinate system to world coordinate system.(range <a title="string" href ="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li> 
@@ -392,7 +392,7 @@ niiri:coordinate_space_id_1 a prov:Entity , nidm_CoordinateSpace: ;
             <section id="section-nidm:'Custom Coordinate System'"> 
                 <h1 label="NIDM_0000017">nidm:'Custom Coordinate System'</h1>
                 <div class="glossary-ref">
-                    A <a title="NIDM_0000017"><dfn title="NIDM_0000017">nidm:'Custom Coordinate System'</dfn></a> is . <a title="NIDM_0000017">nidm:'Custom Coordinate System'</a> is a prov:Entity. 
+                    A <a title="NIDM_0000017"><dfn title="NIDM_0000017">nidm:'Custom Coordinate System'</dfn></a> is custom (unknown) reference space selected by the user. <a title="NIDM_0000017">nidm:'Custom Coordinate System'</a> is a prov:Entity. 
                 </div>
                 <p></p>
                 <div class="attributes" id="attributes-nidm:'Custom Coordinate System'"> A <a title="NIDM_0000017">nidm:'Custom Coordinate System'</a> has attributes:
@@ -404,7 +404,7 @@ niiri:coordinate_space_id_1 a prov:Entity , nidm_CoordinateSpace: ;
             <section id="section-nidm:'MNI Coordinate System'"> 
                 <h1 label="NIDM_0000051">nidm:'MNI Coordinate System'</h1>
                 <div class="glossary-ref">
-                    A <a title="NIDM_0000051"><dfn title="NIDM_0000051">nidm:'MNI Coordinate System'</dfn></a> is coordinate system defined with reference to the MNI atlas. <a title="NIDM_0000051">nidm:'MNI Coordinate System'</a> is a prov:Entity. 
+                    A <a title="NIDM_0000051"><dfn title="NIDM_0000051">nidm:'MNI Coordinate System'</dfn></a> is mNI 305 coordinate system or any coordinate system derived from MNI 305. <a title="NIDM_0000051">nidm:'MNI Coordinate System'</a> is a prov:Entity. 
                 </div>
                 <p></p>
                 <div class="attributes" id="attributes-nidm:'MNI Coordinate System'"> A <a title="NIDM_0000051">nidm:'MNI Coordinate System'</a> has attributes:
@@ -428,7 +428,7 @@ niiri:coordinate_space_id_1 a prov:Entity , nidm_CoordinateSpace: ;
             <section id="section-nidm:'Subject Coordinate System'"> 
                 <h1 label="NIDM_0000077">nidm:'Subject Coordinate System'</h1>
                 <div class="glossary-ref">
-                    A <a title="NIDM_0000077"><dfn title="NIDM_0000077">nidm:'Subject Coordinate System'</dfn></a> is coordinate system defined by the subject brain (no spatial normalisation applied). <a title="NIDM_0000077">nidm:'Subject Coordinate System'</a> is a prov:Entity. 
+                    A <a title="NIDM_0000077"><dfn title="NIDM_0000077">nidm:'Subject Coordinate System'</dfn></a> is reference space corresponding to the subject brain (no spatial normalization applied). <a title="NIDM_0000077">nidm:'Subject Coordinate System'</a> is a prov:Entity. 
                 </div>
                 <p></p>
                 <div class="attributes" id="attributes-nidm:'Subject Coordinate System'"> A <a title="NIDM_0000077">nidm:'Subject Coordinate System'</a> has attributes:
@@ -440,7 +440,7 @@ niiri:coordinate_space_id_1 a prov:Entity , nidm_CoordinateSpace: ;
             <section id="section-nidm:'Talairach Coordinate System'"> 
                 <h1 label="NIDM_0000078">nidm:'Talairach Coordinate System'</h1>
                 <div class="glossary-ref">
-                    A <a title="NIDM_0000078"><dfn title="NIDM_0000078">nidm:'Talairach Coordinate System'</dfn></a> is reference space defined by the dissected brain used for the Talairach and Tournoux atlas. <a title="NIDM_0000078">nidm:'Talairach Coordinate System'</a> is a prov:Entity. 
+                    A <a title="NIDM_0000078"><dfn title="NIDM_0000078">nidm:'Talairach Coordinate System'</dfn></a> is reference space defined by the dissected brain used for the Talairach and Tournoux atlas (cf. http://www.talairach.org/about.html). <a title="NIDM_0000078">nidm:'Talairach Coordinate System'</a> is a prov:Entity. 
                 </div>
                 <p></p>
                 <div class="attributes" id="attributes-nidm:'Talairach Coordinate System'"> A <a title="NIDM_0000078">nidm:'Talairach Coordinate System'</a> has attributes:
@@ -452,7 +452,8 @@ niiri:coordinate_space_id_1 a prov:Entity , nidm_CoordinateSpace: ;
             <section id="section-nidm:'World Coordinate System'"> 
                 <h1 label="NIDM_0000081">nidm:'World Coordinate System'</h1>
                 <div class="glossary-ref">
-                    A <a title="NIDM_0000081"><dfn title="NIDM_0000081">nidm:'World Coordinate System'</dfn></a> is . <a title="NIDM_0000081">nidm:'World Coordinate System'</a> is a prov:Entity. 
+                    A <a title="NIDM_0000081"><dfn title="NIDM_0000081">nidm:'World Coordinate System'</dfn></a> is reference space on which real-world positions are expressed (cf. <a href="http://nipy.org/nipy/stable/devel/code_discussions/understanding_affines.html">Nifti-1 FAQ question 14](http://nifti.nimh.nih.gov/nifti-1/documentation/faq#Q14) and [Understanding affines on nipy</a>
+). A world coordinate system can be represented by an image obtained by registering an initial set of images, using a given normalization algorithm to match a target template. <a title="NIDM_0000081">nidm:'World Coordinate System'</a> is a prov:Entity. 
                 </div>
                 <p></p>
                 <div class="attributes" id="attributes-nidm:'World Coordinate System'"> A <a title="NIDM_0000081">nidm:'World Coordinate System'</a> has attributes:

--- a/nidm/nidm-results/terms/README.md
+++ b/nidm/nidm-results/terms/README.md
@@ -55,11 +55,6 @@ Thank you in advance for taking part in NIDM-Results term curation!
     <td><b>nidm:'SPM Results': </b>&lt;undefined&gt;</td>
 </tr>
 <tr>
-    <td><img src="../../../doc/content/specs/img/red.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/284">#284</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='World Coordinate System'"> [more] </a></td>
-    <td><b>nidm:'World Coordinate System': </b>&lt;undefined&gt;</td>
-</tr>
-<tr>
     <td><img src="../../../doc/content/specs/img/yellow.png?raw=true"/>  </td>
     <td>Under discussion at <a href="https://github.com/ISA-tools/stato/pull/28">ISA-tools/stato#28</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Arbitrarily Correlated Error'"> [more] </a></td>
     <td><b>nidm:'Arbitrarily Correlated Error': </b>&lt;undefined&gt; (editor: TN)</td>
@@ -76,28 +71,13 @@ Thank you in advance for taking part in NIDM-Results term curation!
 </tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/orange.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/284">#284</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Custom Coordinate System'"> [more] </a></td>
-    <td><b>nidm:'Custom Coordinate System': </b>&lt;undefined&gt;</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/orange.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/284">#284</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='MNI Coordinate System'"> [more] </a></td>
-    <td><b>nidm:'MNI Coordinate System': </b>Coordinate system defined with reference to the MNI atlas</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/orange.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/284">#284</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Standardized Coordinate System'"> [more] </a></td>
+    <td>Discussed at <a href="https://github.com/incf-nidash/nidm/pull/284">#284</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Standardized Coordinate System'"> [find issues/PR] </a></td>
     <td><b>nidm:'Standardized Coordinate System': </b>Parent of all reference spaces except "Subject"</td>
 </tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/orange.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/284">#284</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Subject Coordinate System'"> [more] </a></td>
-    <td><b>nidm:'Subject Coordinate System': </b>Coordinate system defined by the subject brain (no spatial normalisation applied)</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/orange.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/284">#284</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Talairach Coordinate System'"> [more] </a></td>
-    <td><b>nidm:'Talairach Coordinate System': </b>Reference space defined by the dissected brain used for the Talairach and Tournoux atlas</td>
+    <td>Discussed at <a href="https://github.com/incf-nidash/nidm/pull/284">#284</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Subject Coordinate System'"> [find issues/PR] </a></td>
+    <td><b>nidm:'Subject Coordinate System': </b>Reference space corresponding to the subject brain (no spatial normalization applied)</td>
 </tr>
 </table><h2>Properties</h2>
 <table>
@@ -251,13 +231,6 @@ Thank you in advance for taking part in NIDM-Results term curation!
 </tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/orange.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/284">#284</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='in World Coordinate System'"> [more] </a></td>
-    <td><b>nidm:'in World Coordinate System': </b>Type of coordinate system</td>
-    <td>nidm:NIDM_0000016 </td>
-    <td>nidm:NIDM_0000081 </td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/orange.png?raw=true"/>  </td>
     <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/173">#173</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='noise FWHM'"> [more] </a></td>
     <td><b>nidm:'noise FWHM': </b>Estimated Full Width at Half Maximum of the noise distribution</td>
     <td></td>
@@ -318,83 +291,5 @@ Thank you in advance for taking part in NIDM-Results term curation!
     <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/281">#281</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='SPM's Temporal Derivative'"> [more] </a></td>
     <td><b>spm:'SPM's Temporal Derivative': </b>Hemodynamic response function basis that is the derivative with respect to time of the SPM's Canonical heamodynamic response function</td>
     <td>nidm:NIDM_0000037</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/orange.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/284">#284</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Colin27 Coordinate System'"> [more] </a></td>
-    <td><b>nidm:'Colin27 Coordinate System': </b>Coordinate system defined by the "stereotaxic average of 27 T1-weighted MRI scans of the same individual"</td>
-    <td>nidm:NIDM_0000075</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/orange.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/284">#284</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Icbm Mni152 Linear Coordinate System'"> [more] </a></td>
-    <td><b>nidm:'Icbm Mni152 Linear Coordinate System': </b>Coordinate system defined by the "average of 152 T1-weighted MRI scans, linearly transformed to Talairach space"</td>
-    <td>nidm:NIDM_0000051</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/orange.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/284">#284</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Icbm Mni152 Non Linear2009a Asymmetric Coordinate System'"> [more] </a></td>
-    <td><b>nidm:'Icbm Mni152 Non Linear2009a Asymmetric Coordinate System': </b>Coordinate system defined by the "average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space"</td>
-    <td>nidm:NIDM_0000051</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/orange.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/284">#284</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Icbm Mni152 Non Linear2009a Symmetric Coordinate System'"> [more] </a></td>
-    <td><b>nidm:'Icbm Mni152 Non Linear2009a Symmetric Coordinate System': </b>Coordinate system defined by the "average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space"</td>
-    <td>nidm:NIDM_0000051</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/orange.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/284">#284</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Icbm Mni152 Non Linear2009b Asymmetric Coordinate System'"> [more] </a></td>
-    <td><b>nidm:'Icbm Mni152 Non Linear2009b Asymmetric Coordinate System': </b>Coordinate system defined by the "average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space"</td>
-    <td>nidm:NIDM_0000051</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/orange.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/284">#284</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Icbm Mni152 Non Linear2009b Symmetric Coordinate System'"> [more] </a></td>
-    <td><b>nidm:'Icbm Mni152 Non Linear2009b Symmetric Coordinate System': </b>Coordinate system defined by the "average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space"</td>
-    <td>nidm:NIDM_0000051</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/orange.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/284">#284</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Icbm Mni152 Non Linear2009c Asymmetric Coordinate System'"> [more] </a></td>
-    <td><b>nidm:'Icbm Mni152 Non Linear2009c Asymmetric Coordinate System': </b>Coordinate system defined by the "average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space"</td>
-    <td>nidm:NIDM_0000051</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/orange.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/284">#284</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Icbm Mni152 Non Linear2009c Symmetric Coordinate System'"> [more] </a></td>
-    <td><b>nidm:'Icbm Mni152 Non Linear2009c Symmetric Coordinate System': </b>Coordinate system defined by the "average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space"</td>
-    <td>nidm:NIDM_0000051</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/orange.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/284">#284</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Icbm Mni152 Non Linear6th Generation Coordinate System'"> [more] </a></td>
-    <td><b>nidm:'Icbm Mni152 Non Linear6th Generation Coordinate System': </b>Coordinate system defined by the "average of 152 T1-weighted MRI scans, linearly and non-linearly (6 iterations) transformed to form a symmetric model in Talairach space"</td>
-    <td>nidm:NIDM_0000051</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/orange.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/284">#284</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Icbm452 Air Coordinate System'"> [more] </a></td>
-    <td><b>nidm:'Icbm452 Air Coordinate System': </b>Coordinate system defined by the "average of 452 T1-weighted MRIs of normal young adult brains" with "linear transforms of the subjects into the atlas space using a 12-parameter affine transformation"</td>
-    <td>nidm:NIDM_0000051</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/orange.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/284">#284</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Icbm452 Warp5 Coordinate System'"> [more] </a></td>
-    <td><b>nidm:'Icbm452 Warp5 Coordinate System': </b>Coordinate system defined by the "average of 452 T1-weighted MRIs of normal young adult brains" "based on a 5th order polynomial transformation into the atlas space"</td>
-    <td>nidm:NIDM_0000051</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/orange.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/284">#284</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Ixi549 Coordinate System'"> [more] </a></td>
-    <td><b>nidm:'Ixi549 Coordinate System': </b>Coordinate system defined by the average of the "549 [...] subjects from the IXI dataset" linearly transformed to ICBM MNI 452</td>
-    <td>nidm:NIDM_0000051</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/orange.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/284">#284</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Mni305 Coordinate System'"> [more] </a></td>
-    <td><b>nidm:'Mni305 Coordinate System': </b>Coordinate system defined by the "average of 305 T1-weighted MRI scans, linearly transformed to Talairach space"</td>
-    <td>nidm:NIDM_0000051</td>
 </tr>
 </table>

--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -241,15 +241,13 @@ nidm:NIDM_0000105 rdf:type owl:ObjectProperty ;
                   
                   rdfs:label "in World Coordinate System" ;
                   
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/284" ;
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/284" ;
                   
-                  obo:IAO_0000115 "Type of coordinate system." ;
+                  obo:IAO_0000115 "Property that associates a world coordinate system to the coordinate space." ;
                   
-                  obo:IAO_0000114 obo:IAO_0000120 ;
+                  obo:IAO_0000114 obo:IAO_0000122 ;
                   
                   rdfs:domain nidm:NIDM_0000016 ;
-                  
-                  obo:IAO_0000112 nidm:NIDM_0000051 ;
                   
                   rdfs:range nidm:NIDM_0000081 .
 
@@ -693,13 +691,11 @@ nidm:NIDM_0000105 rdf:type owl:DatatypeProperty ;
                   
                   rdfs:label "in World Coordinate System" ;
                   
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/284" ;
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/284" ;
                   
-                  obo:IAO_0000115 "Type of coordinate system." ;
+                  obo:IAO_0000115 "Property that associates a world coordinate system to the coordinate space." ;
                   
-                  obo:IAO_0000114 obo:IAO_0000120 ;
-                  
-                  obo:IAO_0000112 nidm:NIDM_0000051 .
+                  obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -2030,9 +2026,11 @@ nidm:NIDM_0000017 rdf:type owl:Class ;
                   
                   rdfs:subClassOf nidm:NIDM_0000075 ;
                   
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/284" ;
+                  obo:IAO_0000115 "Custom (unknown) reference space selected by the user" ;
                   
-                  obo:IAO_0000114 obo:IAO_0000120 .
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/284" ;
+                  
+                  obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -2420,11 +2418,11 @@ nidm:NIDM_0000051 rdf:type owl:Class ;
                   
                   rdfs:seeAlso "birnlex_2125" ;
                   
-                  obo:IAO_0000115 "Coordinate system defined with reference to the MNI atlas." ;
+                  obo:IAO_0000115 "MNI 305 coordinate system or any coordinate system derived from MNI 305." ;
                   
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/284" ;
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/284" ;
                   
-                  obo:IAO_0000114 obo:IAO_0000120 .
+                  obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -2804,7 +2802,7 @@ nidm:NIDM_0000075 rdf:type owl:Class ;
                   
                   obo:IAO_0000115 "Parent of all reference spaces except \"Subject\"." ;
                   
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/284" ;
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/284" ;
                   
                   obo:IAO_0000114 obo:IAO_0000120 .
 
@@ -2836,11 +2834,11 @@ nidm:NIDM_0000077 rdf:type owl:Class ;
                   
                   rdfs:subClassOf nidm:NIDM_0000081 ;
                   
-                  obo:IAO_0000115 "Coordinate system defined by the subject brain (no spatial normalisation applied)." ;
-                  
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/284" ;
+                  obo:IAO_0000115 "Reference space corresponding to the subject brain (no spatial normalization applied)." ;
                   
                   rdfs:comment "Used in FSL and SPM un-registered data." ;
+                  
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/284" ;
                   
                   obo:IAO_0000114 obo:IAO_0000120 .
 
@@ -2854,13 +2852,13 @@ nidm:NIDM_0000078 rdf:type owl:Class ;
                   
                   rdfs:subClassOf nidm:NIDM_0000075 ;
                   
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/284" ;
+                  obo:IAO_0000115 "Reference space defined by the dissected brain used for the Talairach and Tournoux atlas (cf. http://www.talairach.org/about.html)" ;
+                  
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/284" ;
                   
                   rdfs:seeAlso "http://www.talairach.org/" ;
                   
-                  obo:IAO_0000115 "Reference space defined by the dissected brain used for the Talairach and Tournoux atlas." ;
-                  
-                  obo:IAO_0000114 obo:IAO_0000120 .
+                  obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -2904,9 +2902,12 @@ nidm:NIDM_0000081 rdf:type owl:Class ;
                   
                   rdfs:subClassOf prov:Entity ;
                   
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/284" ;
+                  obo:IAO_0000115 """Reference space on which real-world positions are expressed (cf. [Nifti-1 FAQ question 14](http://nifti.nimh.nih.gov/nifti-1/documentation/faq#Q14) and [Understanding affines on nipy](http://nipy.org/nipy/stable/devel/code_discussions/understanding_affines.html)
+). A world coordinate system can be represented by an image obtained by registering an initial set of images, using a given normalization algorithm to match a target template.""" ;
                   
-                  obo:IAO_0000114 obo:IAO_0000124 .
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/284" ;
+                  
+                  obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -3151,15 +3152,15 @@ nidm:NIDM_0000009 rdf:type nidm:NIDM_0000075 ,
                   
                   rdfs:label "Colin27 Coordinate System" ;
                   
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/284" ;
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/284" ;
+                  
+                  obo:IAO_0000115 "Reference space defined as the stereotaxic average of 27 T1-weighted MRI scans of the same individual transformed into the Talairach stereotaxic space (cf. http://www.bic.mni.mcgill.ca/ServicesAtlases/Colin27Highres and http://neuro.debian.net/pkgs/mni-colin27-nifti.html). This is the default in SPM96 (cf. [MRC CBSU Wiki](http://imaging.mrc-cbu.cam.ac.uk/imaging/MniTalairach))." ;
                   
                   rdfs:comment "used in SPM96 (cf. http://imaging.mrc-cbu.cam.ac.uk/imaging/MniTalairach)" ;
                   
                   rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/Colin27Highres" ;
                   
-                  obo:IAO_0000115 "Coordinate system defined by the \"stereotaxic average of 27 T1-weighted MRI scans of the same individual\"." ;
-                  
-                  obo:IAO_0000114 obo:IAO_0000120 .
+                  obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -3170,13 +3171,13 @@ nidm:NIDM_0000038 rdf:type nidm:NIDM_0000051 ,
                   
                   rdfs:label "Icbm452 Air Coordinate System" ;
                   
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/284" ;
-                  
-                  obo:IAO_0000115 "Coordinate system defined by the \"average of 452 T1-weighted MRIs of normal young adult brains\" with \"linear transforms of the subjects into the atlas space using a 12-parameter affine transformation\"" ;
+                  obo:IAO_0000115 "Reference space defined as the average of 452 T1-weighted MRIs of normal young adult brains after 12 parameter AIR linear transform to the MNI 305 space (cf. http://www.loni.usc.edu/ICBM/Downloads/Downloads_452T1.shtml and http://imaging.mrc-cbu.cam.ac.uk/imaging/MniTalairach)" ;
                   
                   rdfs:seeAlso "http://www.loni.usc.edu/ICBM/Downloads/Downloads_452T1.shtml" ;
                   
-                  obo:IAO_0000114 obo:IAO_0000120 .
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/284" ;
+                  
+                  obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -3189,11 +3190,11 @@ nidm:NIDM_0000039 rdf:type nidm:NIDM_0000051 ,
                   
                   rdfs:seeAlso "http://www.loni.usc.edu/ICBM/Downloads/Downloads_452T1.shtml" ;
                   
-                  obo:IAO_0000115 "Coordinate system defined by the \"average of 452 T1-weighted MRIs of normal young adult brains\" \"based on a 5th order polynomial transformation into the atlas space\"" ;
+                  obo:IAO_0000115 "Reference space defined as the average of 452 T1-weighted MRIs of normal young adult brains after affine and 5 order polynomial non-linear warping to the MNI 305 space (cf. http://www.loni.usc.edu/ICBM/Downloads/Downloads_452T1.shtml and http://imaging.mrc-cbu.cam.ac.uk/imaging/MniTalairach)" ;
                   
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/284" ;
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/284" ;
                   
-                  obo:IAO_0000114 obo:IAO_0000120 .
+                  obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -3206,13 +3207,13 @@ nidm:NIDM_0000040 rdf:type nidm:NIDM_0000051 ,
                   
                   rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152Lin" ;
                   
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/284" ;
-                  
                   rdfs:comment "used in SPM99 to SPM8 (cf. http://imaging.mrc-cbu.cam.ac.uk/imaging/MniTalairach and spm8/spm_templates.man)" ;
                   
-                  obo:IAO_0000115 "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, linearly transformed to Talairach space\"." ;
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/284" ;
                   
-                  obo:IAO_0000114 obo:IAO_0000120 .
+                  obo:IAO_0000115 "Reference space which is the average of 152 T1-weighted MRI scans, linearly transformed onto the MNI 305 reference space (definition adapted from: http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152Lin). This is the default in SPM99 to SPM8 (cf. [MRC CBSU Wiki](http://imaging.mrc-cbu.cam.ac.uk/imaging/MniTalairach) and spm8/spm_templates.man." ;
+                  
+                  obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -3225,11 +3226,11 @@ nidm:NIDM_0000041 rdf:type nidm:NIDM_0000051 ,
                   
                   rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009" ;
                   
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/284" ;
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/284" ;
                   
-                  obo:IAO_0000115 "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." ;
+                  obo:IAO_0000115 "Reference space defined as the average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space (cf. http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009 for more details)." ;
                   
-                  obo:IAO_0000114 obo:IAO_0000120 .
+                  obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -3240,13 +3241,13 @@ nidm:NIDM_0000042 rdf:type nidm:NIDM_0000051 ,
                   
                   rdfs:label "Icbm Mni152 Non Linear2009a Symmetric Coordinate System" ;
                   
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/284" ;
-                  
-                  obo:IAO_0000115 "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." ;
-                  
                   rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009" ;
                   
-                  obo:IAO_0000114 obo:IAO_0000120 .
+                  obo:IAO_0000115 "Reference space defined as the average of 152 T1-weighted MRI scans, non-linearly transformed to to form a symmetric model in MNI152 linear space (cf. http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009 for more details)." ;
+                  
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/284" ;
+                  
+                  obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -3257,13 +3258,13 @@ nidm:NIDM_0000043 rdf:type nidm:NIDM_0000051 ,
                   
                   rdfs:label "Icbm Mni152 Non Linear2009b Asymmetric Coordinate System" ;
                   
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/284" ;
+                  
                   rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009" ;
                   
-                  obo:IAO_0000115 "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." ;
+                  obo:IAO_0000115 "Reference space defined as the average of 152 T1-weighted MRI scans in high-resolution, non-linearly transformed to MNI152 linear space (cf. http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009 for more details)." ;
                   
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/284" ;
-                  
-                  obo:IAO_0000114 obo:IAO_0000120 .
+                  obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -3274,13 +3275,13 @@ nidm:NIDM_0000044 rdf:type nidm:NIDM_0000051 ,
                   
                   rdfs:label "Icbm Mni152 Non Linear2009b Symmetric Coordinate System" ;
                   
-                  obo:IAO_0000115 "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." ;
+                  obo:IAO_0000115 "Reference space defined as the average of 152 T1-weighted MRI scans in high-resolution, non-linearly transformed to form a symmetric model in MNI152 linear space (cf. http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009 for more details)." ;
                   
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/284" ;
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/284" ;
                   
                   rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009" ;
                   
-                  obo:IAO_0000114 obo:IAO_0000120 .
+                  obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -3293,13 +3294,13 @@ nidm:NIDM_0000045 rdf:type nidm:NIDM_0000051 ,
                   
                   rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009" ;
                   
-                  obo:IAO_0000115 "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." ;
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/284" ;
+                  
+                  obo:IAO_0000115 "Reference space defined as the average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space using the N3 algorithm (cf. http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009 for more details)." ;
                   
                   rdfs:comment "Used in DARTEL toolbox in SPM12b (cf. spm12b/spm_templates.man)" ;
                   
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/284" ;
-                  
-                  obo:IAO_0000114 obo:IAO_0000120 .
+                  obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -3312,11 +3313,11 @@ nidm:NIDM_0000046 rdf:type nidm:NIDM_0000051 ,
                   
                   rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009" ;
                   
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/284" ;
+                  obo:IAO_0000115 "Reference space defined as the average of 152 T1-weighted MRI scans, non-linearly transformed to form a symmetric model in MNI152 linear space using the N3 algorithm (cf. http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009 for more details). This is the default for DARTEL toolbox in SPM12b (cf. spm12/spm_templates.man)." ;
                   
-                  obo:IAO_0000115 "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space\"." ;
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/284" ;
                   
-                  obo:IAO_0000114 obo:IAO_0000120 .
+                  obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -3329,13 +3330,13 @@ nidm:NIDM_0000047 rdf:type nidm:NIDM_0000051 ,
                   
                   rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin6"^^xsd:anyURI ;
                   
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/284" ;
+                  obo:IAO_0000115 "Reference space defined as the average of 152 T1-weighted MRI scans, linearly and non-linearly (6 iterations) transformed to form a symmetric model in Talairach space (cf. http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin6)" ;
                   
                   rdfs:comment "Used in FSL (cf. http://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Atlases)" ;
                   
-                  obo:IAO_0000115 "Coordinate system defined by the \"average of 152 T1-weighted MRI scans, linearly and non-linearly (6 iterations) transformed to form a symmetric model in Talairach space\"" ;
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/284" ;
                   
-                  obo:IAO_0000114 obo:IAO_0000120 .
+                  obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -3346,15 +3347,15 @@ nidm:NIDM_0000050 rdf:type nidm:NIDM_0000051 ,
                   
                   rdfs:label "Ixi549 Coordinate System" ;
                   
-                  obo:IAO_0000115 "Coordinate system defined by the average of the \"549 [...] subjects from the IXI dataset\" linearly transformed to ICBM MNI 452." ;
+                  obo:IAO_0000115 "Reference space defined by the average of the 549 subjects from the IXI dataset linearly transformed to the ICBM MNI 452 (cf. spm12/spm\\_templates.man and http://biomedic.doc.ic.ac.uk/brain-development/index.php?n=Main.Datasets). This is the default in SPM12 (cf. spm12/spm_templates.man)." ;
                   
                   rdfs:seeAlso "http://biomedic.doc.ic.ac.uk/brain-development/index.php?n=Main.Datasets" ;
                   
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/284" ;
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/284" ;
                   
                   rdfs:comment "Used in SPM12b (cf. spm12b/spm_templates.man)" ;
                   
-                  obo:IAO_0000114 obo:IAO_0000120 .
+                  obo:IAO_0000114 obo:IAO_0000122 .
 
 
 
@@ -3365,13 +3366,13 @@ nidm:NIDM_0000055 rdf:type nidm:NIDM_0000051 ,
                   
                   rdfs:label "Mni305 Coordinate System" ;
                   
-                  obo:IAO_0000115 "Coordinate system defined by the \"average of 305 T1-weighted MRI scans, linearly transformed to Talairach space\"." ;
-                  
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/284" ;
+                  obo:IAO_0000115 "Reference space defined as the average of 305 T1-weighted MRI scans, linearly transformed to Talairach space (cf. http://www.bic.mni.mcgill.ca/ServicesAtlases/MNI305 for more details)" ;
                   
                   rdfs:seeAlso "http://www.bic.mni.mcgill.ca/ServicesAtlases/MNI305" ;
                   
-                  obo:IAO_0000114 obo:IAO_0000120 .
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/284" ;
+                  
+                  obo:IAO_0000114 obo:IAO_0000122 .
 
 
 


### PR DESCRIPTION
Following #52 and #123, this issue is open to curate the definitions of the terms used to model coordinate systems.

First, let's define the parent class and its associated object property:
 - **nidm:WorldCoordinateSystem**: reference space on which real-world positions are expressed (cf. [Nifti-1 FAQ question 14](http://nifti.nimh.nih.gov/nifti-1/documentation/faq#Q14) and [Understanding affines on nipy](http://nipy.org/nipy/stable/devel/code_discussions/understanding_affines.html)
). A world coordinate system can be represented by an image obtained by registering an initial set of images, using a given normalization algorithm to match a target template.
 - **nidm:inWorldCoordinateSystem**: Property that associates a world coordinate system to the coordinate space.

Terms *in italics* are individuals, **in bold** are classes:
  - ~~nidm:StandardizedCoordinateSystem~~
  
  - *nidm:TalairachCoordinateSystem*: Reference space defined by the dissected brain used for the Talairach and Tournoux atlas (cf. http://www.talairach.org/about.html).
  

  - **nidm:MNICoordinateSystem**: MNI 305 coordinate system or any coordinate system derived from MNI 305. 
    
    - *nidm:Mni305CoordinateSystem*: Reference space defined as the average of 305 T1-weighted MRI scans, linearly transformed to Talairach space (cf. http://www.bic.mni.mcgill.ca/ServicesAtlases/MNI305 for more details).

    - *nidm:IcbmMni152LinearCoordinateSystem*: Reference space which is the average of 152 T1-weighted MRI scans, linearly transformed onto the MNI 305 reference space (definition adapted from: http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152Lin). This is the default in SPM99 to SPM8 (cf. [MRC CBSU Wiki](http://imaging.mrc-cbu.cam.ac.uk/imaging/MniTalairach) and `spm8/spm_templates.man`.

    -  *nidm:IcbmMni152NonLinear2009aSymmetricCoordinateSystem*: Reference space defined as the average of 152 T1-weighted MRI scans, non-linearly transformed to to form a symmetric model in MNI152 linear space (cf. http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009 for more details).
    -  *nidm:IcbmMni152NonLinear2009aAsymmetricCoordinateSystem*: Reference space defined as the average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space (cf. http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009 for more details).
    -  *nidm:IcbmMni152NonLinear2009bSymmetricCoordinateSystem*: Reference space defined as the average of 152 T1-weighted MRI scans in high-resolution, non-linearly transformed to form a symmetric model in MNI152 linear space (cf. http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009 for more details).         
    -  *nidm:IcbmMni152NonLinear2009bAsymmetricCoordinateSystem*: Reference space defined as the average of 152 T1-weighted MRI scans in high-resolution, non-linearly transformed to MNI152 linear space (cf. http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009 for more details).
    -  *nidm:IcbmMni152NonLinear2009cSymmetricCoordinateSystem*: Reference space defined as the average of 152 T1-weighted MRI scans, non-linearly transformed to form a symmetric model in MNI152 linear space using the N3 algorithm (cf. http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009 for more details). This is the default for DARTEL toolbox in SPM12b (cf. spm12/spm_templates.man).
    -  *nidm:IcbmMni152NonLinear2009cAsymmetricCoordinateSystem*: Reference space defined as the average of 152 T1-weighted MRI scans, non-linearly transformed to MNI152 linear space using the N3 algorithm (cf. http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin2009 for more details).
      
    - *nidm:IcbmMni152NonLinear6thGenerationCoordinateSystem*: Reference space defined as the average of 152 T1-weighted MRI scans, linearly and non-linearly (6 iterations) transformed to form a symmetric model in Talairach space (cf. http://www.bic.mni.mcgill.ca/ServicesAtlases/ICBM152NLin6)"
     
    - *nidm:Icbm452AirCoordinateSystem*: Reference space defined as the average of 452 T1-weighted MRIs of normal young adult brains after 12 parameter AIR linear transform to the MNI 305 space (cf. http://www.loni.usc.edu/ICBM/Downloads/Downloads_452T1.shtml and http://imaging.mrc-cbu.cam.ac.uk/imaging/MniTalairach)
    - *nidm:Icbm452Warp5CoordinateSystem*: Reference space defined as the average of 452 T1-weighted MRIs of normal young adult brains after affine and 5 order polynomial non-linear warping to the MNI 305 space (cf. http://www.loni.usc.edu/ICBM/Downloads/Downloads_452T1.shtml and http://imaging.mrc-cbu.cam.ac.uk/imaging/MniTalairach)
     
    - *nidm:Ixi549CoordinateSystem*: Reference space defined by the average of the 549 subjects from the IXI dataset linearly transformed to the ICBM MNI 452 (cf. spm12/spm\_templates.man and http://biomedic.doc.ic.ac.uk/brain-development/index.php?n=Main.Datasets). This is the default in SPM12 (cf. spm12/spm_templates.man).

  - *nidm:Colin27CoordinateSystem*: Reference space defined as the stereotaxic average of 27 T1-weighted MRI scans of the same individual transformed into the Talairach stereotaxic space (cf. http://www.bic.mni.mcgill.ca/ServicesAtlases/Colin27Highres and http://neuro.debian.net/pkgs/mni-colin27-nifti.html). This is the default in SPM96 (cf. [MRC CBSU Wiki](http://imaging.mrc-cbu.cam.ac.uk/imaging/MniTalairach)).
   
  - **nidm:CustomCoordinateSystem**: Custom (unknown) reference space selected by the user.
    
  - **nidm:SubjectCoordinateSystem**: Reference space corresponding to the subject brain (no spatial normalisation applied).

Note: these definitions mostly come from the table discussed in #52. 

Please let me know what you think. Thank you!