### PR TITLE
Definition of "randomFieldStationarity"

### DIFF
--- a/nidm/nidm-results/terms/README.md
+++ b/nidm/nidm-results/terms/README.md
@@ -100,13 +100,6 @@ Thank you in advance for taking part in NIDM-Results term curation!
     <td></td>
 </tr>
 <tr>
-    <td><img src="../../../doc/content/specs/img/green.png?raw=true"/>  </td>
-    <td>Under discussion at <a href="https://github.com/incf-nidash/nidm/pull/130">#130</a><br/><a href="https://github.com/incf-nidash/nidm//issues?&q='random Field Stationarity'"> [more] </a></td>
-    <td><b>nidm:'random Field Stationarity': </b>A binary flag that indicates whether Random Field Theory methods assumed smoothness that was homogeneous over the map (true), or allowed for smoothness that varies over the map (false)</td>
-    <td>nidm:NIDM_0000068 </td>
-    <td>xsd:boolean </td>
-</tr>
-<tr>
     <td><img src="../../../doc/content/specs/img/orange.png?raw=true"/>  </td>
     <td><a href="https://github.com/incf-nidash/nidm//issues?&q='user Specified Threshold Type'"> [find issues/PR] </a></td>
     <td><b>nidm:'user Specified Threshold Type': </b>Type of method used to define a threshold (e.g. statistic value, uncorrected P-value or corrected P-value) (editor: Discussed in https://github.com/incf-nidash/nidm/pull/150)</td>

--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -950,11 +950,11 @@ nidm:NIDM_0000120 rdf:type owl:DatatypeProperty ;
                   
                   rdfs:label "random Field Stationarity" ;
                   
-                  obo:IAO_0000116 "Under discussion at https://github.com/incf-nidash/nidm/issues/130" ;
+                  obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/130" ;
                   
                   obo:IAO_0000115 "A binary flag that indicates whether Random Field Theory methods assumed smoothness that was homogeneous over the map (true), or allowed for smoothness that varies over the map (false)." ;
                   
-                  obo:IAO_0000114 obo:IAO_0000125 ;
+                  obo:IAO_0000114 obo:IAO_0000122 ;
                   
                   rdfs:domain nidm:NIDM_0000068 ;
                   


### PR DESCRIPTION
**Original term**: `nonStationaryRandomField`
**Original definition**: "Random field that is variable across the search volume".
**Original comment**: [link](https://docs.google.com/spreadsheets/d/16pC2cDsdxlzv2CzlNMtStqt5-xHwDEsU6MjZVxWhrE4/edit?disco=AAAAAJVbYzE)

**Current term**: `randomFieldStationarity`
**Current link**:  [nidm-results.owl/nonStationaryRandomField](https://github.com/incf-nidash/nidm/blob/master/nidm/nidm-results/nidm-results.owl#L619-L632)
**Current definition**: "Is the random field assumed to be stationary across the entire search volume?" 

---

@cmaumet `10:44 9 Apr`
This also needs to be reviewed.
	
@khelm `19:39 23 Apr`
Yes, I agree. How about "A stochastic process that is indexed by a spatial variable in which the process has a mean, variance or covariance that varies over the spatial domain."