### PR TITLE
Further STATO reuse: Design Matrix and Z statistic

### DIFF
--- a/doc/content/specs/nidm-results_dev.html
+++ b/doc/content/specs/nidm-results_dev.html
@@ -604,7 +604,7 @@ niiri:data_id a prov:Entity , nidm_DataScaling: , prov:Collection ;
             <section id="section-nidm:'Design Matrix'"> 
                 <h1 label="NIDM_0000019">nidm:'Design Matrix'</h1>
                 <div class="glossary-ref">
-                    A <a title="NIDM_0000019"><dfn title="NIDM_0000019">nidm:'Design Matrix'</dfn></a> is a matrix of values defining the explanatory variables used in a regression model.  Each column corresponds to one explanatory variable, each row corresponds to one observation. <a title="NIDM_0000019">nidm:'Design Matrix'</a> is a prov:Entity used by <a title="NIDM_0000001">nidm:'Contrast Estimation'</a>, <a title="NIDM_0000056">nidm:'Model Parameters Estimation'</a>. 
+                    A <a title="NIDM_0000019"><dfn title="NIDM_0000019">nidm:'Design Matrix'</dfn></a> is a <a href="http://purl.obolibrary.org/obo/STATO_0000289">stato:design matrix</a>, with additional neuroimaging attributes, including HRF and drift for first level fMRI models. <a title="NIDM_0000019">nidm:'Design Matrix'</a> is a prov:Entity used by <a title="NIDM_0000001">nidm:'Contrast Estimation'</a>, <a title="NIDM_0000056">nidm:'Model Parameters Estimation'</a>. 
                 </div>
                 <p></p>
                 <div class="attributes" id="attributes-nidm:'Design Matrix'"> A <a title="NIDM_0000019">nidm:'Design Matrix'</a> has attributes:

--- a/nidm/nidm-results/terms/README.md
+++ b/nidm/nidm-results/terms/README.md
@@ -21,11 +21,6 @@ Thank you in advance for taking part in NIDM-Results term curation!
 </tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/274">#274</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Design Matrix'"> [more] </a></td>
-    <td><b>nidm:'Design Matrix': </b>A matrix of values defining the explanatory variables used in a regression model.  Each column corresponds to one explanatory variable, each row corresponds to one observation (editor: TN)</td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
     <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/294">#294</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='Partial Conjunction Inference'"> [more] </a></td>
     <td><b>spm:'Partial Conjunction Inference': </b>The process of testing the joint significance of multiple effects to infer that some (not necessarily all) of the respective effects are real (i.e. their null hypotheses are false). If there are K effects considered, the partial conjunction degree u is the number non-null effects allowed as part of partial conjunction null hypothesis; if the partial conjunction null is rejected, it may be inferred that u+1 or more effects are real. The case of u=K-1 corresponds to proper "conjunction inference", while the case of u=0 corresponds to "global null" conjunction test. See [Friston et al. (2005). Conjunction revisited. NeuroImage, 25(3), 661-7.](http://dx.doi.org/10.1016/j.neuroimage.2005.01.013)</td>
 </tr>

--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -2077,15 +2077,13 @@ nidm:NIDM_0000019 rdf:type owl:Class ;
                   
                   obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/DesignMatrix.txt"^^xsd:anyURI ;
                   
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/274" ;
+                  
                   rdfs:seeAlso "stato:design matrix" ;
                   
-                  obo:IAO_0000117 "TN" ;
+                  obo:IAO_0000115 "A [stato:design matrix](http://purl.obolibrary.org/obo/STATO_0000289), with additional neuroimaging attributes, including HRF and drift for first level fMRI models" ;
                   
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/274" ;
-                  
-                  obo:IAO_0000115 "A matrix of values defining the explanatory variables used in a regression model.  Each column corresponds to one explanatory variable, each row corresponds to one observation." ;
-                  
-                  obo:IAO_0000114 obo:IAO_0000125 .
+                  obo:IAO_0000114 obo:IAO_0000122 .
 
 
 


### PR DESCRIPTION
I propose the following actions

* **nidm:DesignMatrix** :  Replace with external term "design matrix" http://purl.obolibrary.org/obo/STATO_0000289 (in fact proposed by Nolan!)
* **nidm:ZStatistic** : This term can be deleted.  (SPM & FSL have nidm:equivalentZStatistic on the results page).  The term "z-score" can also be directly references: http://purl.obolibrary.org/obo/STATO_0000104 


Current definitions: 
* **nidm:DesignMatrix** :  A matrix of values defining the explanatory variables used in a regression model. Each column corresponds to one explanatory variable, each row corresponds to one observation 
* **nidm:ZStatistic** : *undefined* 

@jbpoline , @cmaumet: Comments?

(See PURL links for STATO definitions)
