### PR TITLE
noiseFWHM: see also "Full width at half maximum"

### DIFF
--- a/nidm/nidm-results/terms/README.md
+++ b/nidm/nidm-results/terms/README.md
@@ -221,13 +221,6 @@ Thank you in advance for taking part in NIDM-Results term curation!
 </tr>
 <tr>
     <td><img src="../../../doc/content/specs/img/orange.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/173">#173</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='noise FWHM'"> [more] </a></td>
-    <td><b>nidm:'noise FWHM': </b>Estimated Full Width at Half Maximum of the noise distribution</td>
-    <td></td>
-    <td></td>
-</tr>
-<tr>
-    <td><img src="../../../doc/content/specs/img/orange.png?raw=true"/>  </td>
     <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/130">#130</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='random Field Stationarity'"> [more] </a></td>
     <td><b>nidm:'random Field Stationarity': </b>Is the random field assumed to be stationary across the entire search volume?</td>
     <td>nidm:NIDM_0000068 </td>

--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -775,24 +775,6 @@ nidm:NIDM_0000109 rdf:type owl:DatatypeProperty ;
 
 
 
-###  http://purl.org/nidash/nidm#NIDM_0000110
-
-nidm:NIDM_0000110 rdf:type owl:DatatypeProperty ;
-                  
-                  rdfs:label "noise FWHM" ;
-                  
-                  obo:IAO_0000115 "Estimated Full Width at Half Maximum of the noise distribution." ;
-                  
-                  rdfs:seeAlso "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#Full_Width_at_Half_Maximum" ;
-                  
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/173" ;
-                  
-                  obo:IAO_0000112 "2.35" ;
-                  
-                  obo:IAO_0000114 obo:IAO_0000120 .
-
-
-
 ###  http://purl.org/nidash/nidm#NIDM_0000111
 
 nidm:NIDM_0000111 rdf:type owl:DatatypeProperty ;
@@ -1474,9 +1456,9 @@ spm:noiseFWHMInUnits rdf:type owl:DatatypeProperty ;
                      
                      rdfs:domain nidm:NIDM_0000068 ;
                      
-                     rdfs:subPropertyOf nidm:NIDM_0000110 ;
+                     rdfs:range xsd:string ;
                      
-                     rdfs:range xsd:string .
+                     rdfs:subPropertyOf owl:topDataProperty .
 
 
 
@@ -1498,7 +1480,7 @@ spm:noiseFWHMInVertices rdf:type owl:DatatypeProperty ;
                         
                         rdfs:domain nidm:NIDM_0000054 ;
                         
-                        rdfs:subPropertyOf nidm:NIDM_0000110 .
+                        rdfs:subPropertyOf owl:topDataProperty .
 
 
 
@@ -1523,9 +1505,9 @@ spm:noiseFWHMInVoxels rdf:type owl:DatatypeProperty ;
                       
                       rdfs:domain nidm:NIDM_0000068 ;
                       
-                      rdfs:subPropertyOf nidm:NIDM_0000110 ;
+                      rdfs:range xsd:string ;
                       
-                      rdfs:range xsd:string .
+                      rdfs:subPropertyOf owl:topDataProperty .
 
 
 


### PR DESCRIPTION
**Term**: `noiseFWHM `
**Current definition**: "Estimated Full Width at Half Maximum of the noise distribution."
**See also**: [Full_Width_at_Half_Maximum](http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#Full_Width_at_Half_Maximum)

---

@Jessica Turner `03:44 5 Mar 2013`
[Commenting on "see also: http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#Full_Width_at_Half_Maximum"]

this is the definition of FWHM, not the FWHM of the noise, per se
	
@cmaumet `08:41 24 Apr`
Would it be better to have the NCICB FWHM term as a parent of noiseFWHM?
	
@nicholsn `22:02 24 Apr`
noiseFWHM seems more like an attribute of some entity whose FWHM was calculated. Child terms should stand in an "is-a" relationship with parent terms. Following this which would you choose?

noiseFWHM is-a noiseMeasure
or
noiseFWHM is-a FWHM
	
@cmaumet `11:30 25 Apr`
noiseFWHMInUnits is an attribute of MaskMap (but as commented elsewhere we probably want another type for that entity). 

I would say noiseFWHM is-a FWHM of the noise. Does that make sense?