### PR TITLE
New script: create a NIDM-Results release

### DIFF
--- a/doc/content/specs/nidm-results_100.html
+++ b/doc/content/specs/nidm-results_100.html
@@ -386,11 +386,11 @@
 niiri:coordinate_space_id_1 a prov:Entity , nidm_CoordinateSpace: ;
 	rdfs:label "Coordinate space 1" ;
 	nidm_voxelToWorldMapping: "[[-3, 0, 0, 78],[0, 3, 0, -112],[0, 0, 3, -50],[0, 0, 0, 1]]"^^xsd:string ;
-	nidm_voxelUnits: "[ 'mm', 'mm', 'mm' ]"^^xsd:string ;
-	nidm_voxelSize: "[ 3, 3, 3 ]"^^xsd:string ;
+	nidm_voxelUnits: "['mm', 'mm', 'mm']"^^xsd:string ;
+	nidm_voxelSize: "[3, 3, 3]"^^xsd:string ;
 	nidm_inWorldCoordinateSystem: nidm_MNICoordinateSystem: ;
 	nidm_numberOfDimensions: "3"^^xsd:int ;
-	nidm_dimensionsInVoxels: "[ 53, 63, 46 ]"^^xsd:string .</pre>
+	nidm_dimensionsInVoxels: "[53,63,46]"^^xsd:string .</pre>
             <!-- nidm:'Custom Coordinate System' (NIDM_0000017) -->
             <section id="section-nidm:'Custom Coordinate System'">
                 <h1 label="NIDM_0000017">nidm:'Custom Coordinate System'</h1>
@@ -1252,7 +1252,7 @@ niiri:contrast_estimation_id a prov:Activity , nidm_ContrastEstimation: ;
 
 niiri:contrast_id a prov:Entity , obo_contrastweightmatrix: ;
 	rdfs:label "Contrast: Listening &gt; Rest" ;
-	prov:value "[ 1, 0, 0 ]"^^xsd:string ;
+	prov:value "[1, 0, 0]"^^xsd:string ;
 	nidm_statisticType: obo_tstatistic: ; # obo:'t-statistic'
 	nidm_contrastName: "listening &gt; rest"^^xsd:string .</pre>
             </section>
@@ -1633,7 +1633,7 @@ niiri:cluster_label_map_id a prov:Entity , nidm_ClusterLabelsMap: ;
 
 niiri:coordinate_0001 a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate: 0001" ;
-	nidm_coordinateVector: "[ -60, -28, 13 ]"^^xsd:string .</pre>
+	nidm_coordinateVector: "[-60, -28, 13]"^^xsd:string .</pre>
             </section>
             <!-- nidm:'Display Mask Map' (NIDM_0000020) -->
             <section id="section-nidm:'Display Mask Map'">
@@ -1697,9 +1697,9 @@ niiri:display_map_id a prov:Entity , nidm_DisplayMaskMap: ;
 
 niiri:excursion_set_map_id a prov:Entity , nidm_ExcursionSetMap: ;
 	rdfs:label "Excursion Set Map" ;
-	prov:atLocation "file:///path/to/ExcursionSet.nii.gz"^^xsd:anyURI ;
+	prov:atLocation "file:///path/to/ExcursionSetMap.nii.gz"^^xsd:anyURI ;
 	dct:format "image/nifti"^^xsd:string ;
-	nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
+	nfo:fileName "ExcursionSetMap.nii.gz"^^xsd:string ;
 	nidm_hasClusterLabelsMap: niiri:cluster_label_map_id ;
 	nidm_hasMaximumIntensityProjection: niiri:maximum_intensity_projection_id ;
 	nidm_inCoordinateSpace: niiri:coordinate_space_id_1 ;
@@ -1901,8 +1901,8 @@ niiri:search_space_mask_id a prov:Entity , nidm_SearchSpaceMaskMap: ;
 	nidm_reselSizeInVoxels: "22.9229643140043"^^xsd:float ;
 	nidm_searchVolumeInResels: "2552.68032521656"^^xsd:float ;
 	spm_searchVolumeReselsGeometry: "[3, 72.3216126440484, 850.716735116472, 2552.68032521656]"^^xsd:string ;
-	spm_noiseFWHMInVoxels: "[ 2.95881189165801, 2.96628446669584, 2.61180425626264 ]"^^xsd:string ;
-	spm_noiseFWHMInUnits: "[ 8.87643567497404, 8.89885340008753, 7.83541276878791 ]"^^xsd:string ;
+	spm_noiseFWHMInVoxels: "[2.95881189165801, 2.96628446669584, 2.61180425626264]"^^xsd:string ;
+	spm_noiseFWHMInUnits: "[8.87643567497404, 8.89885340008753, 7.83541276878791]"^^xsd:string ;
 	nidm_randomFieldStationarity: "false"^^xsd:boolean ;
 	crypto:sha512 "e43b6e01b0463fe7d40782137867a..."^^xsd:string ;
 	prov:wasGeneratedBy niiri:inference_id .</pre>

--- a/doc/content/specs/nidm-results_dev.html
+++ b/doc/content/specs/nidm-results_dev.html
@@ -801,39 +801,18 @@ niiri:error_model_id a prov:Entity , nidm_ErrorModel: ;
                 <h1 label="NIDM_0000003">nidm:'Arbitrarily Correlated Error'</h1>
                 <div class="glossary-ref">
                     <a title="NIDM_0000003"><dfn title="NIDM_0000003">nidm:'Arbitrarily Correlated Error'</dfn></a>:  <a title="NIDM_0000003">nidm:'Arbitrarily Correlated Error'</a> is a prov:Entity.
-                </div>
-                <p></p>
-                <div class="attributes" id="attributes-nidm:'Arbitrarily Correlated Error'"> A <a title="NIDM_0000003">nidm:'Arbitrarily Correlated Error'</a> has attributes:
-                <ul>
-                    <li><span class="attribute" id="nidm:'Arbitrarily Correlated Error'.label">rdfs:label</span>:                     (<em class="rfc2119" title="OPTIONAL">OPTIONAL</em>) Human readable description of the <a title="NIDM_0000003">nidm:'Arbitrarily Correlated Error'</a>.</li>
-                        <li><a title="BFO_0000050" href ="http://purl.obolibrary.org/obo/BFO_0000050"><dfn title="BFO_0000050" href ="http://purl.obolibrary.org/obo/BFO_0000050">obo:BFO_0000050</dfn></a></span>: (<em class="rfc2119" title="OPTIONAL">OPTIONAL</em>) 
-                        <li><a title="IAO_0000136" href ="http://purl.obolibrary.org/obo/IAO_0000136"><dfn title="IAO_0000136" href ="http://purl.obolibrary.org/obo/IAO_0000136">obo:'is about'</dfn></a></span>: (<em class="rfc2119" title="OPTIONAL">OPTIONAL</em>) Is_about is a (currently) primitive relation that relates an information artifact to an entity
             </section>
             <!-- nidm:'Exchangeable Error' (NIDM_0000024) -->
             <section id="section-nidm:'Exchangeable Error'">
                 <h1 label="NIDM_0000024">nidm:'Exchangeable Error'</h1>
                 <div class="glossary-ref">
                     <a title="NIDM_0000024"><dfn title="NIDM_0000024">nidm:'Exchangeable Error'</dfn></a>:  <a title="NIDM_0000024">nidm:'Exchangeable Error'</a> is a prov:Entity.
-                </div>
-                <p></p>
-                <div class="attributes" id="attributes-nidm:'Exchangeable Error'"> A <a title="NIDM_0000024">nidm:'Exchangeable Error'</a> has attributes:
-                <ul>
-                    <li><span class="attribute" id="nidm:'Exchangeable Error'.label">rdfs:label</span>:                     (<em class="rfc2119" title="OPTIONAL">OPTIONAL</em>) Human readable description of the <a title="NIDM_0000024">nidm:'Exchangeable Error'</a>.</li>
-                        <li><a title="BFO_0000050" href ="http://purl.obolibrary.org/obo/BFO_0000050">obo:BFO_0000050</a></span>: (<em class="rfc2119" title="OPTIONAL">OPTIONAL</em>) 
-                        <li><a title="IAO_0000136" href ="http://purl.obolibrary.org/obo/IAO_0000136">obo:'is about'</a></span>: (<em class="rfc2119" title="OPTIONAL">OPTIONAL</em>) Is_about is a (currently) primitive relation that relates an information artifact to an entity
             </section>
             <!-- nidm:'Independent Error' (NIDM_0000048) -->
             <section id="section-nidm:'Independent Error'">
                 <h1 label="NIDM_0000048">nidm:'Independent Error'</h1>
                 <div class="glossary-ref">
                     <a title="NIDM_0000048"><dfn title="NIDM_0000048">nidm:'Independent Error'</dfn></a>:  <a title="NIDM_0000048">nidm:'Independent Error'</a> is a prov:Entity.
-                </div>
-                <p></p>
-                <div class="attributes" id="attributes-nidm:'Independent Error'"> A <a title="NIDM_0000048">nidm:'Independent Error'</a> has attributes:
-                <ul>
-                    <li><span class="attribute" id="nidm:'Independent Error'.label">rdfs:label</span>:                     (<em class="rfc2119" title="OPTIONAL">OPTIONAL</em>) Human readable description of the <a title="NIDM_0000048">nidm:'Independent Error'</a>.</li>
-                        <li><a title="BFO_0000050" href ="http://purl.obolibrary.org/obo/BFO_0000050">obo:BFO_0000050</a></span>: (<em class="rfc2119" title="OPTIONAL">OPTIONAL</em>) 
-                        <li><a title="IAO_0000136" href ="http://purl.obolibrary.org/obo/IAO_0000136">obo:'is about'</a></span>: (<em class="rfc2119" title="OPTIONAL">OPTIONAL</em>) Is_about is a (currently) primitive relation that relates an information artifact to an entity
             </section>
             <!-- nidm:'Binomial Distribution' (NIDM_0000005) -->
             <section id="section-nidm:'Binomial Distribution'">
@@ -1106,8 +1085,6 @@ niiri:contrast_estimation_id a prov:Activity , nidm_ContrastEstimation: ;
                 <div class="attributes" id="attributes-obo:'contrast weight matrix'"> A <a title="STATO_0000323" href ="http://purl.obolibrary.org/obo/STATO_0000323">obo:'contrast weight matrix'</a> has attributes:
                 <ul>
                     <li><span class="attribute" id="obo:'contrast weight matrix'.label">rdfs:label</span>:                     (<em class="rfc2119" title="OPTIONAL">OPTIONAL</em>) Human readable description of the <a title="STATO_0000323" href ="http://purl.obolibrary.org/obo/STATO_0000323">obo:'contrast weight matrix'</a>.</li>
-                        <li><a title="BFO_0000051" href ="http://purl.obolibrary.org/obo/BFO_0000051"><dfn title="BFO_0000051" href ="http://purl.obolibrary.org/obo/BFO_0000051">obo:BFO_0000051</dfn></a></span>: (<em class="rfc2119" title="OPTIONAL">OPTIONAL</em>) 
-                        <li><a title="IAO_0000136" href ="http://purl.obolibrary.org/obo/IAO_0000136">obo:'is about'</a></span>: (<em class="rfc2119" title="OPTIONAL">OPTIONAL</em>) Is_about is a (currently) primitive relation that relates an information artifact to an entity
                         <li><a title="NIDM_0000085"><dfn title="NIDM_0000085">nidm:'contrast Name'</dfn></a></span>: (<em class="rfc2119" title="OPTIONAL">OPTIONAL</em>) Name of the contrast (range <a title="string" href ="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>).</li>
                         <li><a title="NIDM_0000123"><dfn title="NIDM_0000123">nidm:'statistic Type'</dfn></a></span>: (<em class="rfc2119" title="OPTIONAL">OPTIONAL</em>) Property that associates a  <a href="http://purl.obolibrary.org/obo/STATO_0000039">stato:"statistic"</a> with a StatisticMap or a ContrastWeights entity (range <a title="STATO_0000039" href ="http://purl.obolibrary.org/obo/STATO_0000039">obo:'statistic'</a> such as <a title="STATO_0000030" href ="http://purl.obolibrary.org/obo/STATO_0000030">obo:'Chi-Squared statistic'</a>, <a title="STATO_0000282" href ="http://purl.obolibrary.org/obo/STATO_0000282">obo:'F-statistic'</a>, <a title="STATO_0000376" href ="http://purl.obolibrary.org/obo/STATO_0000376">obo:'Z-statistic'</a>, <a title="STATO_0000176" href ="http://purl.obolibrary.org/obo/STATO_0000176">obo:'t-statistic'</a>).</li>
                 </ul>

--- a/nidm/imports/iao_import.ttl
+++ b/nidm/imports/iao_import.ttl
@@ -409,8 +409,6 @@ obo:IAO_0000136 rdf:type owl:ObjectProperty ;
                 
                 obo:IAO_0000117 "person:Alan Ruttenberg"@en ;
                 
-                rdfs:domain obo:IAO_0000030 ;
-                
                 obo:IAO_0000114 obo:IAO_0000125 ;
                 
                 obo:IAO_0000412 <http://purl.obolibrary.org/obo/iao.owl> .
@@ -433,64 +431,6 @@ doap:revision rdf:type owl:DatatypeProperty ;
               obo:IAO_0000412 <http://purl.obolibrary.org/obo/iao.owl> ;
               
               rdfs:isDefinedBy ns:doap .
-
-
-
-
-
-#################################################################
-#
-#    Classes
-#
-#################################################################
-
-
-###  http://purl.obolibrary.org/obo/IAO_0000030
-
-obo:IAO_0000030 rdf:type owl:Class ;
-                
-                rdfs:label "information content entity"@en ;
-                
-                obo:IAO_0000116 "2014-03-10: The use of \"thing\" is intended to be general enough to include universals and configurations (see https://groups.google.com/d/msg/information-ontology/GBxvYZCk1oc/-L6B5fSBBTQJ)."@en ;
-                
-                obo:IAO_0000115 "A generically dependent continuant that is about some thing."@en ;
-                
-                obo:IAO_0000112 "Examples of information content entites include journal articles, data, graphical layouts, and graphs."@en ;
-                
-                obo:IAO_0000119 "OBI_0000142"@en ;
-                
-                obo:IAO_0000117 "PERSON: Chris Stoeckert"@en ;
-                
-                obo:IAO_0000111 "information content entity"@en ;
-                
-                obo:IAO_0000114 obo:IAO_0000122 ;
-                
-                obo:IAO_0000412 <http://purl.obolibrary.org/obo/iao.owl> .
-
-
-
-###  http://purl.obolibrary.org/obo/IAO_0000109
-
-obo:IAO_0000109 rdf:type owl:Class ;
-                
-                rdfs:label "measurement datum"@en ;
-                
-                obo:IAO_0000116 "2/2/2009 is_specified_output of some assay?"@en ;
-                
-                obo:IAO_0000115 "A measurement datum is an information content entity that is a recording of the output of a measurement such as produced by a device."@en ;
-                
-                obo:IAO_0000112 "Examples of measurement data are the recoding of the weight of a mouse as {40,mass,\"grams\"}, the recording of an observation of the behavior of the mouse {,process,\"agitated\"}, the recording of the expression level of a gene as measured through the process of microarray experiment {3.4,luminosity,}."@en ;
-                
-                obo:IAO_0000119 "OBI_0000305"@en ,
-                                "group:OBI"@en ;
-                
-                obo:IAO_0000111 "measurement datum"@en ;
-                
-                obo:IAO_0000117 "person:Chris Stoeckert"@en ;
-                
-                obo:IAO_0000114 obo:IAO_0000125 ;
-                
-                obo:IAO_0000412 <http://purl.obolibrary.org/obo/iao.owl> .
 
 
 

--- a/nidm/imports/stato_import.ttl
+++ b/nidm/imports/stato_import.ttl
@@ -1,4 +1,3 @@
-@prefix : <http://www.w3.org/2002/07/owl#> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -7,7 +6,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @base <http://purl.org/nidash/nidm/stato_import.owl> .
 
-<http://purl.org/nidash/nidm/stato_import.owl> rdf:type :Ontology .
+<http://purl.org/nidash/nidm/stato_import.owl> rdf:type owl:Ontology .
 
 
 #################################################################
@@ -19,55 +18,55 @@
 
 ###  http://purl.obolibrary.org/obo/IAO_0000112
 
-obo:IAO_0000112 rdf:type :AnnotationProperty .
+obo:IAO_0000112 rdf:type owl:AnnotationProperty .
 
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000114
 
-obo:IAO_0000114 rdf:type :AnnotationProperty .
+obo:IAO_0000114 rdf:type owl:AnnotationProperty .
 
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000115
 
-obo:IAO_0000115 rdf:type :AnnotationProperty .
+obo:IAO_0000115 rdf:type owl:AnnotationProperty .
 
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000116
 
-obo:IAO_0000116 rdf:type :AnnotationProperty .
+obo:IAO_0000116 rdf:type owl:AnnotationProperty .
 
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000117
 
-obo:IAO_0000117 rdf:type :AnnotationProperty .
+obo:IAO_0000117 rdf:type owl:AnnotationProperty .
 
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000118
 
-obo:IAO_0000118 rdf:type :AnnotationProperty .
+obo:IAO_0000118 rdf:type owl:AnnotationProperty .
 
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000119
 
-obo:IAO_0000119 rdf:type :AnnotationProperty .
+obo:IAO_0000119 rdf:type owl:AnnotationProperty .
 
 
 
 ###  http://purl.obolibrary.org/obo/STATO_0000032
 
-obo:STATO_0000032 rdf:type :AnnotationProperty .
+obo:STATO_0000032 rdf:type owl:AnnotationProperty .
 
 
 
 ###  http://purl.obolibrary.org/obo/STATO_0000041
 
-obo:STATO_0000041 rdf:type :AnnotationProperty .
+obo:STATO_0000041 rdf:type owl:AnnotationProperty .
 
 
 
@@ -82,31 +81,31 @@ obo:STATO_0000041 rdf:type :AnnotationProperty .
 
 ###  http://purl.obolibrary.org/obo/BFO_0000050
 
-obo:BFO_0000050 rdf:type :ObjectProperty .
+obo:BFO_0000050 rdf:type owl:ObjectProperty .
 
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000051
 
-obo:BFO_0000051 rdf:type :ObjectProperty .
+obo:BFO_0000051 rdf:type owl:ObjectProperty .
 
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000136
 
-obo:IAO_0000136 rdf:type :ObjectProperty .
+obo:IAO_0000136 rdf:type owl:ObjectProperty .
 
 
 
 ###  http://purl.obolibrary.org/obo/OBI_0000295
 
-obo:OBI_0000295 rdf:type :ObjectProperty .
+obo:OBI_0000295 rdf:type owl:ObjectProperty .
 
 
 
 ###  http://purl.obolibrary.org/obo/OBI_0000299
 
-obo:OBI_0000299 rdf:type :ObjectProperty .
+obo:OBI_0000299 rdf:type owl:ObjectProperty .
 
 
 
@@ -121,56 +120,56 @@ obo:OBI_0000299 rdf:type :ObjectProperty .
 
 ###  http://purl.obolibrary.org/obo/IAO_0000027
 
-obo:IAO_0000027 rdf:type :Class .
+obo:IAO_0000027 rdf:type owl:Class .
 
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000030
 
-obo:IAO_0000030 rdf:type :Class .
+obo:IAO_0000030 rdf:type owl:Class .
 
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000100
 
-obo:IAO_0000100 rdf:type :Class .
+obo:IAO_0000100 rdf:type owl:Class .
 
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000109
 
-obo:IAO_0000109 rdf:type :Class .
+obo:IAO_0000109 rdf:type owl:Class .
 
 
 
 ###  http://purl.obolibrary.org/obo/OBI_0000739
 
-obo:OBI_0000739 rdf:type :Class .
+obo:OBI_0000739 rdf:type owl:Class .
 
 
 
 ###  http://purl.obolibrary.org/obo/OBI_0200000
 
-obo:OBI_0200000 rdf:type :Class .
+obo:OBI_0200000 rdf:type owl:Class .
 
 
 
 ###  http://purl.obolibrary.org/obo/OBI_0200200
 
-obo:OBI_0200200 rdf:type :Class .
+obo:OBI_0200200 rdf:type owl:Class .
 
 
 
 ###  http://purl.obolibrary.org/obo/STATO_0000030
 
-obo:STATO_0000030 rdf:type :Class ;
+obo:STATO_0000030 rdf:type owl:Class ;
                   
                   rdfs:label "Chi-Squared statistic"@en ;
                   
                   rdfs:subClassOf obo:STATO_0000039 ,
-                                  [ rdf:type :Restriction ;
-                                    :onProperty obo:OBI_0000295 ;
-                                    :someValuesFrom obo:OBI_0200200
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty obo:OBI_0000295 ;
+                                    owl:someValuesFrom obo:OBI_0200200
                                   ] ;
                   
                   obo:IAO_0000117 "Orlaith Burke"^^xsd:string ,
@@ -188,14 +187,14 @@ obo:STATO_0000030 rdf:type :Class ;
 
 ###  http://purl.obolibrary.org/obo/STATO_0000039
 
-obo:STATO_0000039 rdf:type :Class ;
+obo:STATO_0000039 rdf:type owl:Class ;
                   
                   rdfs:label "statistic"@en ;
                   
                   rdfs:subClassOf obo:IAO_0000109 ,
-                                  [ rdf:type :Restriction ;
-                                    :onProperty obo:IAO_0000136 ;
-                                    :someValuesFrom obo:IAO_0000100
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty obo:IAO_0000136 ;
+                                    owl:someValuesFrom obo:IAO_0000100
                                   ] ;
                   
                   obo:IAO_0000117 "Orlaith Burke"^^xsd:string ;
@@ -217,32 +216,32 @@ obo:STATO_0000039 rdf:type :Class ;
 
 ###  http://purl.obolibrary.org/obo/STATO_0000052
 
-obo:STATO_0000052 rdf:type :Class .
+obo:STATO_0000052 rdf:type owl:Class .
 
 
 
 ###  http://purl.obolibrary.org/obo/STATO_0000086
 
-obo:STATO_0000086 rdf:type :Class .
+obo:STATO_0000086 rdf:type owl:Class .
 
 
 
 ###  http://purl.obolibrary.org/obo/STATO_0000108
 
-obo:STATO_0000108 rdf:type :Class .
+obo:STATO_0000108 rdf:type owl:Class .
 
 
 
 ###  http://purl.obolibrary.org/obo/STATO_0000119
 
-obo:STATO_0000119 rdf:type :Class ;
+obo:STATO_0000119 rdf:type owl:Class ;
                   
                   rdfs:label "model parameter estimation"@en ;
                   
                   rdfs:subClassOf obo:OBI_0200000 ,
-                                  [ rdf:type :Restriction ;
-                                    :onProperty obo:OBI_0000299 ;
-                                    :someValuesFrom obo:STATO_0000144
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty obo:OBI_0000299 ;
+                                    owl:someValuesFrom obo:STATO_0000144
                                   ] ;
                   
                   obo:IAO_0000117 "Orlaith Burke"^^xsd:string ;
@@ -263,20 +262,20 @@ https://github.com/ISA-tools/stato/issues/18"""@en ;
 
 ###  http://purl.obolibrary.org/obo/STATO_0000144
 
-obo:STATO_0000144 rdf:type :Class .
+obo:STATO_0000144 rdf:type owl:Class .
 
 
 
 ###  http://purl.obolibrary.org/obo/STATO_0000176
 
-obo:STATO_0000176 rdf:type :Class ;
+obo:STATO_0000176 rdf:type owl:Class ;
                   
                   rdfs:label "t-statistic"@en ;
                   
                   rdfs:subClassOf obo:STATO_0000039 ,
-                                  [ rdf:type :Restriction ;
-                                    :onProperty obo:OBI_0000295 ;
-                                    :someValuesFrom obo:OBI_0000739
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty obo:OBI_0000295 ;
+                                    owl:someValuesFrom obo:OBI_0000739
                                   ] ;
                   
                   obo:IAO_0000117 "Orlaith Burke"^^xsd:string ;
@@ -296,14 +295,14 @@ obo:STATO_0000176 rdf:type :Class ;
 
 ###  http://purl.obolibrary.org/obo/STATO_0000282
 
-obo:STATO_0000282 rdf:type :Class ;
+obo:STATO_0000282 rdf:type owl:Class ;
                   
                   rdfs:label "F-statistic"@en ;
                   
                   rdfs:subClassOf obo:STATO_0000039 ,
-                                  [ rdf:type :Restriction ;
-                                    :onProperty obo:OBI_0000295 ;
-                                    :someValuesFrom obo:STATO_0000086
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty obo:OBI_0000295 ;
+                                    owl:someValuesFrom obo:STATO_0000086
                                   ] ;
                   
                   obo:IAO_0000117 "Orlaith Burke"^^xsd:string ,
@@ -321,36 +320,36 @@ obo:STATO_0000282 rdf:type :Class ;
 
 ###  http://purl.obolibrary.org/obo/STATO_0000290
 
-obo:STATO_0000290 rdf:type :Class .
+obo:STATO_0000290 rdf:type owl:Class .
 
 
 
 ###  http://purl.obolibrary.org/obo/STATO_0000301
 
-obo:STATO_0000301 rdf:type :Class .
+obo:STATO_0000301 rdf:type owl:Class .
 
 
 
 ###  http://purl.obolibrary.org/obo/STATO_0000322
 
-obo:STATO_0000322 rdf:type :Class .
+obo:STATO_0000322 rdf:type owl:Class .
 
 
 
 ###  http://purl.obolibrary.org/obo/STATO_0000323
 
-obo:STATO_0000323 rdf:type :Class ;
+obo:STATO_0000323 rdf:type owl:Class ;
                   
                   rdfs:label "contrast weight matrix"@en ;
                   
                   rdfs:subClassOf obo:IAO_0000030 ,
-                                  [ rdf:type :Restriction ;
-                                    :onProperty obo:IAO_0000136 ;
-                                    :someValuesFrom obo:STATO_0000290
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty obo:IAO_0000136 ;
+                                    owl:someValuesFrom obo:STATO_0000290
                                   ] ,
-                                  [ rdf:type :Restriction ;
-                                    :onProperty obo:BFO_0000051 ;
-                                    :someValuesFrom obo:STATO_0000322
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty obo:BFO_0000051 ;
+                                    owl:someValuesFrom obo:STATO_0000322
                                   ] ;
                   
                   obo:IAO_0000117 "Alejandra Gonzalez-Beltran"@en ,
@@ -372,18 +371,18 @@ obo:STATO_0000323 rdf:type :Class ;
 
 ###  http://purl.obolibrary.org/obo/STATO_0000346
 
-obo:STATO_0000346 rdf:type :Class ;
+obo:STATO_0000346 rdf:type owl:Class ;
                   
                   rdfs:label "covariance structure"@en ;
                   
                   rdfs:subClassOf obo:IAO_0000027 ,
-                                  [ rdf:type :Restriction ;
-                                    :onProperty obo:BFO_0000050 ;
-                                    :someValuesFrom :regression_model
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty obo:IAO_0000136 ;
+                                    owl:someValuesFrom obo:STATO_0000301
                                   ] ,
-                                  [ rdf:type :Restriction ;
-                                    :onProperty obo:IAO_0000136 ;
-                                    :someValuesFrom obo:STATO_0000301
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty obo:BFO_0000050 ;
+                                    owl:someValuesFrom owl:regression_model
                                   ] ;
                   
                   obo:IAO_0000117 "Orlaith Burke" ,
@@ -403,7 +402,7 @@ obo:STATO_0000346 rdf:type :Class ;
 
 ###  http://purl.obolibrary.org/obo/STATO_0000357
 
-obo:STATO_0000357 rdf:type :Class ;
+obo:STATO_0000357 rdf:type owl:Class ;
                   
                   rdfs:label "Toeplitz covariance structure"@en ;
                   
@@ -431,7 +430,7 @@ obo:STATO_0000357 rdf:type :Class ;
 
 ###  http://purl.obolibrary.org/obo/STATO_0000362
 
-obo:STATO_0000362 rdf:type :Class ;
+obo:STATO_0000362 rdf:type owl:Class ;
                   
                   rdfs:label "compound symmetry covariance structure"@en ;
                   
@@ -458,14 +457,14 @@ obo:STATO_0000362 rdf:type :Class ;
 
 ###  http://purl.obolibrary.org/obo/STATO_0000370
 
-obo:STATO_0000370 rdf:type :Class ;
+obo:STATO_0000370 rdf:type owl:Class ;
                   
                   rdfs:label "ordinary least squares estimation"@en ;
                   
                   rdfs:subClassOf obo:STATO_0000119 ,
-                                  [ rdf:type :Restriction ;
-                                    :onProperty obo:BFO_0000050 ;
-                                    :someValuesFrom obo:STATO_0000108
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty obo:BFO_0000050 ;
+                                    owl:someValuesFrom obo:STATO_0000108
                                   ] ;
                   
                   obo:STATO_0000032 "OLS estimation" ;
@@ -489,14 +488,14 @@ obo:STATO_0000370 rdf:type :Class ;
 
 ###  http://purl.obolibrary.org/obo/STATO_0000371
 
-obo:STATO_0000371 rdf:type :Class ;
+obo:STATO_0000371 rdf:type owl:Class ;
                   
                   rdfs:label "weighted least squares estimation"@en ;
                   
                   rdfs:subClassOf obo:STATO_0000119 ,
-                                  [ rdf:type :Restriction ;
-                                    :onProperty obo:BFO_0000050 ;
-                                    :someValuesFrom obo:STATO_0000108
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty obo:BFO_0000050 ;
+                                    owl:someValuesFrom obo:STATO_0000108
                                   ] ;
                   
                   obo:STATO_0000032 "WLS estimation" ;
@@ -519,14 +518,14 @@ obo:STATO_0000371 rdf:type :Class ;
 
 ###  http://purl.obolibrary.org/obo/STATO_0000372
 
-obo:STATO_0000372 rdf:type :Class ;
+obo:STATO_0000372 rdf:type owl:Class ;
                   
                   rdfs:label "generalized least squares estimation"@en ;
                   
                   rdfs:subClassOf obo:STATO_0000119 ,
-                                  [ rdf:type :Restriction ;
-                                    :onProperty obo:BFO_0000050 ;
-                                    :someValuesFrom obo:STATO_0000108
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty obo:BFO_0000050 ;
+                                    owl:someValuesFrom obo:STATO_0000108
                                   ] ;
                   
                   obo:STATO_0000032 "GLS estimation" ;
@@ -546,14 +545,14 @@ obo:STATO_0000372 rdf:type :Class ;
 
 ###  http://purl.obolibrary.org/obo/STATO_0000373
 
-obo:STATO_0000373 rdf:type :Class ;
+obo:STATO_0000373 rdf:type owl:Class ;
                   
                   rdfs:label "iteratively reweighted least squares estimation"@en ;
                   
                   rdfs:subClassOf obo:STATO_0000119 ,
-                                  [ rdf:type :Restriction ;
-                                    :onProperty obo:BFO_0000050 ;
-                                    :someValuesFrom obo:STATO_0000108
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty obo:BFO_0000050 ;
+                                    owl:someValuesFrom obo:STATO_0000108
                                   ] ;
                   
                   obo:IAO_0000117 "Alejandra Gonzalez-Beltran" ,
@@ -575,14 +574,14 @@ obo:STATO_0000373 rdf:type :Class ;
 
 ###  http://purl.obolibrary.org/obo/STATO_0000374
 
-obo:STATO_0000374 rdf:type :Class ;
+obo:STATO_0000374 rdf:type owl:Class ;
                   
                   rdfs:label "feasible generalized least squares estimation"@en ;
                   
                   rdfs:subClassOf obo:STATO_0000372 ,
-                                  [ rdf:type :Restriction ;
-                                    :onProperty obo:BFO_0000050 ;
-                                    :someValuesFrom obo:STATO_0000108
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty obo:BFO_0000050 ;
+                                    owl:someValuesFrom obo:STATO_0000108
                                   ] ;
                   
                   obo:IAO_0000115 "the feasible generalized least squares estimation is a model parameter estimation which is a practical implementation of Generalised Least Squares, where the covariance of the errors is estimated from the residuals of the regression model, providing the information needed to whiten the data and model. Each successive estimate of the whitening matrix improves the estimation of the regression parameters, which in turn are used to compute residuals and update the whitening matrix." ;
@@ -602,14 +601,14 @@ obo:STATO_0000374 rdf:type :Class ;
 
 ###  http://purl.obolibrary.org/obo/STATO_0000376
 
-obo:STATO_0000376 rdf:type :Class ;
+obo:STATO_0000376 rdf:type owl:Class ;
                   
                   rdfs:label "Z-statistic" ;
                   
                   rdfs:subClassOf obo:STATO_0000039 ,
-                                  [ rdf:type :Restriction ;
-                                    :onProperty obo:OBI_0000295 ;
-                                    :someValuesFrom obo:STATO_0000052
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty obo:OBI_0000295 ;
+                                    owl:someValuesFrom obo:STATO_0000052
                                   ] ;
                   
                   obo:IAO_0000117 "Alejandra Gonzalez-Beltran" ,
@@ -627,7 +626,7 @@ obo:STATO_0000376 rdf:type :Class ;
 
 ###  http://www.w3.org/2002/07/owl#regression_model
 
-:regression_model rdf:type :Class .
+owl:regression_model rdf:type owl:Class .
 
 
 

--- a/nidm/imports/stato_import.ttl
+++ b/nidm/imports/stato_import.ttl
@@ -1,3 +1,4 @@
+@prefix : <http://www.semanticweb.org/owl/owlapi/turtle#> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -118,59 +119,13 @@ obo:OBI_0000299 rdf:type owl:ObjectProperty .
 #################################################################
 
 
-###  http://purl.obolibrary.org/obo/IAO_0000027
-
-obo:IAO_0000027 rdf:type owl:Class .
-
-
-
-###  http://purl.obolibrary.org/obo/IAO_0000030
-
-obo:IAO_0000030 rdf:type owl:Class .
-
-
-
-###  http://purl.obolibrary.org/obo/IAO_0000100
-
-obo:IAO_0000100 rdf:type owl:Class .
-
-
-
-###  http://purl.obolibrary.org/obo/IAO_0000109
-
-obo:IAO_0000109 rdf:type owl:Class .
-
-
-
-###  http://purl.obolibrary.org/obo/OBI_0000739
-
-obo:OBI_0000739 rdf:type owl:Class .
-
-
-
-###  http://purl.obolibrary.org/obo/OBI_0200000
-
-obo:OBI_0200000 rdf:type owl:Class .
-
-
-
-###  http://purl.obolibrary.org/obo/OBI_0200200
-
-obo:OBI_0200200 rdf:type owl:Class .
-
-
-
 ###  http://purl.obolibrary.org/obo/STATO_0000030
 
 obo:STATO_0000030 rdf:type owl:Class ;
                   
                   rdfs:label "Chi-Squared statistic"@en ;
                   
-                  rdfs:subClassOf obo:STATO_0000039 ,
-                                  [ rdf:type owl:Restriction ;
-                                    owl:onProperty obo:OBI_0000295 ;
-                                    owl:someValuesFrom obo:OBI_0200200
-                                  ] ;
+                  rdfs:subClassOf obo:STATO_0000039 ;
                   
                   obo:IAO_0000117 "Orlaith Burke"^^xsd:string ,
                                   "Alejandra Gonzalez-Beltran"@en ;
@@ -191,12 +146,6 @@ obo:STATO_0000039 rdf:type owl:Class ;
                   
                   rdfs:label "statistic"@en ;
                   
-                  rdfs:subClassOf obo:IAO_0000109 ,
-                                  [ rdf:type owl:Restriction ;
-                                    owl:onProperty obo:IAO_0000136 ;
-                                    owl:someValuesFrom obo:IAO_0000100
-                                  ] ;
-                  
                   obo:IAO_0000117 "Orlaith Burke"^^xsd:string ;
                   
                   obo:IAO_0000112 ""@en ;
@@ -214,35 +163,11 @@ obo:STATO_0000039 rdf:type owl:Class ;
 
 
 
-###  http://purl.obolibrary.org/obo/STATO_0000052
-
-obo:STATO_0000052 rdf:type owl:Class .
-
-
-
-###  http://purl.obolibrary.org/obo/STATO_0000086
-
-obo:STATO_0000086 rdf:type owl:Class .
-
-
-
-###  http://purl.obolibrary.org/obo/STATO_0000108
-
-obo:STATO_0000108 rdf:type owl:Class .
-
-
-
 ###  http://purl.obolibrary.org/obo/STATO_0000119
 
 obo:STATO_0000119 rdf:type owl:Class ;
                   
                   rdfs:label "model parameter estimation"@en ;
-                  
-                  rdfs:subClassOf obo:OBI_0200000 ,
-                                  [ rdf:type owl:Restriction ;
-                                    owl:onProperty obo:OBI_0000299 ;
-                                    owl:someValuesFrom obo:STATO_0000144
-                                  ] ;
                   
                   obo:IAO_0000117 "Orlaith Burke"^^xsd:string ;
                   
@@ -260,23 +185,13 @@ https://github.com/ISA-tools/stato/issues/18"""@en ;
 
 
 
-###  http://purl.obolibrary.org/obo/STATO_0000144
-
-obo:STATO_0000144 rdf:type owl:Class .
-
-
-
 ###  http://purl.obolibrary.org/obo/STATO_0000176
 
 obo:STATO_0000176 rdf:type owl:Class ;
                   
                   rdfs:label "t-statistic"@en ;
                   
-                  rdfs:subClassOf obo:STATO_0000039 ,
-                                  [ rdf:type owl:Restriction ;
-                                    owl:onProperty obo:OBI_0000295 ;
-                                    owl:someValuesFrom obo:OBI_0000739
-                                  ] ;
+                  rdfs:subClassOf obo:STATO_0000039 ;
                   
                   obo:IAO_0000117 "Orlaith Burke"^^xsd:string ;
                   
@@ -299,11 +214,7 @@ obo:STATO_0000282 rdf:type owl:Class ;
                   
                   rdfs:label "F-statistic"@en ;
                   
-                  rdfs:subClassOf obo:STATO_0000039 ,
-                                  [ rdf:type owl:Restriction ;
-                                    owl:onProperty obo:OBI_0000295 ;
-                                    owl:someValuesFrom obo:STATO_0000086
-                                  ] ;
+                  rdfs:subClassOf obo:STATO_0000039 ;
                   
                   obo:IAO_0000117 "Orlaith Burke"^^xsd:string ,
                                   "Alejandra Gonzalez-Beltran"@en ;
@@ -318,39 +229,11 @@ obo:STATO_0000282 rdf:type owl:Class ;
 
 
 
-###  http://purl.obolibrary.org/obo/STATO_0000290
-
-obo:STATO_0000290 rdf:type owl:Class .
-
-
-
-###  http://purl.obolibrary.org/obo/STATO_0000301
-
-obo:STATO_0000301 rdf:type owl:Class .
-
-
-
-###  http://purl.obolibrary.org/obo/STATO_0000322
-
-obo:STATO_0000322 rdf:type owl:Class .
-
-
-
 ###  http://purl.obolibrary.org/obo/STATO_0000323
 
 obo:STATO_0000323 rdf:type owl:Class ;
                   
                   rdfs:label "contrast weight matrix"@en ;
-                  
-                  rdfs:subClassOf obo:IAO_0000030 ,
-                                  [ rdf:type owl:Restriction ;
-                                    owl:onProperty obo:IAO_0000136 ;
-                                    owl:someValuesFrom obo:STATO_0000290
-                                  ] ,
-                                  [ rdf:type owl:Restriction ;
-                                    owl:onProperty obo:BFO_0000051 ;
-                                    owl:someValuesFrom obo:STATO_0000322
-                                  ] ;
                   
                   obo:IAO_0000117 "Alejandra Gonzalez-Beltran"@en ,
                                   "Camille Maumet"@en ,
@@ -375,26 +258,15 @@ obo:STATO_0000346 rdf:type owl:Class ;
                   
                   rdfs:label "covariance structure"@en ;
                   
-                  rdfs:subClassOf obo:IAO_0000027 ,
-                                  [ rdf:type owl:Restriction ;
-                                    owl:onProperty obo:IAO_0000136 ;
-                                    owl:someValuesFrom obo:STATO_0000301
-                                  ] ,
-                                  [ rdf:type owl:Restriction ;
-                                    owl:onProperty obo:BFO_0000050 ;
-                                    owl:someValuesFrom owl:regression_model
-                                  ] ;
-                  
-                  obo:IAO_0000117 "Orlaith Burke" ,
+                  obo:IAO_0000117 "Camille Maumet" ,
+                                  "Orlaith Burke" ,
                                   "Tom Nichols" ,
+                                  "Alejandra Gonzalez-Beltran" ,
                                   "Philippe Rocca-Serra" ;
                   
-                  obo:IAO_0000119 "http://www3.nd.edu/~kyuan/courses/sem/readpapers/benter.pdf" ;
-                  
-                  obo:IAO_0000117 "Camille Maumet" ,
-                                  "Alejandra Gonzalez-Beltran" ;
-                  
                   obo:IAO_0000115 "a covariance structure is a data item which is part of a regression model and which indicates a pattern in the covariance matrix. The nature of covariance structure is specified before the regression analysis and various covariance structure may be tested and evaluated using information criteria to help choose the most suiteable model"@en ;
+                  
+                  obo:IAO_0000119 "http://www3.nd.edu/~kyuan/courses/sem/readpapers/benter.pdf" ;
                   
                   obo:IAO_0000114 obo:IAO_0000120 .
 
@@ -461,24 +333,19 @@ obo:STATO_0000370 rdf:type owl:Class ;
                   
                   rdfs:label "ordinary least squares estimation"@en ;
                   
-                  rdfs:subClassOf obo:STATO_0000119 ,
-                                  [ rdf:type owl:Restriction ;
-                                    owl:onProperty obo:BFO_0000050 ;
-                                    owl:someValuesFrom obo:STATO_0000108
-                                  ] ;
+                  rdfs:subClassOf obo:STATO_0000119 ;
                   
                   obo:STATO_0000032 "OLS estimation" ;
                   
-                  obo:STATO_0000041 ""@en ;
-                  
-                  obo:IAO_0000119 "http://en.wikipedia.org/wiki/Ordinary_least_squares and Tom Nichols"@en ;
-                  
-                  obo:STATO_0000041 "https://stat.ethz.ch/R-manual/R-patched/library/stats/html/lm.html" ;
+                  obo:STATO_0000041 ""@en ,
+                                    "https://stat.ethz.ch/R-manual/R-patched/library/stats/html/lm.html" ;
                   
                   obo:IAO_0000117 "Alejandra Gonzalez-Beltran"@en ,
                                   "Camille Maumet"@en ,
                                   "Philippe Rocca-Serra"@en ,
                                   "Tom Nichols"@en ;
+                  
+                  obo:IAO_0000119 "http://en.wikipedia.org/wiki/Ordinary_least_squares and Tom Nichols"@en ;
                   
                   obo:IAO_0000115 "the ordinary least squares estimation is a model parameter estimation for a linear regression model when the errors are uncorrelated and equal in variance. Is the Best Linear Unbiased Estimation (BLUE) method under these assumptions, Uniformly Minimum-Variance Unbiased Estimator (UMVUE) with addition of a Gaussian assumption."@en ;
                   
@@ -492,11 +359,7 @@ obo:STATO_0000371 rdf:type owl:Class ;
                   
                   rdfs:label "weighted least squares estimation"@en ;
                   
-                  rdfs:subClassOf obo:STATO_0000119 ,
-                                  [ rdf:type owl:Restriction ;
-                                    owl:onProperty obo:BFO_0000050 ;
-                                    owl:someValuesFrom obo:STATO_0000108
-                                  ] ;
+                  rdfs:subClassOf obo:STATO_0000119 ;
                   
                   obo:STATO_0000032 "WLS estimation" ;
                   
@@ -522,11 +385,7 @@ obo:STATO_0000372 rdf:type owl:Class ;
                   
                   rdfs:label "generalized least squares estimation"@en ;
                   
-                  rdfs:subClassOf obo:STATO_0000119 ,
-                                  [ rdf:type owl:Restriction ;
-                                    owl:onProperty obo:BFO_0000050 ;
-                                    owl:someValuesFrom obo:STATO_0000108
-                                  ] ;
+                  rdfs:subClassOf obo:STATO_0000119 ;
                   
                   obo:STATO_0000032 "GLS estimation" ;
                   
@@ -549,11 +408,7 @@ obo:STATO_0000373 rdf:type owl:Class ;
                   
                   rdfs:label "iteratively reweighted least squares estimation"@en ;
                   
-                  rdfs:subClassOf obo:STATO_0000119 ,
-                                  [ rdf:type owl:Restriction ;
-                                    owl:onProperty obo:BFO_0000050 ;
-                                    owl:someValuesFrom obo:STATO_0000108
-                                  ] ;
+                  rdfs:subClassOf obo:STATO_0000119 ;
                   
                   obo:IAO_0000117 "Alejandra Gonzalez-Beltran" ,
                                   "Camille Maumet" ,
@@ -561,10 +416,11 @@ obo:STATO_0000373 rdf:type owl:Class ;
                   
                   obo:STATO_0000041 ""@en ;
                   
-                  obo:IAO_0000117 "Philippe Rocca-Serra"@en ,
-                                  "Tom Nichols"@en ;
+                  obo:IAO_0000117 "Philippe Rocca-Serra"@en ;
                   
                   obo:IAO_0000119 "Tom Nichols"@en ;
+                  
+                  obo:IAO_0000117 "Tom Nichols"@en ;
                   
                   obo:IAO_0000115 "the iteratively reweighted least squares estimation is a model parameter estimation which is a practical implementation of Weighted Least Squares, where the heterogeneous variances of the errors are estimated from the residuals of the regression model, providing an estimate for the weights. Each successive estimate of the weights improves the estimation of the regression parameters, which in turn are used to compute residuals and update the weights"@en ;
                   
@@ -578,21 +434,17 @@ obo:STATO_0000374 rdf:type owl:Class ;
                   
                   rdfs:label "feasible generalized least squares estimation"@en ;
                   
-                  rdfs:subClassOf obo:STATO_0000372 ,
-                                  [ rdf:type owl:Restriction ;
-                                    owl:onProperty obo:BFO_0000050 ;
-                                    owl:someValuesFrom obo:STATO_0000108
-                                  ] ;
+                  rdfs:subClassOf obo:STATO_0000372 ;
                   
                   obo:IAO_0000115 "the feasible generalized least squares estimation is a model parameter estimation which is a practical implementation of Generalised Least Squares, where the covariance of the errors is estimated from the residuals of the regression model, providing the information needed to whiten the data and model. Each successive estimate of the whitening matrix improves the estimation of the regression parameters, which in turn are used to compute residuals and update the whitening matrix." ;
                   
                   obo:IAO_0000117 "Alejandra Gonzalez-Beltran"@en ,
-                                  "Philippe Rocca-Serra"@en ;
+                                  "Orlaith Burke"@en ;
                   
                   obo:IAO_0000119 "Tom Nichols" ;
                   
                   obo:IAO_0000117 "Camille Maumet" ,
-                                  "Orlaith Burke"@en ,
+                                  "Philippe Rocca-Serra"@en ,
                                   "Tom Nichols"@en ;
                   
                   obo:IAO_0000114 obo:IAO_0000120 .
@@ -605,11 +457,7 @@ obo:STATO_0000376 rdf:type owl:Class ;
                   
                   rdfs:label "Z-statistic" ;
                   
-                  rdfs:subClassOf obo:STATO_0000039 ,
-                                  [ rdf:type owl:Restriction ;
-                                    owl:onProperty obo:OBI_0000295 ;
-                                    owl:someValuesFrom obo:STATO_0000052
-                                  ] ;
+                  rdfs:subClassOf obo:STATO_0000039 ;
                   
                   obo:IAO_0000117 "Alejandra Gonzalez-Beltran" ,
                                   "Camille Maument" ,
@@ -621,12 +469,6 @@ obo:STATO_0000376 rdf:type owl:Class ;
                   obo:IAO_0000115 "Z-statistic is a statistic computed from observations and used to produce a p-value when compared to a Standard Normal Distribution in a statistical test called the Z-test." ;
                   
                   obo:IAO_0000114 obo:IAO_0000120 .
-
-
-
-###  http://www.w3.org/2002/07/owl#regression_model
-
-owl:regression_model rdf:type owl:Class .
 
 
 

--- a/nidm/nidm-results/scripts/release_nidm_results.py
+++ b/nidm/nidm-results/scripts/release_nidm_results.py
@@ -84,18 +84,20 @@ class NIDMRelease(object):
                     im_txt = im_txt.replace(" :", " "+name+":")
                     im_txt = im_txt.replace("\n:", "\n"+name+":")
 
+                # Remove base prefix
+                base_match = re.search(r'@base <.*>', im_txt)
+                if base_match:
+                    im_txt = im_txt.replace(base_match.group(), "")
+
                 # Copy missing prefixes in nidm-results owl file
-                prefixes = re.findall(r'@prefix \w+: <.*>', im_txt)
+                prefixes = re.findall(r'@prefix \w+: <.*> \.\n', im_txt)
                 for prefix in prefixes:
                     if not prefix in owl_txt:
-                        owl_txt = prefix+"\n"+owl_txt
+                        owl_txt = prefix+owl_txt
+                    im_txt = im_txt.replace(prefix, "")
 
-                body_match = re.search(
-                    r'#################################(.*\n*)*', im_txt)
-                if body_match:
-                    owl_txt = owl_txt + "\n\n##### Imports from %s #####" \
-                        % (name)
-                    owl_txt = owl_txt + body_match.group()
+                owl_txt = owl_txt + "\n\n##### Imports from %s #####" % (name)
+                owl_txt = owl_txt + im_txt
 
         # Remove AFNI-related terms (not ready for release yet)
         if int(self.nidm_version) <= 100:

--- a/nidm/nidm-results/scripts/release_nidm_results.py
+++ b/nidm/nidm-results/scripts/release_nidm_results.py
@@ -67,6 +67,7 @@ class NIDMRelease(object):
             for im in owl_imports:
                 im = im.replace("<", "").replace(">", "")
                 im_name = self.get_import_name(im)
+                name = im_name.split("-")[0].replace("_import", "")
 
                 im_file = os.path.join(IMPORT_FOLDER, im_name+".ttl")
 
@@ -80,7 +81,6 @@ class NIDMRelease(object):
                 # Replace prefix ":" by named namespace in import
                 default_match = re.search(r'@prefix : <.*>', im_txt)
                 if default_match:
-                    name = im_name.split("-")[0].replace("_import", "")
                     im_txt = im_txt.replace(" :", " "+name+":")
                     im_txt = im_txt.replace("\n:", "\n"+name+":")
 

--- a/nidm/nidm-results/scripts/release_nidm_results.py
+++ b/nidm/nidm-results/scripts/release_nidm_results.py
@@ -99,6 +99,13 @@ class NIDMRelease(object):
                 owl_txt = owl_txt + "\n\n##### Imports from %s #####" % (name)
                 owl_txt = owl_txt + im_txt
 
+                # Replace address of examples
+                owl_txt = owl_txt.replace(
+                    "https://raw.githubusercontent.com/incf-nidash/nidm/\
+master/",
+                    "https://raw.githubusercontent.com/incf-nidash/nidm/\
+NIDM-Results_"+self.nidm_original_version+"/")
+
         # Remove AFNI-related terms (not ready for release yet)
         if int(self.nidm_version) <= 100:
             owl_txt = owl_txt.replace(

--- a/nidm/nidm-results/scripts/release_nidm_results.py
+++ b/nidm/nidm-results/scripts/release_nidm_results.py
@@ -56,8 +56,9 @@ class NIDMRelease(object):
             owl_txt = fp.read()
 
         # Remove imports and copy the import directly in the release file
-        match = re.search(r'\[[\w:;\n\s]' +
-                          r'*(?P<imports>(\s*<.*>\s*,?\s*\n)*)\s*\] \.', owl_txt)
+        match = re.search(
+            r'\[[\w:;\n\s]' +
+            r'*(?P<imports>(\s*<.*>\s*,?\s*\n)*)\s*\] \.', owl_txt)
         if match:
             owl_txt = owl_txt.replace(match.group(), "")
 
@@ -86,7 +87,7 @@ class NIDMRelease(object):
                     im_txt = im_txt.replace(" :", " "+name+":")
                     im_txt = im_txt.replace("\n:", "\n"+name+":")
 
-                # Copy missing prefixes in nidm-results release owl file
+                # Copy missing prefixes in nidm-results owl file
                 prefixes = re.findall(r'@prefix \w+: <.*>', im_txt)
                 for prefix in prefixes:
                     if not prefix in owl_txt:
@@ -95,7 +96,8 @@ class NIDMRelease(object):
                 body_match = re.search(
                     r'#################################(.*\n*)*', im_txt)
                 if body_match:
-                    owl_txt = owl_txt + "\n\n##### Imports from %s #####" % (name)
+                    owl_txt = owl_txt + "\n\n##### Imports from %s #####" \
+                        % (name)
                     owl_txt = owl_txt + body_match.group()
 
         with open(release_owl_file, 'w') as fp:
@@ -103,8 +105,6 @@ class NIDMRelease(object):
 
                 # with open(release_owl_file, 'r') as fp:
                 #     owl_txt = fp.read()
-
-
 
 if __name__ == '__main__':
     if len(sys.argv) > 1:

--- a/nidm/nidm-results/scripts/release_nidm_results.py
+++ b/nidm/nidm-results/scripts/release_nidm_results.py
@@ -64,10 +64,7 @@ class NIDMRelease(object):
 
             owl_imports = re.findall(r"<.*>", match.group("imports"))
 
-            # import_names = map(self.get_import_name, owl_imports)
-            # print import_names
-
-            for im in sorted(owl_imports, key=self.get_import_name):
+            for im in owl_imports:
                 im = im.replace("<", "").replace(">", "")
                 im_name = self.get_import_name(im)
 
@@ -100,11 +97,22 @@ class NIDMRelease(object):
                         % (name)
                     owl_txt = owl_txt + body_match.group()
 
+        # Remove AFNI-related terms (not ready for release yet)
+        if int(self.nidm_version) <= 100:
+            owl_txt = owl_txt.replace(
+                "@prefix afni: <http://purl.org/nidash/afni#> .\n", "")
+            # Remove terms: nidm:'Legendre Polynomial Order', afni:'BLOCK',
+            # afni:'GammaHRF' and afni:'LegendrePolynomialDriftModel'
+            terms_under_development = [
+                NIDM['NIDM_0000014'], AFNI['BLOCK'], AFNI['GammaHRF'],
+                AFNI['LegendrePolynomialDriftModel']]
+            for term in terms_under_development:
+                m = re.search(
+                    re.escape("###  "+str(term))+r"[^\#]*\.", owl_txt)
+                owl_txt = owl_txt.replace(m.group(), "")
+
         with open(release_owl_file, 'w') as fp:
             owl_txt = fp.write(owl_txt)
-
-                # with open(release_owl_file, 'r') as fp:
-                #     owl_txt = fp.read()
 
 if __name__ == '__main__':
     if len(sys.argv) > 1:

--- a/nidm/nidm-results/scripts/release_nidm_results.py
+++ b/nidm/nidm-results/scripts/release_nidm_results.py
@@ -49,7 +49,7 @@ class NIDMRelease(object):
         # Copy the owl file to the release folder
         release_owl_file = os.path.join(
             RELEASED_TERMS_FOLDER,
-            "nidm_results_%s.owl" % (self.nidm_version))
+            "nidm-results_%s.owl" % (self.nidm_version))
         shutil.copyfile(owl_file, release_owl_file)
 
         with open(release_owl_file, 'r') as fp:

--- a/nidm/nidm-results/scripts/release_nidm_results.py
+++ b/nidm/nidm-results/scripts/release_nidm_results.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+''' Create a NIDM-Results release including:
+ - copy the owl file to the release directory
+ - merge all the import owl import files
+ - update the examples address
+ - create a git tag
+
+@author: Camille Maumet <c.m.j.maumet@warwick.ac.uk>
+@copyright: University of Warwick 2015
+'''
+
+import logging
+import os
+from rdflib.compare import *
+import sys
+import shutil
+
+RELPATH = os.path.dirname(os.path.abspath(__file__))
+NIDMRESULTSPATH = os.path.dirname(RELPATH)
+NIDMPATH = os.path.join(NIDMRESULTSPATH, os.pardir)
+
+# Append parent script directory to path
+sys.path.append(os.path.join(NIDMRESULTSPATH, os.pardir, os.pardir, "scripts"))
+from Constants import *
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
+
+TERMS_FOLDER = os.path.join(NIDMRESULTSPATH, 'terms')
+RELEASED_TERMS_FOLDER = os.path.join(TERMS_FOLDER, "releases")
+
+
+def main(nidm_original_version):
+    nidm_version = nidm_original_version.replace(".", "")
+
+    owl_file = os.path.join(TERMS_FOLDER, 'nidm-results.owl')
+    assert os.path.exists(owl_file)
+
+    # Copy the owl file to the release folder
+    release_owl_file = os.path.join(RELEASED_TERMS_FOLDER,
+                                    "nidm_results_%s.owl" % (nidm_version))
+    shutil.copyfile(owl_file, release_owl_file)
+
+
+if __name__ == '__main__':
+    if len(sys.argv) > 1:
+        nidm_version = sys.argv[1]
+    else:
+        raise Exception("Error: missing version number for NIDM release")
+
+    main(nidm_version)

--- a/nidm/nidm-results/terms/nidm-results.owl
+++ b/nidm/nidm-results/terms/nidm-results.owl
@@ -19,9 +19,9 @@
 @base <http://www.w3.org/2002/07/owl#> .
 
 [ rdf:type owl:Ontology ;
-  owl:imports <http://purl.obolibrary.org/nidm/iao_import.owl> ,
-              <http://purl.org/nidash/nidm/crypto_import.owl> ,
+  owl:imports <http://purl.org/nidash/nidm/crypto_import.owl> ,
               <http://purl.org/nidash/nidm/dc_import.owl> ,
+              <http://purl.obolibrary.org/nidm/iao_import.owl> ,
               <http://purl.org/nidash/nidm/nfo_import.owl> ,
               <http://purl.org/nidash/nidm/nlx_import.owl> ,
               <http://purl.org/nidash/nidm/stato_import.owl> ,

--- a/nidm/nidm-results/terms/releases/nidm-results_100.owl
+++ b/nidm/nidm-results/terms/releases/nidm-results_100.owl
@@ -1,3 +1,15 @@
+@prefix stato: <http://www.semanticweb.org/owl/owlapi/turtle#> .
+@prefix nlx: <http://purl.org/nidash/nidm/nlx_import.owl#> .
+@prefix nrl: <http://www.semanticdesktop.org/ontologies/2007/08/15/nrl#> .
+@prefix nfo: <http://purl.org/nidash/nidm/nfo_import.owl#> .
+@prefix protege: <http://protege.stanford.edu/plugins/owl/protege#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix iao: <http://purl.obolibrary.org/obo/iao/2015-02-23/> .
+@prefix ns: <http://usefulinc.com/ns/> .
+@prefix iao: <http://purl.obolibrary.org/obo/iao.owl#> .
+@prefix dc: <http://purl.org/nidash/nidm/dc_import.owl#> .
+@prefix crypto: <http://purl.org/nidash/nidm/dc_import.owl#> .
 @prefix : <http://www.semanticweb.org/owl/owlapi/turtle#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
@@ -15,8 +27,9 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#> .
 @prefix dctype: <http://purl.org/dc/dcmitype/> .
-@prefix nrl: <http://www.semanticdesktop.org/ontologies/2007/08/15/nrl#> .
 @base <http://www.w3.org/2002/07/owl#> .
+
+
 
 
 #################################################################
@@ -407,6 +420,11 @@ fsl:FSL_0000005 rdf:type owl:DatatypeProperty ;
                 obo:IAO_0000114 obo:IAO_0000122 ;
                 
                 rdfs:range xsd:string .
+
+
+
+
+
 
 
 ###  http://purl.org/nidash/nidm#NIDM_0000021
@@ -1633,7 +1651,7 @@ obo:STATO_0000323 rdf:type owl:Class ;
                   
                   rdfs:subClassOf prov:Entity ;
                   
-                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ContrastWeights.txt" .
+                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/ContrastWeights.txt" .
 
 
 
@@ -1660,6 +1678,15 @@ dctype:Image rdf:type owl:Class ;
                              ] .
 
 
+
+
+
+
+
+
+
+
+
 ###  http://purl.org/nidash/fsl#FSL_0000002
 
 fsl:FSL_0000002 rdf:type owl:Class ;
@@ -1684,7 +1711,7 @@ nidm:NIDM_0000001 rdf:type owl:Class ;
                   
                   rdfs:subClassOf prov:Activity ;
                   
-                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ContrastEstimation.txt"^^xsd:anyURI ;
+                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/ContrastEstimation.txt"^^xsd:anyURI ;
                   
                   obo:IAO_0000115 "The process of performing a [obo:contrast estimation](http://purl.obolibrary.org/obo/STATO_0000383) at each element (e.g., pixel, voxel, vertex, or face) of a map" ;
                   
@@ -1704,7 +1731,7 @@ nidm:NIDM_0000002 rdf:type owl:Class ;
                   
                   obo:IAO_0000115 "A map whose value at each element (e.g., pixel, voxel, vertex, or face) is a [contrast estimate](http://purl.obolibrary.org/obo/STATO_0000384)."^^xsd:string ;
                   
-                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ContrastMap.txt"^^xsd:anyURI ;
+                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/ContrastMap.txt"^^xsd:anyURI ;
                   
                   obo:IAO_0000116 "Discussed in https://github.com/incf-nidash/nidm/issues/255" ;
                   
@@ -1786,7 +1813,7 @@ nidm:NIDM_0000007 rdf:type owl:Class ;
                   
                   obo:IAO_0000115 "Set of criterion specified a priori to define the clusters reported after inference (e.g. pixel or voxel connectivity criterion)." ;
                   
-                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ClusterDefinitionCriteria.txt" ;
+                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/ClusterDefinitionCriteria.txt" ;
                   
                   obo:IAO_0000114 obo:IAO_0000122 .
 
@@ -1800,7 +1827,7 @@ nidm:NIDM_0000008 rdf:type owl:Class ;
                   
                   rdfs:subClassOf nidm:NIDM_0000052 ;
                   
-                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ClusterLabelsMap.txt"^^xsd:anyURI ;
+                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/ClusterLabelsMap.txt"^^xsd:anyURI ;
                   
                   obo:IAO_0000115 "A map whose value at each element (e.g., pixel, voxel, vertex, or face) denotes cluster membership within the excursion set. Each cluster is denoted by a different integer and all members of the same cluster have the same value." ;
                   
@@ -1854,7 +1881,7 @@ nidm:NIDM_0000013 rdf:type owl:Class ;
                   
                   obo:IAO_0000116 "Discussed in https://github.com/incf-nidash/nidm/issues/255."^^xsd:anyURI ;
                   
-                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ContrastStandardErrorMap.txt"^^xsd:anyURI ;
+                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/ContrastStandardErrorMap.txt"^^xsd:anyURI ;
                   
                   obo:IAO_0000115 "A map whose value at each element (e.g., pixel, voxel, vertex, or face) is a [standard error of a contrast estimate](http://purl.obolibrary.org/obo/STATO_0000385)." ;
                   
@@ -1872,7 +1899,7 @@ nidm:NIDM_0000015 rdf:type owl:Class ;
                   
                   owl:sameAs "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C44465"^^xsd:anyURI ;
                   
-                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/Coordinate.txt"^^xsd:anyURI ;
+                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/Coordinate.txt"^^xsd:anyURI ;
                   
                   obo:IAO_0000116 "Discussed in https://github.com/incf-nidash/nidm/pull/144 and https://github.com/incf-nidash/nidm/pull/172" ;
                   
@@ -1888,7 +1915,7 @@ nidm:NIDM_0000016 rdf:type owl:Class ;
                   
                   rdfs:subClassOf prov:Entity ;
                   
-                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/CoordinateSpace.txt"^^xsd:anyURI ;
+                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/CoordinateSpace.txt"^^xsd:anyURI ;
                   
                   obo:IAO_0000115 "An entity with spatial attributes (e.g., dimensions, units, and voxel-to-world mapping) that provides context to a Map (e.g., a Statistic Map, a Contrast Map...)." ;
                   
@@ -1922,7 +1949,7 @@ nidm:NIDM_0000018 rdf:type owl:Class ;
                   
                   rdfs:subClassOf prov:Entity ;
                   
-                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/Data.txt"^^xsd:anyURI ;
+                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/Data.txt"^^xsd:anyURI ;
                   
                   obo:IAO_0000115 "Scaling applied to the data before parameter estimation, including specification of the target intensity." ;
                   
@@ -1955,7 +1982,7 @@ nidm:NIDM_0000019 rdf:type owl:Class ;
                                     owl:onDataRange xsd:string
                                   ] ;
                   
-                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/DesignMatrix.txt"^^xsd:anyURI ;
+                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/DesignMatrix.txt"^^xsd:anyURI ;
                   
                   obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/274" ;
                   
@@ -1975,7 +2002,7 @@ nidm:NIDM_0000020 rdf:type owl:Class ;
                   
                   rdfs:subClassOf nidm:NIDM_0000004 ;
                   
-                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/DisplayMaskMap.txt"^^xsd:anyURI ;
+                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/DisplayMaskMap.txt"^^xsd:anyURI ;
                   
                   obo:IAO_0000116 "Discussed at: https://github.com/incf-nidash/nidm/pull/258 and https://github.com/incf-nidash/nidm/pull/157" ;
                   
@@ -2007,7 +2034,7 @@ nidm:NIDM_0000023 rdf:type owl:Class ;
                   
                   rdfs:subClassOf prov:Entity ;
                   
-                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ErrorModel.txt"^^xsd:anyURI ;
+                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/ErrorModel.txt"^^xsd:anyURI ;
                   
                   obo:IAO_0000115 "Model used to describe the random variation of the error term as part of parameter estimation, including specification of the error probability distribution, its variance and dependence both spatially and across observations." ;
                   
@@ -2048,7 +2075,7 @@ nidm:NIDM_0000025 rdf:type owl:Class ;
                   
                   obo:IAO_0000116 "Discussed in the Neuroimaging terms spreadsheet and in https://github.com/incf-nidash/nidm/issues/256." ;
                   
-                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ExcursionSetMap.txt" ;
+                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/ExcursionSetMap.txt" ;
                   
                   obo:IAO_0000115 "A map in which the set of elements (e.g., pixels, voxels, vertices, or faces) not selected by the inference activity is set to zero or NaN" ;
                   
@@ -2064,7 +2091,7 @@ nidm:NIDM_0000026 rdf:type owl:Class ;
                   
                   rdfs:subClassOf prov:Entity ;
                   
-                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ExtentThreshold.txt"^^xsd:anyURI ;
+                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/ExtentThreshold.txt"^^xsd:anyURI ;
                   
                   obo:IAO_0000115 "A numerical value that establishes a lower bound on cluster-sizes and can be specified by the user in terms of FWER-corrected p-value, uncorrected p-value or minimum cluster size in voxels" ;
                   
@@ -2178,7 +2205,7 @@ nidm:NIDM_0000033 rdf:type owl:Class ;
                   
                   rdfs:subClassOf nidm:NIDM_0000052 ;
                   
-                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/GrandMeanMap.txt"^^xsd:anyURI ;
+                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/GrandMeanMap.txt"^^xsd:anyURI ;
                   
                   obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/288" ;
                   
@@ -2196,7 +2223,7 @@ nidm:NIDM_0000034 rdf:type owl:Class ;
                   
                   rdfs:subClassOf prov:Entity ;
                   
-                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/HeightThreshold_P.txt"^^xsd:anyURI ;
+                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/HeightThreshold_P.txt"^^xsd:anyURI ;
                   
                   obo:IAO_0000115 "A numerical value that establishes a lower bound on statistic values and can be specified by the user in terms of FWER-corrected p-value, uncorrected p-value or minimum statistic value." ;
                   
@@ -2278,7 +2305,7 @@ nidm:NIDM_0000049 rdf:type owl:Class ;
                   
                   rdfs:subClassOf prov:Activity ;
                   
-                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/Inference.txt"^^xsd:anyURI ;
+                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/Inference.txt"^^xsd:anyURI ;
                   
                   obo:IAO_0000115 "Statistical inference is a process of drawing conclusions following data analysis using statistical methods (statistical tests) and evaluating whether to reject or accept null hypothesis. (definition from STATO)." ;
                   
@@ -2380,7 +2407,7 @@ nidm:NIDM_0000054 rdf:type owl:Class ;
                   
                   obo:IAO_0000115 "A binary map representing the exact set of elements (e.g., pixels, voxels, vertices, and faces) in which an activity was performed (e.g. the mask map generated by the model parameter estimation activity represents the exact set of voxels in which the mass univariate model was estimated) and/or restraining the space in which an activity was performed (e.g. the mask map used by inference)" ;
                   
-                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/MaskMap.txt" ;
+                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/MaskMap.txt" ;
                   
                   obo:IAO_0000114 obo:IAO_0000122 .
 
@@ -2394,7 +2421,7 @@ nidm:NIDM_0000056 rdf:type owl:Class ;
                   
                   rdfs:subClassOf prov:Activity ;
                   
-                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ModelParametersEstimation.txt"^^xsd:anyURI ;
+                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/ModelParametersEstimation.txt"^^xsd:anyURI ;
                   
                   obo:IAO_0000115 "the process of performing a [obo:model parameter estimation](http://purl.obolibrary.org/obo/STATO_0000119) at each element (e.g., pixel, voxel, vertex, or face) of a map" ;
                   
@@ -2472,7 +2499,7 @@ nidm:NIDM_0000061 rdf:type owl:Class ;
                   
                   rdfs:subClassOf nidm:NIDM_0000052 ;
                   
-                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ParameterEstimateMap.txt"^^xsd:anyURI ;
+                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/ParameterEstimateMap.txt"^^xsd:anyURI ;
                   
                   obo:IAO_0000116 "Discussed in https://github.com/incf-nidash/nidm/issues/255 and https://github.com/incf-nidash/nidm/issues/141 (see also https://github.com/ISA-tools/stato/issues/18)" ;
                   
@@ -2494,7 +2521,7 @@ nidm:NIDM_0000062 rdf:type owl:Class ;
                   
                   obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/283" ;
                   
-                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/Peak_ValueP.txt" ;
+                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/Peak_ValueP.txt" ;
                   
                   obo:IAO_0000114 obo:IAO_0000122 .
 
@@ -2508,7 +2535,7 @@ nidm:NIDM_0000063 rdf:type owl:Class ;
                   
                   rdfs:subClassOf prov:Entity ;
                   
-                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/PeakDefinitionCriteria_MaxPeaks.txt"^^xsd:anyURI ;
+                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/PeakDefinitionCriteria_MaxPeaks.txt"^^xsd:anyURI ;
                   
                   obo:IAO_0000117 "Discussed in https://github.com/incf-nidash/nidm/pull/200" ;
                   
@@ -2562,7 +2589,7 @@ nidm:NIDM_0000066 rdf:type owl:Class ;
                   
                   obo:IAO_0000115 "A map whose value at each element (e.g., pixel, voxel, vertex, or face) is a [residual mean square](http://purl.obolibrary.org/obo/STATO_0000375)." ;
                   
-                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/ResidualMeanSquaresMap.txt" ;
+                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/ResidualMeanSquaresMap.txt" ;
                   
                   obo:IAO_0000114 obo:IAO_0000122 .
 
@@ -2592,7 +2619,7 @@ nidm:NIDM_0000068 rdf:type owl:Class ;
                   
                   rdfs:subClassOf nidm:NIDM_0000054 ;
                   
-                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/SearchSpaceMaskMap.txt" ;
+                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/SearchSpaceMaskMap.txt" ;
                   
                   obo:IAO_0000116 "Discussed at: https://github.com/incf-nidash/nidm/pull/258" ;
                   
@@ -2630,7 +2657,7 @@ nidm:NIDM_0000070 rdf:type owl:Class ;
                   
                   prov:editorialNote "Discussed in https://github.com/incf-nidash/nidm/issues/71."^^xsd:string ;
                   
-                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/SignificantCluster.txt" ;
+                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/SignificantCluster.txt" ;
                   
                   obo:IAO_0000114 obo:IAO_0000122 .
 
@@ -2726,7 +2753,7 @@ nidm:NIDM_0000076 rdf:type owl:Class ;
                   
                   rdfs:subClassOf nidm:NIDM_0000052 ;
                   
-                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/StatisticMap_T.txt"^^xsd:anyURI ;
+                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/StatisticMap_T.txt"^^xsd:anyURI ;
                   
                   obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/255" ;
                   
@@ -2829,8 +2856,8 @@ nidm:NIDM_0000087 rdf:type owl:Class ;
                   
                   rdfs:subClassOf prov:Entity ;
                   
-                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/FSL_DriftModel.txt"^^xsd:anyURI ,
-                                  "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/SPM_DriftModel.txt"^^xsd:anyURI ;
+                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/FSL_DriftModel.txt"^^xsd:anyURI ,
+                                  "https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/SPM_DriftModel.txt"^^xsd:anyURI ;
                   
                   obo:IAO_0000116 "Discussed at https://github.com/incf-nidash/nidm/issues/298" ;
                   
@@ -2886,7 +2913,7 @@ nidm:NIDM_0000140 rdf:type owl:Class ;
                   
                   rdfs:seeAlso "http://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Cluster" ;
                   
-                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/FSL_ClusterCenterOfGravity.txt" ;
+                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/FSL_ClusterCenterOfGravity.txt" ;
                   
                   obo:IAO_0000114 obo:IAO_0000122 .
 
@@ -2900,7 +2927,7 @@ nidm:NIDM_0000144 rdf:type owl:Class ;
                   
                   rdfs:subClassOf nidm:NIDM_0000052 ;
                   
-                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/examples/SPM_ReselsPerVoxelMap.txt"^^xsd:anyURI ;
+                  obo:IAO_0000112 "https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/SPM_ReselsPerVoxelMap.txt"^^xsd:anyURI ;
                   
                   obo:IAO_0000115 "A map whose value at each element (e.g., pixel, voxel, vertex, or face) location is the number of resels per voxel." ;
                   
@@ -2995,6 +3022,10 @@ spm:SPM_0000005 rdf:type owl:Class ;
 #    Individuals
 #
 #################################################################
+
+
+
+
 
 
 ###  http://purl.org/nidash/fsl#FSL_0000001
@@ -3428,9 +3459,9 @@ spm:SPM_0000006 rdf:type nidm:NIDM_0000037 ,
 
 
 
+##### Imports from crypto ##### .
 
-
-#################### Imports from CRYPTO ##############################
+<http://purl.org/nidash/nidm/crypto_import.owl> rdf:type owl:Ontology .
 
 #################################################################
 #
@@ -3447,7 +3478,11 @@ crypto:sha512 rdf:type owl:DatatypeProperty ;
            
            rdfs:comment "SHA stands for Secure Hash Algorithm. Hash algorithms compute a fixed-length digital representation (known as a message digest) of an input data sequence (the message) of any length." .
 
-#################### Imports from Dublin Core ##############################     
+##### Imports from dc ##### .
+
+<http://purl.org/nidash/nidm/dc_import.owl> rdf:type owl:Ontology .
+
+
 #################################################################
 #
 #    Object Properties
@@ -3496,8 +3531,6 @@ dct:format rdf:type owl:DatatypeProperty ;
 ###  http://purl.org/dc/dcmitype/Image
 
 dctype:Image rdf:type owl:Class ;
-
-             owl:subClassOf prov:Entity ;
              
              obo:IAO_0000115 "A visual representation other than text." ;
              
@@ -3509,12 +3542,75 @@ dctype:Image rdf:type owl:Class ;
 ###  Generated by the OWL API (version 3.5.0) http://owlapi.sourceforge.net
 
 
-#################### Imports from OBO ##############################     
+
+##### Imports from iao ##### .
+
+<http://purl.obolibrary.org/obo/iao.owl> rdf:type owl:Ontology ;
+                                         
+                                         dc:date "2009-07-31"^^xsd:date ;
+                                         
+                                         owl:versionInfo "2015-02-23"^^xsd:string ;
+                                         
+                                         rdfs:comment "An information artifact is, loosely, a dependent continuant or its bearer that is created as the result of one or more intentional processes. Examples: uniprot, the english language, the contents of this document or a printout of it, the temperature measurements from a weather balloon. For more information, see the project home page at http://code.google.com/p/information-artifact-ontology/"^^xsd:string ,
+                                                      "IDs allocated to related efforts: PNO: IAO_0020000-IAO_0020999, D_ACTS: IAO_0021000-IAO_0021999"^^xsd:string ,
+                                                      "IDs allocated to subdomains of IAO. pno.owl: IAO_0020000-IAO_0020999, d-acts.owl: IAO_0021000-IAO_0021999"^^xsd:string ,
+                                                      "This file is based on checkout of our SVN repository revision $Revision: 717 $ "^^xsd:string ;
+                                         
+                                         protege:defaultLanguage "en"^^xsd:string ;
+                                         
+                                         dc:contributor "Adam Goldstein"@en ,
+                                                        "Alan Ruttenberg"@en ,
+                                                        "Albert Goldfain"@en ,
+                                                        "Barry Smith"@en ,
+                                                        "Bjoern Peters"@en ,
+                                                        "Carlo Torniai"@en ,
+                                                        "Chris Mungall"@en ,
+                                                        "Chris Stoeckert"@en ,
+                                                        "Christian A. Boelling"@en ,
+                                                        "Darren Natale"@en ,
+                                                        "David Osumi-Sutherland"@en ,
+                                                        "Gwen Frishkoff"@en ,
+                                                        "Holger Stenzhorn"@en ,
+                                                        "James A. Overton"@en ,
+                                                        "James Malone"@en ,
+                                                        "Jennifer Fostel"@en ,
+                                                        "Jie Zheng"@en ,
+                                                        "Jonathan Rees"@en ,
+                                                        "Larisa Soldatova"@en ,
+                                                        "Lawrence Hunter"@en ,
+                                                        "Mathias Brochhausen"@en ,
+                                                        "Matt Brush"@en ,
+                                                        "Melanie Courtot"@en ,
+                                                        "Michel Dumontier"@en ,
+                                                        "Paolo Ciccarese"@en ,
+                                                        "Pat Hayes"@en ,
+                                                        "Philippe Rocca-Serra"@en ,
+                                                        "Randy Dipert"@en ,
+                                                        "Ron Rudnicki"@en ,
+                                                        "Satya Sahoo"@en ,
+                                                        "Sivaram Arabandi"@en ,
+                                                        "Werner Ceusters"@en ,
+                                                        "William Duncan"@en ,
+                                                        "William Hogan"@en ,
+                                                        "Yongqun (Oliver) He"@en ;
+                                         
+                                         foaf:homepage <http://code.google.com/p/information-artifact-ontology/> ;
+                                         
+                                         dc:license <http://creativecommons.org/licenses/by/3.0/> ;
+                                         
+                                         owl:versionIRI iao:iao.owl .
+
+
 #################################################################
 #
 #    Annotation properties
 #
 #################################################################
+
+
+###  http://protege.stanford.edu/plugins/owl/protege#defaultLanguage
+
+protege:defaultLanguage rdf:type owl:AnnotationProperty .
 
 
 
@@ -3798,6 +3894,11 @@ dc:date rdf:type owl:AnnotationProperty ;
 
 
 
+###  http://usefulinc.com/ns/doap#file-release
+
+doap:file-release rdf:type owl:AnnotationProperty .
+
+
 
 ###  http://www.w3.org/2000/01/rdf-schema#label
 
@@ -3808,6 +3909,13 @@ rdfs:label rdf:type owl:AnnotationProperty .
 ###  http://www.w3.org/2002/07/owl#versionInfo
 
 owl:versionInfo rdf:type owl:AnnotationProperty .
+
+
+
+###  http://xmlns.com/foaf/0.1/homepage
+
+foaf:homepage rdf:type owl:AnnotationProperty .
+
 
 
 
@@ -3833,11 +3941,31 @@ obo:IAO_0000136 rdf:type owl:ObjectProperty ;
                 
                 obo:IAO_0000117 "person:Alan Ruttenberg"@en ;
                 
-                rdfs:domain obo:IAO_0000030 ;
-                
                 obo:IAO_0000114 obo:IAO_0000125 ;
                 
                 obo:IAO_0000412 <http://purl.obolibrary.org/obo/iao.owl> .
+
+
+
+
+
+#################################################################
+#
+#    Data properties
+#
+#################################################################
+
+
+###  http://usefulinc.com/ns/doap#revision
+
+doap:revision rdf:type owl:DatatypeProperty ;
+              
+              obo:IAO_0000412 <http://purl.obolibrary.org/obo/iao.owl> ;
+              
+              rdfs:isDefinedBy ns:doap .
+
+
+
 
 
 #################################################################
@@ -3955,12 +4083,30 @@ obo:IAO_0000428 rdf:type owl:NamedIndividual ;
 
 
 
+###  http://purl.obolibrary.org/obo/iao/2015-02-23/iao.owl
+
+iao:iao.owl rdf:type owl:NamedIndividual ;
+            
+            rdfs:label "IAO Release 2015-02-23" ;
+            
+            doap:revision "SVN $Revision: 717 $" ;
+            
+            doap:file-release <http://purl.obolibrary.org/obo/iao.owl> ,
+                              iao:iao.owl ;
+            
+            rdfs:seeAlso <http://purl.obolibrary.org/obo/iao/wiki/Releases/2015-02-23> .
+
+
+
 ###  http://purl.obolibrary.org/obo/iao/wiki/Releases/2015-02-23
 
 <http://purl.obolibrary.org/obo/iao/wiki/Releases/2015-02-23> rdf:type owl:NamedIndividual .
 
 
 
+###  http://usefulinc.com/ns/doap
+
+ns:doap rdf:type owl:NamedIndividual .
 
 
 
@@ -3969,7 +4115,11 @@ obo:IAO_0000428 rdf:type owl:NamedIndividual ;
 
 
 
-#################### Imports from NFO ##############################     
+##### Imports from nfo ##### .
+
+<http://purl.org/nidash/nidm/nfo_import.owl> rdf:type owl:Ontology .
+
+
 #################################################################
 #
 #    Annotation properties
@@ -4014,7 +4164,12 @@ nfo:fileName rdf:type owl:DatatypeProperty ;
 ###  Generated by the OWL API (version 3.5.0) http://owlapi.sourceforge.net
 
 
-#################### Imports from Neurolex ##############################     
+
+##### Imports from nlx ##### .
+
+<http://purl.org/nidash/nidm/nlx_import.owl> rdf:type owl:Ontology .
+
+
 #################################################################
 #
 #    Annotation properties
@@ -4061,7 +4216,12 @@ nlx:nif-0000-00343 rdf:type owl:Class ;
 ###  Generated by the OWL API (version 3.5.0) http://owlapi.sourceforge.net
 
 
-#################### Imports from STATO ##############################     
+
+##### Imports from stato ##### .
+
+<http://purl.org/nidash/nidm/stato_import.owl> rdf:type owl:Ontology .
+
+
 #################################################################
 #
 #    Annotation properties
@@ -4198,8 +4358,6 @@ obo:STATO_0000039 rdf:type owl:Class ;
                   
                   rdfs:label "statistic"@en ;
                   
-                  rdfs:subClassOf prov:Entity ;
-                  
                   obo:IAO_0000117 "Orlaith Burke"^^xsd:string ;
                   
                   obo:IAO_0000112 ""@en ;
@@ -4223,8 +4381,6 @@ obo:STATO_0000119 rdf:type owl:Class ;
                   
                   rdfs:label "model parameter estimation"@en ;
                   
-                  rdfs:subClassOf prov:Activity ;
-                  
                   obo:IAO_0000117 "Orlaith Burke"^^xsd:string ;
                   
                   obo:IAO_0000119 ""@en ;
@@ -4238,8 +4394,6 @@ obo:STATO_0000119 rdf:type owl:Class ;
 https://github.com/ISA-tools/stato/issues/18"""@en ;
                   
                   obo:IAO_0000114 obo:IAO_0000125 .
-
-
 
 
 
@@ -4293,8 +4447,6 @@ obo:STATO_0000323 rdf:type owl:Class ;
                   
                   rdfs:label "contrast weight matrix"@en ;
                   
-                  rdfs:subClassOf prov:Entity ;
-                  
                   obo:IAO_0000117 "Alejandra Gonzalez-Beltran"@en ,
                                   "Camille Maumet"@en ,
                                   "Orlaith Burke"@en ,
@@ -4318,18 +4470,15 @@ obo:STATO_0000346 rdf:type owl:Class ;
                   
                   rdfs:label "covariance structure"@en ;
                   
-                  rdfs:subClassOf prov:Entity ;
-                  
-                  obo:IAO_0000117 "Orlaith Burke" ,
+                  obo:IAO_0000117 "Camille Maumet" ,
+                                  "Orlaith Burke" ,
                                   "Tom Nichols" ,
+                                  "Alejandra Gonzalez-Beltran" ,
                                   "Philippe Rocca-Serra" ;
                   
-                  obo:IAO_0000119 "http://www3.nd.edu/~kyuan/courses/sem/readpapers/benter.pdf" ;
-                  
-                  obo:IAO_0000117 "Camille Maumet" ,
-                                  "Alejandra Gonzalez-Beltran" ;
-                  
                   obo:IAO_0000115 "a covariance structure is a data item which is part of a regression model and which indicates a pattern in the covariance matrix. The nature of covariance structure is specified before the regression analysis and various covariance structure may be tested and evaluated using information criteria to help choose the most suiteable model"@en ;
+                  
+                  obo:IAO_0000119 "http://www3.nd.edu/~kyuan/courses/sem/readpapers/benter.pdf" ;
                   
                   obo:IAO_0000114 obo:IAO_0000120 .
 
@@ -4400,16 +4549,15 @@ obo:STATO_0000370 rdf:type owl:Class ;
                   
                   obo:STATO_0000032 "OLS estimation" ;
                   
-                  obo:STATO_0000041 ""@en ;
-                  
-                  obo:IAO_0000119 "http://en.wikipedia.org/wiki/Ordinary_least_squares and Tom Nichols"@en ;
-                  
-                  obo:STATO_0000041 "https://stat.ethz.ch/R-manual/R-patched/library/stats/html/lm.html" ;
+                  obo:STATO_0000041 ""@en ,
+                                    "https://stat.ethz.ch/R-manual/R-patched/library/stats/html/lm.html" ;
                   
                   obo:IAO_0000117 "Alejandra Gonzalez-Beltran"@en ,
                                   "Camille Maumet"@en ,
                                   "Philippe Rocca-Serra"@en ,
                                   "Tom Nichols"@en ;
+                  
+                  obo:IAO_0000119 "http://en.wikipedia.org/wiki/Ordinary_least_squares and Tom Nichols"@en ;
                   
                   obo:IAO_0000115 "the ordinary least squares estimation is a model parameter estimation for a linear regression model when the errors are uncorrelated and equal in variance. Is the Best Linear Unbiased Estimation (BLUE) method under these assumptions, Uniformly Minimum-Variance Unbiased Estimator (UMVUE) with addition of a Gaussian assumption."@en ;
                   
@@ -4449,7 +4597,7 @@ obo:STATO_0000372 rdf:type owl:Class ;
                   
                   rdfs:label "generalized least squares estimation"@en ;
                   
-                  rdfs:subClassOf obo:STATO_0000119  ;
+                  rdfs:subClassOf obo:STATO_0000119 ;
                   
                   obo:STATO_0000032 "GLS estimation" ;
                   
@@ -4480,10 +4628,11 @@ obo:STATO_0000373 rdf:type owl:Class ;
                   
                   obo:STATO_0000041 ""@en ;
                   
-                  obo:IAO_0000117 "Philippe Rocca-Serra"@en ,
-                                  "Tom Nichols"@en ;
+                  obo:IAO_0000117 "Philippe Rocca-Serra"@en ;
                   
                   obo:IAO_0000119 "Tom Nichols"@en ;
+                  
+                  obo:IAO_0000117 "Tom Nichols"@en ;
                   
                   obo:IAO_0000115 "the iteratively reweighted least squares estimation is a model parameter estimation which is a practical implementation of Weighted Least Squares, where the heterogeneous variances of the errors are estimated from the residuals of the regression model, providing an estimate for the weights. Each successive estimate of the weights improves the estimation of the regression parameters, which in turn are used to compute residuals and update the weights"@en ;
                   
@@ -4502,12 +4651,12 @@ obo:STATO_0000374 rdf:type owl:Class ;
                   obo:IAO_0000115 "the feasible generalized least squares estimation is a model parameter estimation which is a practical implementation of Generalised Least Squares, where the covariance of the errors is estimated from the residuals of the regression model, providing the information needed to whiten the data and model. Each successive estimate of the whitening matrix improves the estimation of the regression parameters, which in turn are used to compute residuals and update the whitening matrix." ;
                   
                   obo:IAO_0000117 "Alejandra Gonzalez-Beltran"@en ,
-                                  "Philippe Rocca-Serra"@en ;
+                                  "Orlaith Burke"@en ;
                   
                   obo:IAO_0000119 "Tom Nichols" ;
                   
                   obo:IAO_0000117 "Camille Maumet" ,
-                                  "Orlaith Burke"@en ,
+                                  "Philippe Rocca-Serra"@en ,
                                   "Tom Nichols"@en ;
                   
                   obo:IAO_0000114 obo:IAO_0000120 .
@@ -4539,194 +4688,840 @@ obo:STATO_0000376 rdf:type owl:Class ;
 ###  Generated by the OWL API (version 3.5.0) http://owlapi.sourceforge.net
 
 
-######################### Imports from PROV #################
 
-#################################################################
-#
-#    Annotation properties
-#
-#################################################################
-
-
-###  http://www.w3.org/2000/01/rdf-schema#comment
-
-rdfs:comment rdf:type owl:AnnotationProperty ;
-             
-             rdfs:comment ""@en ;
-             
-             rdfs:isDefinedBy prov: ,
-                              <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/2000/01/rdf-schema#isDefinedBy
-
-rdfs:isDefinedBy rdf:type owl:AnnotationProperty .
-
-
-
-###  http://www.w3.org/2000/01/rdf-schema#label
-
-rdfs:label rdf:type owl:AnnotationProperty ;
-           
-           rdfs:comment ""@en ;
-           
-           rdfs:isDefinedBy prov: ,
-                            <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/2000/01/rdf-schema#seeAlso
-
-rdfs:seeAlso rdf:type owl:AnnotationProperty ;
-             
-             rdfs:comment ""@en .
-
-
-
-###  http://www.w3.org/2002/07/owl#versionInfo
-
-owl:versionInfo rdf:type owl:AnnotationProperty .
-
-
-
-###  http://www.w3.org/ns/prov#aq
-
-prov:aq rdf:type owl:AnnotationProperty ;
-        
-        rdfs:subPropertyOf rdfs:seeAlso ;
-        
-        rdfs:isDefinedBy prov: ,
-                         <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#category
-
-prov:category rdf:type owl:AnnotationProperty ;
-              
-              rdfs:comment "Classify prov-o terms into three categories, including 'starting-point', 'qualifed', and 'extended'. This classification is used by the prov-o html document to gently introduce prov-o terms to its users. "@en ;
-              
-              rdfs:isDefinedBy prov: ,
-                               <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#component
-
-prov:component rdf:type owl:AnnotationProperty ;
-               
-               rdfs:comment "Classify prov-o terms into six components according to prov-dm, including 'agents-responsibility', 'alternate', 'annotations', 'collections', 'derivations', and 'entities-activities'. This classification is used so that readers of prov-o specification can find its correspondence with the prov-dm specification."@en ;
-               
-               rdfs:isDefinedBy prov: ,
-                                <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#constraints
-
-prov:constraints rdf:type owl:AnnotationProperty ;
-                 
-                 rdfs:comment "A reference to the principal section of the PROV-CONSTRAINTS document that describes this concept."@en ;
-                 
-                 rdfs:subPropertyOf rdfs:seeAlso ;
-                 
-                 rdfs:isDefinedBy prov: ,
-                                  <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#definition
-
-prov:definition rdf:type owl:AnnotationProperty ;
-                
-                rdfs:comment "A definition quoted from PROV-DM or PROV-CONSTRAINTS that describes the concept expressed with this OWL term."@en ;
-                
-                rdfs:isDefinedBy prov: ,
-                                 <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#dm
-
-prov:dm rdf:type owl:AnnotationProperty ;
-        
-        rdfs:comment "A reference to the principal section of the PROV-DM document that describes this concept."@en ;
-        
-        rdfs:subPropertyOf rdfs:seeAlso ;
-        
-        rdfs:isDefinedBy prov: ,
-                         <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#editorialNote
-
-prov:editorialNote rdf:type owl:AnnotationProperty ;
-                   
-                   rdfs:comment "A note by the OWL development team about how this term expresses the PROV-DM concept, or how it should be used in context of semantic web or linked data."@en ;
-                   
-                   rdfs:isDefinedBy prov: ,
-                                    <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#editorsDefinition
-
-prov:editorsDefinition rdf:type owl:AnnotationProperty ;
-                       
-                       rdfs:comment "When the prov-o term does not have a definition drawn from prov-dm, and the prov-o editor provides one."@en ;
-                       
-                       rdfs:isDefinedBy prov: ;
-                       
-                       rdfs:subPropertyOf prov:definition ;
-                       
-                       rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#inverse
-
-prov:inverse rdf:type owl:AnnotationProperty ;
-             
-             rdfs:comment "PROV-O does not define all property inverses. The directionalities defined in PROV-O should be given preference over those not defined. However, if users wish to name the inverse of a PROV-O property, the local name given by prov:inverse should be used."@en ;
-             
-             rdfs:seeAlso <http://www.w3.org/TR/prov-o/#names-of-inverse-properties> ;
-             
-             rdfs:isDefinedBy prov: ,
-                              <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#n
-
-prov:n rdf:type owl:AnnotationProperty ;
-       
-       rdfs:comment "A reference to the principal section of the PROV-DM document that describes this concept."@en ,
-                    "A reference to the principal section of the PROV-M document that describes this concept."@en ;
-       
-       rdfs:subPropertyOf rdfs:seeAlso ;
-       
-       rdfs:isDefinedBy prov: ,
-                        <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#order
-
-prov:order rdf:type owl:AnnotationProperty ;
-           
-           rdfs:comment "The position that this OWL term should be listed within documentation. The scope of the documentation (e.g., among all terms, among terms within a prov:category, among properties applying to a particular class, etc.) is unspecified."@en ;
-           
-           rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#qualifiedForm
-
-prov:qualifiedForm rdf:type owl:AnnotationProperty ;
-                   
-                   rdfs:comment """This annotation property links a subproperty of prov:wasInfluencedBy with the subclass of prov:Influence and the qualifying property that are used to qualify it. 
+##### Imports from prov #####
+rdfs:comment
+    a owl:AnnotationProperty ;
+    rdfs:comment ""@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
+
+rdfs:isDefinedBy
+    a owl:AnnotationProperty .
+
+rdfs:label
+    a owl:AnnotationProperty ;
+    rdfs:comment ""@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
+
+rdfs:seeAlso
+    a owl:AnnotationProperty ;
+    rdfs:comment ""@en .
+
+owl:Thing
+    a owl:Class .
+
+owl:versionInfo
+    a owl:AnnotationProperty .
+
+<http://www.w3.org/ns/prov#>
+    a owl:Ontology .
+
+prov:Activity
+    a owl:Class ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Activity" ;
+    owl:disjointWith prov:Entity ;
+    prov:category "starting-point" ;
+    prov:component "entities-activities" ;
+    prov:constraints "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
+    prov:definition "An activity is something that occurs over a period of time and acts upon or with entities; it may include consuming, processing, transforming, modifying, relocating, using, or generating entities." ;
+    prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Activity"^^xsd:anyURI ;
+    prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Activity"^^xsd:anyURI .
+
+prov:ActivityInfluence
+    a owl:Class ;
+    rdfs:comment "ActivityInfluence provides additional descriptions of an Activity's binary influence upon any other kind of resource. Instances of ActivityInfluence use the prov:activity property to cite the influencing Activity."@en, "It is not recommended that the type ActivityInfluence be asserted without also asserting one of its more specific subclasses."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "ActivityInfluence" ;
+    rdfs:seeAlso prov:activity ;
+    rdfs:subClassOf prov:Influence, [
+        a owl:Restriction ;
+        owl:maxCardinality "0"^^xsd:nonNegativeInteger ;
+        owl:onProperty prov:hadActivity
+    ] ;
+    owl:disjointWith prov:EntityInfluence ;
+    prov:category "qualified" ;
+    prov:editorsDefinition "ActivitiyInfluence is the capacity of an activity to have an effect on the character, development, or behavior of another by means of generation, invalidation, communication, or other."@en .
+
+prov:Agent
+    a owl:Class ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Agent" ;
+    owl:disjointWith prov:InstantaneousEvent ;
+    prov:category "starting-point" ;
+    prov:component "agents-responsibility" ;
+    prov:definition "An agent is something that bears some form of responsibility for an activity taking place, for the existence of an entity, or for another agent's activity. "@en ;
+    prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-agent"^^xsd:anyURI ;
+    prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Agent"^^xsd:anyURI .
+
+prov:AgentInfluence
+    a owl:Class ;
+    rdfs:comment "AgentInfluence provides additional descriptions of an Agent's binary influence upon any other kind of resource. Instances of AgentInfluence use the prov:agent property to cite the influencing Agent."@en, "It is not recommended that the type AgentInfluence be asserted without also asserting one of its more specific subclasses."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "AgentInfluence" ;
+    rdfs:seeAlso prov:agent ;
+    rdfs:subClassOf prov:Influence ;
+    prov:category "qualified" ;
+    prov:editorsDefinition "AgentInfluence is the capacity of an agent to have an effect on the character, development, or behavior of another by means of attribution, association, delegation, or other."@en .
+
+prov:Association
+    a owl:Class ;
+    rdfs:comment "An instance of prov:Association provides additional descriptions about the binary prov:wasAssociatedWith relation from an prov:Activity to some prov:Agent that had some responsiblity for it. For example, prov:baking prov:wasAssociatedWith prov:baker; prov:qualifiedAssociation [ a prov:Association; prov:agent prov:baker; prov:foo prov:bar ]."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Association" ;
+    rdfs:subClassOf prov:AgentInfluence ;
+    prov:category "qualified" ;
+    prov:component "agents-responsibility" ;
+    prov:definition "An activity association is an assignment of responsibility to an agent for an activity, indicating that the agent had a role in the activity. It further allows for a plan to be specified, which is the plan intended by the agent to achieve some goals in the context of this activity."@en ;
+    prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Association"^^xsd:anyURI ;
+    prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Association"^^xsd:anyURI ;
+    prov:unqualifiedForm prov:wasAssociatedWith .
+
+prov:Attribution
+    a owl:Class ;
+    rdfs:comment "An instance of prov:Attribution provides additional descriptions about the binary prov:wasAttributedTo relation from an prov:Entity to some prov:Agent that had some responsible for it. For example, prov:cake prov:wasAttributedTo prov:baker; prov:qualifiedAttribution [ a prov:Attribution; prov:entity prov:baker; prov:foo prov:bar ]."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Attribution" ;
+    rdfs:subClassOf prov:AgentInfluence ;
+    prov:category "qualified" ;
+    prov:component "agents-responsibility" ;
+    prov:constraints "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
+    prov:definition """Attribution is the ascribing of an entity to an agent.
+
+When an entity e is attributed to agent ag, entity e was generated by some unspecified activity that in turn was associated to agent ag. Thus, this relation is useful when the activity is not known, or irrelevant."""@en ;
+    prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-attribution"^^xsd:anyURI ;
+    prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-attribution"^^xsd:anyURI ;
+    prov:unqualifiedForm prov:wasAttributedTo .
+
+prov:Bundle
+    a owl:Class ;
+    rdfs:comment "Note that there are kinds of bundles (e.g. handwritten letters, audio recordings, etc.) that are not expressed in PROV-O, but can be still be described by PROV-O."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Bundle" ;
+    rdfs:subClassOf prov:Entity ;
+    prov:category "expanded" ;
+    prov:definition "A bundle is a named set of provenance descriptions, and is itself an Entity, so allowing provenance of provenance to be expressed."@en ;
+    prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-bundle-entity"^^xsd:anyURI ;
+    prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-bundle-declaration"^^xsd:anyURI .
+
+prov:Collection
+    a owl:Class ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Collection" ;
+    rdfs:subClassOf prov:Entity ;
+    prov:category "expanded" ;
+    prov:component "collections" ;
+    prov:definition "A collection is an entity that provides a structure to some constituents, which are themselves entities. These constituents are said to be member of the collections."@en ;
+    prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-collection"^^xsd:anyURI .
+
+prov:Communication
+    a owl:Class ;
+    rdfs:comment "An instance of prov:Communication provides additional descriptions about the binary prov:wasInformedBy relation from an informed prov:Activity to the prov:Activity that informed it. For example, prov:you_jumping_off_bridge prov:wasInformedBy prov:everyone_else_jumping_off_bridge; prov:qualifiedCommunication [ a prov:Communication; prov:activity prov:everyone_else_jumping_off_bridge; prov:foo prov:bar ]."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Communication" ;
+    rdfs:subClassOf prov:ActivityInfluence ;
+    prov:category "qualified" ;
+    prov:component "entities-activities" ;
+    prov:constraints "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
+    prov:definition "Communication is the exchange of an entity by two activities, one activity using the entity generated by the other." ;
+    prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Communication"^^xsd:anyURI ;
+    prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-wasInformedBy"^^xsd:anyURI ;
+    prov:unqualifiedForm prov:wasInformedBy .
+
+prov:Delegation
+    a owl:Class ;
+    rdfs:comment "An instance of prov:Delegation provides additional descriptions about the binary prov:actedOnBehalfOf relation from a performing prov:Agent to some prov:Agent for whom it was performed. For example, prov:mixing prov:wasAssociatedWith prov:toddler . prov:toddler prov:actedOnBehalfOf prov:mother; prov:qualifiedDelegation [ a prov:Delegation; prov:entity prov:mother; prov:foo prov:bar ]."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Delegation" ;
+    rdfs:subClassOf prov:AgentInfluence ;
+    prov:category "qualified" ;
+    prov:component "agents-responsibility" ;
+    prov:definition """Delegation is the assignment of authority and responsibility to an agent (by itself or by another agent) to carry out a specific activity as a delegate or representative, while the agent it acts on behalf of retains some responsibility for the outcome of the delegated work.
+
+For example, a student acted on behalf of his supervisor, who acted on behalf of the department chair, who acted on behalf of the university; all those agents are responsible in some way for the activity that took place but we do not say explicitly who bears responsibility and to what degree."""@en ;
+    prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-delegation"^^xsd:anyURI ;
+    prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-delegation"^^xsd:anyURI ;
+    prov:unqualifiedForm prov:actedOnBehalfOf .
+
+prov:Derivation
+    a owl:Class ;
+    rdfs:comment "An instance of prov:Derivation provides additional descriptions about the binary prov:wasDerivedFrom relation from some derived prov:Entity to another prov:Entity from which it was derived. For example, prov:chewed_bubble_gum prov:wasDerivedFrom prov:unwrapped_bubble_gum; prov:qualifiedDerivation [ a prov:Derivation; prov:entity prov:unwrapped_bubble_gum; prov:foo prov:bar ]."@en, "The more specific forms of prov:Derivation (i.e., prov:Revision, prov:Quotation, prov:PrimarySource) should be asserted if they apply."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Derivation" ;
+    rdfs:subClassOf prov:EntityInfluence ;
+    prov:category "qualified" ;
+    prov:component "derivations" ;
+    prov:constraints "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
+    prov:definition "A derivation is a transformation of an entity into another, an update of an entity resulting in a new one, or the construction of a new entity based on a pre-existing entity."@en ;
+    prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Derivation"^^xsd:anyURI ;
+    prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#Derivation-Relation"^^xsd:anyURI ;
+    prov:unqualifiedForm prov:wasDerivedFrom .
+
+prov:EmptyCollection
+    a owl:Class, owl:NamedIndividual ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "EmptyCollection"@en ;
+    rdfs:subClassOf prov:Collection ;
+    prov:category "expanded" ;
+    prov:component "collections" ;
+    prov:definition "An empty collection is a collection without members."@en .
+
+prov:End
+    a owl:Class ;
+    rdfs:comment "An instance of prov:End provides additional descriptions about the binary prov:wasEndedBy relation from some ended prov:Activity to an prov:Entity that ended it. For example, prov:ball_game prov:wasEndedBy prov:buzzer; prov:qualifiedEnd [ a prov:End; prov:entity prov:buzzer; prov:foo prov:bar; prov:atTime '2012-03-09T08:05:08-05:00'^^xsd:dateTime ]."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "End" ;
+    rdfs:subClassOf prov:EntityInfluence, prov:InstantaneousEvent ;
+    prov:category "qualified" ;
+    prov:component "entities-activities" ;
+    prov:constraints "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
+    prov:definition "End is when an activity is deemed to have been ended by an entity, known as trigger. The activity no longer exists after its end. Any usage, generation, or invalidation involving an activity precedes the activity's end. An end may refer to a trigger entity that terminated the activity, or to an activity, known as ender that generated the trigger."@en ;
+    prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-End"^^xsd:anyURI ;
+    prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-End"^^xsd:anyURI ;
+    prov:unqualifiedForm prov:wasEndedBy .
+
+prov:Entity
+    a owl:Class ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Entity" ;
+    owl:disjointWith prov:InstantaneousEvent ;
+    prov:category "starting-point" ;
+    prov:component "entities-activities" ;
+    prov:constraints "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
+    prov:definition "An entity is a physical, digital, conceptual, or other kind of thing with some fixed aspects; entities may be real or imaginary. "@en ;
+    prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-entity"^^xsd:anyURI ;
+    prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Entity"^^xsd:anyURI .
+
+prov:EntityInfluence
+    a owl:Class ;
+    rdfs:comment "EntityInfluence provides additional descriptions of an Entity's binary influence upon any other kind of resource. Instances of EntityInfluence use the prov:entity property to cite the influencing Entity."@en, "It is not recommended that the type EntityInfluence be asserted without also asserting one of its more specific subclasses."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "EntityInfluence" ;
+    rdfs:seeAlso prov:entity ;
+    rdfs:subClassOf prov:Influence ;
+    prov:category "qualified" ;
+    prov:editorsDefinition "EntityInfluence is the capacity of an entity to have an effect on the character, development, or behavior of another by means of usage, start, end, derivation, or other. "@en .
+
+prov:Generation
+    a owl:Class ;
+    rdfs:comment "An instance of prov:Generation provides additional descriptions about the binary prov:wasGeneratedBy relation from a generated prov:Entity to the prov:Activity that generated it. For example, prov:cake prov:wasGeneratedBy prov:baking; prov:qualifiedGeneration [ a prov:Generation; prov:activity prov:baking; prov:foo prov:bar ]."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Generation" ;
+    rdfs:subClassOf prov:ActivityInfluence, prov:InstantaneousEvent ;
+    prov:category "qualified" ;
+    prov:component "entities-activities" ;
+    prov:constraints "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
+    prov:definition "Generation is the completion of production of a new entity by an activity. This entity did not exist before generation and becomes available for usage after this generation."@en ;
+    prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Generation"^^xsd:anyURI ;
+    prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Generation"^^xsd:anyURI ;
+    prov:unqualifiedForm prov:wasGeneratedBy .
+
+prov:Influence
+    a owl:Class ;
+    rdfs:comment "An instance of prov:Influence provides additional descriptions about the binary prov:wasInfluencedBy relation from some influenced Activity, Entity, or Agent to the influencing Activity, Entity, or Agent. For example, prov:stomach_ache prov:wasInfluencedBy prov:spoon; prov:qualifiedInfluence [ a prov:Influence; prov:entity prov:spoon; prov:foo prov:bar ] . Because prov:Influence is a broad relation, the more specific relations (Communication, Delegation, End, etc.) should be used when applicable."@en, "Because prov:Influence is a broad relation, its most specific subclasses (e.g. prov:Communication, prov:Delegation, prov:End, prov:Revision, etc.) should be used when applicable."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Influence" ;
+    prov:category "qualified" ;
+    prov:component "derivations" ;
+    prov:definition "Influence is the capacity of an entity, activity, or agent to have an effect on the character, development, or behavior of another by means of usage, start, end, generation, invalidation, communication, derivation, attribution, association, or delegation."@en ;
+    prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-influence"^^xsd:anyURI ;
+    prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-influence"^^xsd:anyURI ;
+    prov:unqualifiedForm prov:wasInfluencedBy .
+
+prov:InstantaneousEvent
+    a owl:Class ;
+    rdfs:comment "An instantaneous event, or event for short, happens in the world and marks a change in the world, in its activities and in its entities. The term 'event' is commonly used in process algebra with a similar meaning. Events represent communications or interactions; they are assumed to be atomic and instantaneous."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "InstantaneousEvent" ;
+    prov:category "qualified" ;
+    prov:component "entities-activities" ;
+    prov:constraints "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#dfn-event"^^xsd:anyURI ;
+    prov:definition "The PROV data model is implicitly based on a notion of instantaneous events (or just events), that mark transitions in the world. Events include generation, usage, or invalidation of entities, as well as starting or ending of activities. This notion of event is not first-class in the data model, but it is useful for explaining its other concepts and its semantics."@en .
+
+prov:Invalidation
+    a owl:Class ;
+    rdfs:comment "An instance of prov:Invalidation provides additional descriptions about the binary prov:wasInvalidatedBy relation from an invalidated prov:Entity to the prov:Activity that invalidated it. For example, prov:uncracked_egg prov:wasInvalidatedBy prov:baking; prov:qualifiedInvalidation [ a prov:Invalidation; prov:activity prov:baking; prov:foo prov:bar ]."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Invalidation" ;
+    rdfs:subClassOf prov:ActivityInfluence, prov:InstantaneousEvent ;
+    prov:category "qualified" ;
+    prov:component "entities-activities" ;
+    prov:constraints "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
+    prov:definition "Invalidation is the start of the destruction, cessation, or expiry of an existing entity by an activity. The entity is no longer available for use (or further invalidation) after invalidation. Any generation or usage of an entity precedes its invalidation." ;
+    prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Invalidation"^^xsd:anyURI ;
+    prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Invalidation"^^xsd:anyURI ;
+    prov:unqualifiedForm prov:wasInvalidatedBy .
+
+prov:Location
+    a owl:Class ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Location" ;
+    rdfs:seeAlso prov:atLocation ;
+    prov:category "expanded" ;
+    prov:definition "A location can be an identifiable geographic place (ISO 19112), but it can also be a non-geographic place such as a directory, row, or column. As such, there are numerous ways in which location can be expressed, such as by a coordinate, address, landmark, and so forth."@en ;
+    prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-attribute-location"^^xsd:anyURI ;
+    prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-attribute"^^xsd:anyURI .
+
+prov:Organization
+    a owl:Class ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Organization" ;
+    rdfs:subClassOf prov:Agent ;
+    prov:category "expanded" ;
+    prov:component "agents-responsibility" ;
+    prov:definition "An organization is a social or legal institution such as a company, society, etc." ;
+    prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-agent"^^xsd:anyURI ;
+    prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-types"^^xsd:anyURI .
+
+prov:Person
+    a owl:Class ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Person" ;
+    rdfs:subClassOf prov:Agent ;
+    prov:category "expanded" ;
+    prov:component "agents-responsibility" ;
+    prov:definition "Person agents are people."@en ;
+    prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-agent"^^xsd:anyURI ;
+    prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-types"^^xsd:anyURI .
+
+prov:Plan
+    a owl:Class ;
+    rdfs:comment "There exist no prescriptive requirement on the nature of plans, their representation, the actions or steps they consist of, or their intended goals. Since plans may evolve over time, it may become necessary to track their provenance, so plans themselves are entities. Representing the plan explicitly in the provenance can be useful for various tasks: for example, to validate the execution as represented in the provenance record, to manage expectation failures, or to provide explanations."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Plan" ;
+    rdfs:subClassOf prov:Entity ;
+    prov:category "expanded", "qualified" ;
+    prov:component "agents-responsibility" ;
+    prov:definition "A plan is an entity that represents a set of actions or steps intended by one or more agents to achieve some goals." ;
+    prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Association"^^xsd:anyURI ;
+    prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Association"^^xsd:anyURI .
+
+prov:PrimarySource
+    a owl:Class ;
+    rdfs:comment "An instance of prov:PrimarySource provides additional descriptions about the binary prov:hadPrimarySource relation from some secondary prov:Entity to an earlier, primary prov:Entity. For example, prov:blog prov:hadPrimarySource prov:newsArticle; prov:qualifiedPrimarySource [ a prov:PrimarySource; prov:entity prov:newsArticle; prov:foo prov:bar ] ."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "PrimarySource" ;
+    rdfs:subClassOf prov:Derivation ;
+    prov:category "qualified" ;
+    prov:component "derivations" ;
+    prov:definition """A primary source for a topic refers to something produced by some agent with direct experience and knowledge about the topic, at the time of the topic's study, without benefit from hindsight.
+
+Because of the directness of primary sources, they 'speak for themselves' in ways that cannot be captured through the filter of secondary sources. As such, it is important for secondary sources to reference those primary sources from which they were derived, so that their reliability can be investigated.
+
+A primary source relation is a particular case of derivation of secondary materials from their primary sources. It is recognized that the determination of primary sources can be up to interpretation, and should be done according to conventions accepted within the application's domain."""@en ;
+    prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-primary-source"^^xsd:anyURI ;
+    prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-original-source"^^xsd:anyURI ;
+    prov:unqualifiedForm prov:hadPrimarySource .
+
+prov:Quotation
+    a owl:Class ;
+    rdfs:comment "An instance of prov:Quotation provides additional descriptions about the binary prov:wasQuotedFrom relation from some taken prov:Entity from an earlier, larger prov:Entity. For example, prov:here_is_looking_at_you_kid prov:wasQuotedFrom prov:casablanca_script; prov:qualifiedQuotation [ a prov:Quotation; prov:entity prov:casablanca_script; prov:foo prov:bar ]."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Quotation" ;
+    rdfs:subClassOf prov:Derivation ;
+    prov:category "qualified" ;
+    prov:component "derivations" ;
+    prov:definition "A quotation is the repeat of (some or all of) an entity, such as text or image, by someone who may or may not be its original author. Quotation is a particular case of derivation."@en ;
+    prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-quotation"^^xsd:anyURI ;
+    prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-quotation"^^xsd:anyURI ;
+    prov:unqualifiedForm prov:wasQuotedFrom .
+
+prov:Revision
+    a owl:Class ;
+    rdfs:comment "An instance of prov:Revision provides additional descriptions about the binary prov:wasRevisionOf relation from some newer prov:Entity to an earlier prov:Entity. For example, prov:draft_2 prov:wasRevisionOf prov:draft_1; prov:qualifiedRevision [ a prov:Revision; prov:entity prov:draft_1; prov:foo prov:bar ]."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Revision" ;
+    rdfs:subClassOf prov:Derivation ;
+    prov:category "qualified" ;
+    prov:component "derivations" ;
+    prov:definition "A revision is a derivation for which the resulting entity is a revised version of some original. The implication here is that the resulting entity contains substantial content from the original. Revision is a particular case of derivation."@en ;
+    prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-revision"^^xsd:anyURI ;
+    prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Revision"^^xsd:anyURI ;
+    prov:unqualifiedForm prov:wasRevisionOf .
+
+prov:Role
+    a owl:Class ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Role" ;
+    rdfs:seeAlso prov:hadRole ;
+    prov:category "qualified" ;
+    prov:component "agents-responsibility" ;
+    prov:definition "A role is the function of an entity or agent with respect to an activity, in the context of a usage, generation, invalidation, association, start, and end."@en ;
+    prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-attribute-role"^^xsd:anyURI ;
+    prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-attribute"^^xsd:anyURI .
+
+prov:SoftwareAgent
+    a owl:Class ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "SoftwareAgent" ;
+    rdfs:subClassOf prov:Agent ;
+    prov:category "expanded" ;
+    prov:component "agents-responsibility" ;
+    prov:definition "A software agent is running software."@en ;
+    prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-agent"^^xsd:anyURI ;
+    prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-types"^^xsd:anyURI .
+
+prov:Start
+    a owl:Class ;
+    rdfs:comment "An instance of prov:Start provides additional descriptions about the binary prov:wasStartedBy relation from some started prov:Activity to an prov:Entity that started it. For example, prov:foot_race prov:wasStartedBy prov:bang; prov:qualifiedStart [ a prov:Start; prov:entity prov:bang; prov:foo prov:bar; prov:atTime '2012-03-09T08:05:08-05:00'^^xsd:dateTime ] ."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Start" ;
+    rdfs:subClassOf prov:EntityInfluence, prov:InstantaneousEvent ;
+    prov:category "qualified" ;
+    prov:component "entities-activities" ;
+    prov:constraints "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
+    prov:definition "Start is when an activity is deemed to have been started by an entity, known as trigger. The activity did not exist before its start. Any usage, generation, or invalidation involving an activity follows the activity's start. A start may refer to a trigger entity that set off the activity, or to an activity, known as starter, that generated the trigger."@en ;
+    prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Start"^^xsd:anyURI ;
+    prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Start"^^xsd:anyURI ;
+    prov:unqualifiedForm prov:wasStartedBy .
+
+prov:Usage
+    a owl:Class ;
+    rdfs:comment "An instance of prov:Usage provides additional descriptions about the binary prov:used relation from some prov:Activity to an prov:Entity that it used. For example, prov:keynote prov:used prov:podium; prov:qualifiedUsage [ a prov:Usage; prov:entity prov:podium; prov:foo prov:bar ]."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Usage" ;
+    rdfs:subClassOf prov:EntityInfluence, prov:InstantaneousEvent ;
+    prov:category "qualified" ;
+    prov:component "entities-activities" ;
+    prov:constraints "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
+    prov:definition "Usage is the beginning of utilizing an entity by an activity. Before usage, the activity had not begun to utilize this entity and could not have been affected by the entity."@en ;
+    prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Usage"^^xsd:anyURI ;
+    prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Usage"^^xsd:anyURI ;
+    prov:unqualifiedForm prov:used .
+
+prov:actedOnBehalfOf
+    a owl:ObjectProperty ;
+    rdfs:comment "An object property to express the accountability of an agent towards another agent. The subordinate agent acted on behalf of the responsible agent in an actual activity. "@en ;
+    rdfs:domain prov:Agent ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "actedOnBehalfOf" ;
+    rdfs:range prov:Agent ;
+    rdfs:subPropertyOf prov:wasInfluencedBy ;
+    owl:propertyChainAxiom (:qualifiedDelegation
+        prov:agent
+    ) ;
+    prov:category "starting-point" ;
+    prov:component "agents-responsibility" ;
+    prov:inverse "hadDelegate" ;
+    prov:qualifiedForm prov:Delegation, prov:qualifiedDelegation .
+
+prov:activity
+    a owl:ObjectProperty ;
+    rdfs:domain prov:ActivityInfluence ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "activity" ;
+    rdfs:range prov:Activity ;
+    rdfs:subPropertyOf prov:influencer ;
+    prov:category "qualified" ;
+    prov:editorialNote "This property behaves in spirit like rdf:object; it references the object of a prov:wasInfluencedBy triple."@en ;
+    prov:editorsDefinition "The prov:activity property references an prov:Activity which influenced a resource. This property applies to an prov:ActivityInfluence, which is given by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity or prov:Agent." ;
+    prov:inverse "activityOfInfluence" .
+
+prov:agent
+    a owl:ObjectProperty ;
+    rdfs:domain prov:AgentInfluence ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "agent" ;
+    rdfs:range prov:Agent ;
+    rdfs:subPropertyOf prov:influencer ;
+    prov:category "qualified" ;
+    prov:editorialNote "This property behaves in spirit like rdf:object; it references the object of a prov:wasInfluencedBy triple."@en ;
+    prov:editorsDefinition "The prov:agent property references an prov:Agent which influenced a resource. This property applies to an prov:AgentInfluence, which is given by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity or prov:Agent."@en ;
+    prov:inverse "agentOfInfluence" .
+
+prov:alternateOf
+    a owl:ObjectProperty ;
+    rdfs:domain prov:Entity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "alternateOf" ;
+    rdfs:range prov:Entity ;
+    rdfs:seeAlso prov:specializationOf ;
+    prov:category "expanded" ;
+    prov:component "alternate" ;
+    prov:constraints "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
+    prov:definition "Two alternate entities present aspects of the same thing. These aspects may be the same or different, and the alternate entities may or may not overlap in time."@en ;
+    prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-alternate"^^xsd:anyURI ;
+    prov:inverse "alternateOf" ;
+    prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-alternate"^^xsd:anyURI .
+
+prov:aq
+    a owl:AnnotationProperty ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:subPropertyOf rdfs:seeAlso .
+
+prov:atLocation
+    a owl:ObjectProperty ;
+    rdfs:comment "The Location of any resource."@en, "This property has multiple RDFS domains to suit multiple OWL Profiles. See <a href=\"#owl-profile\">PROV-O OWL Profile</a>." ;
+    rdfs:domain [
+        a owl:Class ;
+        owl:unionOf (:Activity
+            prov:Agent
+            prov:Entity
+            prov:InstantaneousEvent
+        )
+    ] ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "atLocation" ;
+    rdfs:range prov:Location ;
+    prov:category "expanded" ;
+    prov:editorialNote "The naming of prov:atLocation parallels prov:atTime, and is not named prov:hadLocation to avoid conflicting with the convention that prov:had* properties are used on prov:Influence classes."@en, "This property is not functional because the many values could be at a variety of granularies (In this building, in this room, in that chair)."@en ;
+    prov:inverse "locationOf" ;
+    prov:sharesDefinitionWith prov:Location .
+
+prov:atTime
+    a owl:DatatypeProperty ;
+    rdfs:comment "The time at which an InstantaneousEvent occurred, in the form of xsd:dateTime."@en ;
+    rdfs:domain prov:InstantaneousEvent ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "atTime" ;
+    rdfs:range xsd:dateTime ;
+    prov:category "qualified" ;
+    prov:component "entities-activities" ;
+    prov:sharesDefinitionWith prov:InstantaneousEvent ;
+    prov:unqualifiedForm prov:endedAtTime, prov:generatedAtTime, prov:invalidatedAtTime, prov:startedAtTime .
+
+prov:category
+    a owl:AnnotationProperty ;
+    rdfs:comment "Classify prov-o terms into three categories, including 'starting-point', 'qualifed', and 'extended'. This classification is used by the prov-o html document to gently introduce prov-o terms to its users. "@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
+
+prov:component
+    a owl:AnnotationProperty ;
+    rdfs:comment "Classify prov-o terms into six components according to prov-dm, including 'agents-responsibility', 'alternate', 'annotations', 'collections', 'derivations', and 'entities-activities'. This classification is used so that readers of prov-o specification can find its correspondence with the prov-dm specification."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
+
+prov:constraints
+    a owl:AnnotationProperty ;
+    rdfs:comment "A reference to the principal section of the PROV-CONSTRAINTS document that describes this concept."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:subPropertyOf rdfs:seeAlso .
+
+prov:definition
+    a owl:AnnotationProperty ;
+    rdfs:comment "A definition quoted from PROV-DM or PROV-CONSTRAINTS that describes the concept expressed with this OWL term."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
+
+prov:dm
+    a owl:AnnotationProperty ;
+    rdfs:comment "A reference to the principal section of the PROV-DM document that describes this concept."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:subPropertyOf rdfs:seeAlso .
+
+prov:editorialNote
+    a owl:AnnotationProperty ;
+    rdfs:comment "A note by the OWL development team about how this term expresses the PROV-DM concept, or how it should be used in context of semantic web or linked data."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
+
+prov:editorsDefinition
+    a owl:AnnotationProperty ;
+    rdfs:comment "When the prov-o term does not have a definition drawn from prov-dm, and the prov-o editor provides one."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:subPropertyOf prov:definition .
+
+prov:endedAtTime
+    a owl:DatatypeProperty ;
+    rdfs:comment "The time at which an activity ended. See also prov:startedAtTime."@en ;
+    rdfs:domain prov:Activity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "endedAtTime" ;
+    rdfs:range xsd:dateTime ;
+    prov:category "starting-point" ;
+    prov:component "entities-activities" ;
+    prov:editorialNote "It is the intent that the property chain holds: (prov:qualifiedEnd o prov:atTime) rdfs:subPropertyOf prov:endedAtTime."@en ;
+    prov:qualifiedForm prov:End, prov:atTime .
+
+prov:entity
+    a owl:ObjectProperty ;
+    rdfs:domain prov:EntityInfluence ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "entity" ;
+    rdfs:range prov:Entity ;
+    rdfs:subPropertyOf prov:influencer ;
+    prov:category "qualified" ;
+    prov:editorialNote "This property behaves in spirit like rdf:object; it references the object of a prov:wasInfluencedBy triple."@en ;
+    prov:editorsDefinition "The prov:entity property references an prov:Entity which influenced a resource. This property applies to an prov:EntityInfluence, which is given by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity or prov:Agent." ;
+    prov:inverse "entityOfInfluence" .
+
+prov:generated
+    a owl:ObjectProperty ;
+    rdfs:domain prov:Activity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "generated" ;
+    rdfs:range prov:Entity ;
+    rdfs:subPropertyOf prov:influenced ;
+    owl:inverseOf prov:wasGeneratedBy ;
+    prov:category "expanded" ;
+    prov:component "entities-activities" ;
+    prov:editorialNote "prov:generated is one of few inverse property defined, to allow Activity-oriented assertions in addition to Entity-oriented assertions."@en ;
+    prov:inverse "wasGeneratedBy" ;
+    prov:sharesDefinitionWith prov:Generation .
+
+prov:generatedAtTime
+    a owl:DatatypeProperty ;
+    rdfs:comment "The time at which an entity was completely created and is available for use."@en ;
+    rdfs:domain prov:Entity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "generatedAtTime" ;
+    rdfs:range xsd:dateTime ;
+    prov:category "expanded" ;
+    prov:component "entities-activities" ;
+    prov:editorialNote "It is the intent that the property chain holds: (prov:qualifiedGeneration o prov:atTime) rdfs:subPropertyOf prov:generatedAtTime."@en ;
+    prov:qualifiedForm prov:Generation, prov:atTime .
+
+prov:hadActivity
+    a owl:ObjectProperty ;
+    rdfs:comment "The _optional_ Activity of an Influence, which used, generated, invalidated, or was the responsibility of some Entity. This property is _not_ used by ActivityInfluence (use prov:activity instead)."@en, "This property has multiple RDFS domains to suit multiple OWL Profiles. See <a href=\"#owl-profile\">PROV-O OWL Profile</a>." ;
+    rdfs:domain prov:Influence, [
+        a owl:Class ;
+        owl:unionOf (:Delegation
+            prov:Derivation
+            prov:End
+            prov:Start
+        )
+    ] ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "hadActivity" ;
+    rdfs:range prov:Activity ;
+    prov:category "qualified" ;
+    prov:component "derivations" ;
+    prov:editorialNote "The multiple rdfs:domain assertions are intended. One is simpler and works for OWL-RL, the union is more specific but is not recognized by OWL-RL."@en ;
+    prov:inverse "wasActivityOfInfluence" ;
+    prov:sharesDefinitionWith prov:Activity .
+
+prov:hadGeneration
+    a owl:ObjectProperty ;
+    rdfs:comment "The _optional_ Generation involved in an Entity's Derivation."@en ;
+    rdfs:domain prov:Derivation ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "hadGeneration" ;
+    rdfs:range prov:Generation ;
+    prov:category "qualified" ;
+    prov:component "derivations" ;
+    prov:inverse "generatedAsDerivation" ;
+    prov:sharesDefinitionWith prov:Generation .
+
+prov:hadMember
+    a owl:ObjectProperty ;
+    rdfs:domain prov:Collection ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "hadMember" ;
+    rdfs:range prov:Entity ;
+    rdfs:subPropertyOf prov:wasInfluencedBy ;
+    prov:category "expanded" ;
+    prov:component "expanded" ;
+    prov:inverse "wasMemberOf" ;
+    prov:sharesDefinitionWith prov:Collection .
+
+prov:hadPlan
+    a owl:ObjectProperty ;
+    rdfs:comment "The _optional_ Plan adopted by an Agent in Association with some Activity. Plan specifications are out of the scope of this specification."@en ;
+    rdfs:domain prov:Association ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "hadPlan" ;
+    rdfs:range prov:Plan ;
+    prov:category "qualified" ;
+    prov:component "agents-responsibility" ;
+    prov:inverse "wasPlanOf" ;
+    prov:sharesDefinitionWith prov:Plan .
+
+prov:hadPrimarySource
+    a owl:ObjectProperty ;
+    rdfs:domain prov:Entity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "hadPrimarySource" ;
+    rdfs:range prov:Entity ;
+    rdfs:subPropertyOf prov:wasDerivedFrom ;
+    owl:propertyChainAxiom (:qualifiedPrimarySource
+        prov:entity
+    ) ;
+    prov:category "expanded" ;
+    prov:component "derivations" ;
+    prov:inverse "wasPrimarySourceOf" ;
+    prov:qualifiedForm prov:PrimarySource, prov:qualifiedPrimarySource .
+
+prov:hadRole
+    a owl:ObjectProperty ;
+    rdfs:comment "The _optional_ Role that an Entity assumed in the context of an Activity. For example, prov:baking prov:used prov:spoon; prov:qualified [ a prov:Usage; prov:entity prov:spoon; prov:hadRole roles:mixing_implement ]."@en, "This property has multiple RDFS domains to suit multiple OWL Profiles. See <a href=\"#owl-profile\">PROV-O OWL Profile</a>." ;
+    rdfs:domain prov:Influence, [
+        a owl:Class ;
+        owl:unionOf (:Association
+            prov:InstantaneousEvent
+        )
+    ] ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "hadRole" ;
+    rdfs:range prov:Role ;
+    prov:category "qualified" ;
+    prov:component "agents-responsibility" ;
+    prov:editorsDefinition "prov:hadRole references the Role (i.e. the function of an entity with respect to an activity), in the context of an instantaneous usage, generation, association, start, and end."@en ;
+    prov:inverse "wasRoleIn" ;
+    prov:sharesDefinitionWith prov:Role .
+
+prov:hadUsage
+    a owl:ObjectProperty ;
+    rdfs:comment "The _optional_ Usage involved in an Entity's Derivation."@en ;
+    rdfs:domain prov:Derivation ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "hadUsage" ;
+    rdfs:range prov:Usage ;
+    prov:category "qualified" ;
+    prov:component "derivations" ;
+    prov:inverse "wasUsedInDerivation" ;
+    prov:sharesDefinitionWith prov:Usage .
+
+prov:influenced
+    a owl:ObjectProperty ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "influenced" ;
+    owl:inverseOf prov:wasInfluencedBy ;
+    prov:category "expanded" ;
+    prov:component "agents-responsibility" ;
+    prov:inverse "wasInfluencedBy" ;
+    prov:sharesDefinitionWith prov:Influence .
+
+prov:influencer
+    a owl:ObjectProperty ;
+    rdfs:comment "Subproperties of prov:influencer are used to cite the object of an unqualified PROV-O triple whose predicate is a subproperty of prov:wasInfluencedBy (e.g. prov:used, prov:wasGeneratedBy). prov:influencer is used much like rdf:object is used."@en ;
+    rdfs:domain prov:Influence ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "influencer" ;
+    rdfs:range owl:Thing ;
+    prov:category "qualified" ;
+    prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-influence"^^xsd:anyURI ;
+    prov:editorialNote "This property and its subproperties are used in the same way as the rdf:object property, i.e. to reference the object of an unqualified prov:wasInfluencedBy or prov:influenced triple."@en ;
+    prov:editorsDefinition "This property is used as part of the qualified influence pattern. Subclasses of prov:Influence use these subproperties to reference the resource (Entity, Agent, or Activity) whose influence is being qualified."@en ;
+    prov:inverse "hadInfluence" .
+
+prov:invalidated
+    a owl:ObjectProperty ;
+    rdfs:domain prov:Activity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "invalidated" ;
+    rdfs:range prov:Entity ;
+    rdfs:subPropertyOf prov:influenced ;
+    owl:inverseOf prov:wasInvalidatedBy ;
+    prov:category "expanded" ;
+    prov:component "entities-activities" ;
+    prov:editorialNote "prov:invalidated is one of few inverse property defined, to allow Activity-oriented assertions in addition to Entity-oriented assertions."@en ;
+    prov:inverse "wasInvalidatedBy" ;
+    prov:sharesDefinitionWith prov:Invalidation .
+
+prov:invalidatedAtTime
+    a owl:DatatypeProperty ;
+    rdfs:comment "The time at which an entity was invalidated (i.e., no longer usable)."@en ;
+    rdfs:domain prov:Entity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "invalidatedAtTime" ;
+    rdfs:range xsd:dateTime ;
+    prov:category "expanded" ;
+    prov:component "entities-activities" ;
+    prov:editorialNote "It is the intent that the property chain holds: (prov:qualifiedInvalidation o prov:atTime) rdfs:subPropertyOf prov:invalidatedAtTime."@en ;
+    prov:qualifiedForm prov:Invalidation, prov:atTime .
+
+prov:inverse
+    a owl:AnnotationProperty ;
+    rdfs:comment "PROV-O does not define all property inverses. The directionalities defined in PROV-O should be given preference over those not defined. However, if users wish to name the inverse of a PROV-O property, the local name given by prov:inverse should be used."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:seeAlso <http://www.w3.org/TR/prov-o/#names-of-inverse-properties> .
+
+prov:n
+    a owl:AnnotationProperty ;
+    rdfs:comment "A reference to the principal section of the PROV-DM document that describes this concept."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:subPropertyOf rdfs:seeAlso .
+
+prov:order
+    a owl:AnnotationProperty ;
+    rdfs:comment "The position that this OWL term should be listed within documentation. The scope of the documentation (e.g., among all terms, among terms within a prov:category, among properties applying to a particular class, etc.) is unspecified."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
+
+prov:qualifiedAssociation
+    a owl:ObjectProperty ;
+    rdfs:comment "If this Activity prov:wasAssociatedWith Agent prov:ag, then it can qualify the Association using prov:qualifiedAssociation [ a prov:Association;  prov:agent prov:ag; prov:foo prov:bar ]."@en ;
+    rdfs:domain prov:Activity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "qualifiedAssociation" ;
+    rdfs:range prov:Association ;
+    rdfs:subPropertyOf prov:qualifiedInfluence ;
+    prov:category "qualified" ;
+    prov:component "agents-responsibility" ;
+    prov:inverse "qualifiedAssociationOf" ;
+    prov:sharesDefinitionWith prov:Association ;
+    prov:unqualifiedForm prov:wasAssociatedWith .
+
+prov:qualifiedAttribution
+    a owl:ObjectProperty ;
+    rdfs:comment "If this Entity prov:wasAttributedTo Agent prov:ag, then it can qualify how it was influenced using prov:qualifiedAttribution [ a prov:Attribution;  prov:agent prov:ag; prov:foo prov:bar ]."@en ;
+    rdfs:domain prov:Entity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "qualifiedAttribution" ;
+    rdfs:range prov:Attribution ;
+    rdfs:subPropertyOf prov:qualifiedInfluence ;
+    prov:category "qualified" ;
+    prov:component "agents-responsibility" ;
+    prov:inverse "qualifiedAttributionOf" ;
+    prov:sharesDefinitionWith prov:Attribution ;
+    prov:unqualifiedForm prov:wasAttributedTo .
+
+prov:qualifiedCommunication
+    a owl:ObjectProperty ;
+    rdfs:comment "If this Activity prov:wasInformedBy Activity prov:a, then it can qualify how it was influenced using prov:qualifiedCommunication [ a prov:Communication;  prov:activity prov:a; prov:foo prov:bar ]."@en ;
+    rdfs:domain prov:Activity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "qualifiedCommunication" ;
+    rdfs:range prov:Communication ;
+    rdfs:subPropertyOf prov:qualifiedInfluence ;
+    prov:category "qualified" ;
+    prov:component "entities-activities" ;
+    prov:inverse "qualifiedCommunicationOf" ;
+    prov:qualifiedForm prov:Communication ;
+    prov:sharesDefinitionWith prov:Communication .
+
+prov:qualifiedDelegation
+    a owl:ObjectProperty ;
+    rdfs:comment "If this Agent prov:actedOnBehalfOf Agent prov:ag, then it can qualify how with prov:qualifiedResponsibility [ a prov:Responsibility;  prov:agent prov:ag; prov:foo prov:bar ]."@en ;
+    rdfs:domain prov:Agent ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "qualifiedDelegation" ;
+    rdfs:range prov:Delegation ;
+    rdfs:subPropertyOf prov:qualifiedInfluence ;
+    prov:category "qualified" ;
+    prov:component "agents-responsibility" ;
+    prov:inverse "qualifiedDelegationOf" ;
+    prov:sharesDefinitionWith prov:Delegation ;
+    prov:unqualifiedForm prov:actedOnBehalfOf .
+
+prov:qualifiedDerivation
+    a owl:ObjectProperty ;
+    rdfs:comment "If this Entity prov:wasDerivedFrom Entity prov:e, then it can qualify how it was derived using prov:qualifiedDerivation [ a prov:Derivation;  prov:entity prov:e; prov:foo prov:bar ]."@en ;
+    rdfs:domain prov:Entity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "qualifiedDerivation" ;
+    rdfs:range prov:Derivation ;
+    rdfs:subPropertyOf prov:qualifiedInfluence ;
+    prov:category "qualified" ;
+    prov:component "derivations" ;
+    prov:inverse "qualifiedDerivationOf" ;
+    prov:sharesDefinitionWith prov:Derivation ;
+    prov:unqualifiedForm prov:wasDerivedFrom .
+
+prov:qualifiedEnd
+    a owl:ObjectProperty ;
+    rdfs:comment "If this Activity prov:wasEndedBy Entity prov:e1, then it can qualify how it was ended using prov:qualifiedEnd [ a prov:End;  prov:entity prov:e1; prov:foo prov:bar ]."@en ;
+    rdfs:domain prov:Activity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "qualifiedEnd" ;
+    rdfs:range prov:End ;
+    rdfs:subPropertyOf prov:qualifiedInfluence ;
+    prov:category "qualified" ;
+    prov:component "entities-activities" ;
+    prov:inverse "qualifiedEndOf" ;
+    prov:sharesDefinitionWith prov:End ;
+    prov:unqualifiedForm prov:wasEndedBy .
+
+prov:qualifiedForm
+    a owl:AnnotationProperty ;
+    rdfs:comment """This annotation property links a subproperty of prov:wasInfluencedBy with the subclass of prov:Influence and the qualifying property that are used to qualify it. 
 
 Example annotation:
 
@@ -4734,3554 +5529,479 @@ Example annotation:
 
 Then this unqualified assertion:
 
-    :entity1 prov:wasGeneratedBy :activity1 .
+    prov:entity1 prov:wasGeneratedBy prov:activity1 .
 
 can be qualified by adding:
 
-   :entity1 prov:qualifiedGeneration :entity1Gen .
-   :entity1Gen 
+   prov:entity1 prov:qualifiedGeneration prov:entity1Gen .
+   prov:entity1Gen 
        a prov:Generation, prov:Influence;
-       prov:activity :activity1;
-       :customValue 1337 .
-
-Note how the value of the unqualified influence (prov:wasGeneratedBy :activity1) is mirrored as the value of the prov:activity (or prov:entity, or prov:agent) property on the influence class."""@en ;
-                   
-                   rdfs:subPropertyOf rdfs:seeAlso ;
-                   
-                   rdfs:isDefinedBy prov: ,
-                                    <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#sharesDefinitionWith
-
-prov:sharesDefinitionWith rdf:type owl:AnnotationProperty ;
-                          
-                          rdfs:subPropertyOf rdfs:seeAlso ;
-                          
-                          rdfs:isDefinedBy prov: ,
-                                           <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#specializationOf
-
-prov:specializationOf rdf:type owl:AnnotationProperty ;
-                      
-                      rdfs:label "specializationOf" ;
-                      
-                      prov:constraints "http://www.w3.org/TR/2012/WD-prov-dm-20120703/prov-constraints.html#prov-dm-constraints-fig"^^xsd:anyURI ;
-                      
-                      prov:dm "http://www.w3.org/TR/2012/WD-prov-dm-20120703/prov-dm.html#term-specialization"^^xsd:anyURI ;
-                      
-                      prov:n "http://www.w3.org/TR/2012/WD-prov-dm-20120703/prov-n.html#expression-specialization"^^xsd:anyURI ;
-                      
-                      prov:constraints "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
-                      
-                      prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-specialization"^^xsd:anyURI ;
-                      
-                      prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-specialization"^^xsd:anyURI ;
-                      
-                      prov:definition "An entity that is a specialization of another shares all aspects of the latter, and additionally presents more specific aspects of the same thing as the latter. In particular, the lifetime of the entity being specialized contains that of any specialization. Examples of aspects include a time period, an abstraction, and a context associated with the entity."@en ;
-                      
-                      prov:category "expanded" ;
-                      
-                      prov:inverse "generalizationOf" ;
-                      
-                      prov:component "alternate" ;
-                      
-                      rdfs:isDefinedBy prov: ;
-                      
-                      rdfs:seeAlso prov:alternateOf ;
-                      
-                      rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#todo
-
-prov:todo rdf:type owl:AnnotationProperty .
-
-
-
-###  http://www.w3.org/ns/prov#unqualifiedForm
-
-prov:unqualifiedForm rdf:type owl:AnnotationProperty ;
-                     
-                     rdfs:comment "Classes and properties used to qualify relationships are annotated with prov:unqualifiedForm to indicate the property used to assert an unqualified provenance relation."@en ;
-                     
-                     rdfs:subPropertyOf rdfs:seeAlso ;
-                     
-                     rdfs:isDefinedBy prov: ,
-                                      <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#wasRevisionOf
-
-prov:wasRevisionOf rdf:type owl:AnnotationProperty ;
-                   
-                   rdfs:label "wasRevisionOf" ;
-                   
-                   prov:component "derivations" ;
-                   
-                   prov:category "expanded" ;
-                   
-                   prov:inverse "hadRevision" ;
-                   
-                   rdfs:comment "A revision is a derivation that revises an entity into a revised version."@en ;
-                   
-                   prov:qualifiedForm prov:Revision ,
-                                      prov:qualifiedRevision ;
-                   
-                   rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-
-
-#################################################################
-#
-#    Object Properties
-#
-#################################################################
-
-
-###  http://www.w3.org/2002/07/owl#topObjectProperty
-
-owl:topObjectProperty rdf:type owl:ObjectProperty .
-
-
-
-###  http://www.w3.org/ns/prov#actedOnBehalfOf
-
-prov:actedOnBehalfOf rdf:type owl:ObjectProperty ;
-                     
-                     rdfs:label "actedOnBehalfOf" ;
-                     
-                     prov:component "agents-responsibility" ;
-                     
-                     prov:category "starting-point" ;
-                     
-                     prov:inverse "hadDelegate" ;
-                     
-                     rdfs:comment "An object property to express the accountability of an agent towards another agent. The subordinate agent acted on behalf of the responsible agent in an actual activity. "@en ;
-                     
-                     rdfs:range prov:Agent ;
-                     
-                     rdfs:domain prov:Agent ;
-                     
-                     prov:qualifiedForm prov:Delegation ,
-                                        prov:qualifiedDelegation ;
-                     
-                     rdfs:subPropertyOf prov:wasInfluencedBy ;
-                     
-                     rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
-                     
-                     owl:propertyChainAxiom ( prov:qualifiedDelegation
-                                              prov:agent
-                                            ) .
-
-
-
-###  http://www.w3.org/ns/prov#activity
-
-prov:activity rdf:type owl:ObjectProperty ;
-              
-              rdfs:label "activity" ;
-              
-              prov:editorsDefinition "The prov:activity property references an prov:Activity which influenced a resource. This property applies to an prov:ActivityInfluence, which is given by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity or prov:Agent." ;
-              
-              prov:editorialNote "This property behaves in spirit like rdf:object; it references the object of a prov:wasInfluencedBy triple."@en ;
-              
-              prov:category "qualified" ;
-              
-              prov:inverse "activityOfInfluence" ;
-              
-              rdfs:range prov:Activity ;
-              
-              rdfs:domain prov:ActivityInfluence ;
-              
-              rdfs:subPropertyOf prov:influencer ;
-              
-              rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#activityOfInfluence
-
-prov:activityOfInfluence rdfs:label "activityOfInfluence" ;
-                         
-                         rdfs:isDefinedBy prov: ;
-                         
-                         owl:inverseOf prov:activity .
-
-
-
-###  http://www.w3.org/ns/prov#agent
-
-prov:agent rdf:type owl:ObjectProperty ;
-           
-           rdfs:label "agent" ;
-           
-           prov:category "qualified" ;
-           
-           prov:editorsDefinition "The prov:agent property references an prov:Agent which influenced a resource. This property applies to an prov:AgentInfluence, which is given by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity or prov:Agent."@en ;
-           
-           prov:editorialNote "This property behaves in spirit like rdf:object; it references the object of a prov:wasInfluencedBy triple."@en ;
-           
-           prov:inverse "agentOfInfluence" ;
-           
-           rdfs:range prov:Agent ;
-           
-           rdfs:domain prov:AgentInfluence ;
-           
-           rdfs:subPropertyOf prov:influencer ;
-           
-           rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#agentOfInfluence
-
-prov:agentOfInfluence rdfs:label "agentOfInfluence" ;
-                      
-                      rdfs:isDefinedBy prov: ;
-                      
-                      owl:inverseOf prov:agent .
-
-
-
-###  http://www.w3.org/ns/prov#alternateOf
-
-prov:alternateOf rdf:type owl:ObjectProperty ;
-                 
-                 rdfs:label "alternateOf" ;
-                 
-                 prov:constraints "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
-                 
-                 prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-alternate"^^xsd:anyURI ;
-                 
-                 prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-alternate"^^xsd:anyURI ;
-                 
-                 prov:component "alternate" ;
-                 
-                 prov:inverse "alternateOf" ;
-                 
-                 prov:category "expanded" ;
-                 
-                 prov:definition "Two alternate entities present aspects of the same thing. These aspects may be the same or different, and the alternate entities may or may not overlap in time."@en ;
-                 
-                 rdfs:isDefinedBy prov: ;
-                 
-                 rdfs:domain prov:Entity ;
-                 
-                 rdfs:range prov:Entity ;
-                 
-                 owl:inverseOf prov:alternateOf ;
-                 
-                 rdfs:seeAlso prov:specializationOf ;
-                 
-                 rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#asInBundle
-
-prov:asInBundle rdf:type owl:ObjectProperty ;
-                
-                rdfs:label "asInBundle" ;
-                
-                prov:inverse "contextOf" ;
-                
-                rdfs:comment """prov:asInBundle is used to specify which bundle the general entity of a prov:mentionOf property is described.
-
-When :x prov:mentionOf :y and :y is described in Bundle :b, the triple :x prov:asInBundle :b is also asserted to cite the Bundle in which :y was described."""@en ;
-                
-                rdfs:range prov:Bundle ;
-                
-                rdfs:domain prov:Entity ;
-                
-                prov:sharesDefinitionWith prov:mentionOf ;
-                
-                rdfs:isDefinedBy <http://www.w3.org/ns/prov-links#> .
-
-
-
-###  http://www.w3.org/ns/prov#atLocation
-
-prov:atLocation rdf:type owl:ObjectProperty ;
-                
-                rdfs:label "atLocation" ;
-                
-                prov:category "expanded" ;
-                
-                rdfs:comment "This property has multiple RDFS domains to suit multiple OWL Profiles. See <a href=\"#owl-profile\">PROV-O OWL Profile</a>." ;
-                
-                prov:inverse "locationOf" ;
-                
-                rdfs:comment "The Location of any resource."@en ;
-                
-                prov:editorialNote "The naming of prov:atLocation parallels prov:atTime, and is not named prov:hadLocation to avoid conflicting with the convention that prov:had* properties are used on prov:Influence classes."@en ,
-                                   "This property is not functional because the many values could be at a variety of granularies (In this building, in this room, in that chair)."@en ;
-                
-                prov:sharesDefinitionWith prov:Location ;
-                
-                rdfs:range prov:Location ;
-                
-                rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
-                
-                rdfs:domain [ rdf:type owl:Class ;
-                              owl:unionOf ( prov:Activity
-                                            prov:Agent
-                                            prov:Entity
-                                            prov:InstantaneousEvent
-                                          )
-                            ] .
-
-
-
-###  http://www.w3.org/ns/prov#contributed
-
-prov:contributed rdfs:label "contributed" ;
-                 
-                 rdfs:isDefinedBy prov: ;
-                 
-                 owl:inverseOf prov:wasAttributedTo .
-
-
-
-###  http://www.w3.org/ns/prov#derivedByInsertionFrom
-
-prov:derivedByInsertionFrom rdf:type owl:ObjectProperty ;
-                            
-                            rdfs:label "derivedByInsertionFrom" ;
-                            
-                            prov:constraints "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#dictionary-constraints"^^xsd:anyURI ;
-                            
-                            prov:n "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#expression-dictionary-insertion"^^xsd:anyURI ;
-                            
-                            prov:dm "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#term-dictionary-insertion"^^xsd:anyURI ;
-                            
-                            prov:component "collections" ;
-                            
-                            prov:definition "The dictionary was derived from the other by insertion. Can be qualified with prov:qualifiedInsertion, which shows details of the insertion, in particular the inserted key-entity pairs." ;
-                            
-                            prov:category "collections" ;
-                            
-                            rdfs:isDefinedBy prov: ;
-                            
-                            rdfs:domain prov:Dictionary ;
-                            
-                            rdfs:range prov:Dictionary ;
-                            
-                            rdfs:subPropertyOf prov:wasDerivedFrom .
-
-
-
-###  http://www.w3.org/ns/prov#derivedByRemovalFrom
-
-prov:derivedByRemovalFrom rdf:type owl:ObjectProperty ;
-                          
-                          rdfs:label "derivedByRemovalFrom" ;
-                          
-                          prov:constraints "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#dictionary-constraints"^^xsd:anyURI ;
-                          
-                          prov:n "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#expression-dictionary-removal"^^xsd:anyURI ;
-                          
-                          prov:dm "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#term-dictionary-removal"^^xsd:anyURI ;
-                          
-                          prov:component "collections" ;
-                          
-                          prov:category "collections" ;
-                          
-                          prov:definition "The dictionary was derived from the other by removal. Can be qualified with prov:qualifiedRemoval, which shows details of the removal, in particular the removed keys." ;
-                          
-                          rdfs:isDefinedBy prov: ;
-                          
-                          rdfs:domain prov:Dictionary ;
-                          
-                          rdfs:range prov:Dictionary ;
-                          
-                          rdfs:subPropertyOf prov:wasDerivedFrom .
-
-
-
-###  http://www.w3.org/ns/prov#describesService
-
-prov:describesService rdf:type owl:ObjectProperty ;
-                      
-                      rdfs:label "describesService" ;
-                      
-                      prov:aq "http://www.w3.org/TR/2013/NOTE-prov-aq-20130430/rovenance-query-service-description"^^xsd:anyURI ;
-                      
-                      prov:category "access-and-query" ;
-                      
-                      rdfs:comment "relates a generic provenance query service resource (type prov:ServiceDescription) to a specific query service description (e.g. a prov:DirectQueryService or a sd:Service)."@en ;
-                      
-                      prov:inverse "serviceDescribedBy" ;
-                      
-                      rdfs:isDefinedBy prov: .
-
-
-
-###  http://www.w3.org/ns/prov#dictionary
-
-prov:dictionary rdf:type owl:ObjectProperty ;
-                
-                rdfs:label "dictionary" ;
-                
-                prov:constraints "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#dictionary-constraints"^^xsd:anyURI ;
-                
-                prov:n "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#expression-dictionary-insertion"^^xsd:anyURI ,
-                       "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#expression-dictionary-removal"^^xsd:anyURI ;
-                
-                prov:dm "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#term-dictionary-insertion"^^xsd:anyURI ,
-                        "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#term-dictionary-removal"^^xsd:anyURI ;
-                
-                prov:category "collections" ;
-                
-                prov:component "collections" ;
-                
-                prov:definition "The property used by a prov:Insertion and prov:Removal to cite the prov:Dictionary that was prov:derivedByInsertionFrom or prov:derivedByRemovalFrom another dictionary." ;
-                
-                rdfs:isDefinedBy prov: ;
-                
-                rdfs:range prov:Dictionary ;
-                
-                rdfs:domain prov:Insertion ,
-                            prov:Removal ;
-                
-                rdfs:subPropertyOf prov:entity .
-
-
-
-###  http://www.w3.org/ns/prov#ended
-
-prov:ended rdfs:label "ended" ;
-           
-           rdfs:isDefinedBy prov: ;
-           
-           owl:inverseOf prov:wasEndedBy .
-
-
-
-###  http://www.w3.org/ns/prov#entity
-
-prov:entity rdf:type owl:ObjectProperty ;
-            
-            rdfs:label "entity" ;
-            
-            prov:editorialNote "This property behaves in spirit like rdf:object; it references the object of a prov:wasInfluencedBy triple."@en ;
-            
-            prov:inverse "entityOfInfluence" ;
-            
-            prov:editorsDefinition "The prov:entity property references an prov:Entity which influenced a resource. This property applies to an prov:EntityInfluence, which is given by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity or prov:Agent." ;
-            
-            prov:category "qualified" ;
-            
-            rdfs:range prov:Entity ;
-            
-            rdfs:domain prov:EntityInfluence ;
-            
-            rdfs:subPropertyOf prov:influencer ;
-            
-            rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#entityOfInfluence
-
-prov:entityOfInfluence rdfs:label "entityOfInfluence" ;
-                       
-                       rdfs:isDefinedBy prov: ;
-                       
-                       owl:inverseOf prov:entity .
-
-
-
-###  http://www.w3.org/ns/prov#generalizationOf
-
-prov:generalizationOf rdfs:label "generalizationOf" ;
-                      
-                      rdfs:isDefinedBy prov: ;
-                      
-                      owl:inverseOf prov:specializationOf .
-
-
-
-###  http://www.w3.org/ns/prov#generated
-
-prov:generated rdf:type owl:ObjectProperty ;
-               
-               rdfs:label "generated" ;
-               
-               prov:category "expanded" ;
-               
-               prov:component "entities-activities" ;
-               
-               prov:editorialNote "prov:generated is one of few inverse property defined, to allow Activity-oriented assertions in addition to Entity-oriented assertions."@en ;
-               
-               prov:inverse "wasGeneratedBy" ;
-               
-               rdfs:isDefinedBy prov: ;
-               
-               rdfs:domain prov:Activity ;
-               
-               rdfs:range prov:Entity ;
-               
-               prov:sharesDefinitionWith prov:Generation ;
-               
-               rdfs:subPropertyOf prov:influenced ;
-               
-               owl:inverseOf prov:wasGeneratedBy ;
-               
-               rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#generatedAsDerivation
-
-prov:generatedAsDerivation rdfs:label "generatedAsDerivation" ;
-                           
-                           rdfs:isDefinedBy prov: ;
-                           
-                           owl:inverseOf prov:hadGeneration .
-
-
-
-###  http://www.w3.org/ns/prov#hadActivity
-
-prov:hadActivity rdf:type owl:ObjectProperty ;
-                 
-                 rdfs:label "hadActivity" ;
-                 
-                 rdfs:comment "The _optional_ Activity of an Influence, which used, generated, invalidated, or was the responsibility of some Entity. This property is _not_ used by ActivityInfluence (use prov:activity instead)."@en ;
-                 
-                 prov:editorialNote "The multiple rdfs:domain assertions are intended. One is simpler and works for OWL-RL, the union is more specific but is not recognized by OWL-RL."@en ;
-                 
-                 prov:category "qualified" ;
-                 
-                 rdfs:comment "This property has multiple RDFS domains to suit multiple OWL Profiles. See <a href=\"#owl-profile\">PROV-O OWL Profile</a>." ;
-                 
-                 prov:inverse "wasActivityOfInfluence" ;
-                 
-                 prov:component "derivations" ;
-                 
-                 rdfs:range prov:Activity ;
-                 
-                 prov:sharesDefinitionWith prov:Activity ;
-                 
-                 rdfs:domain prov:Influence ;
-                 
-                 rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
-                 
-                 rdfs:domain [ rdf:type owl:Class ;
-                               owl:unionOf ( prov:Delegation
-                                             prov:Derivation
-                                             prov:End
-                                             prov:Start
-                                           )
-                             ] .
-
-
-
-###  http://www.w3.org/ns/prov#hadDelegate
-
-prov:hadDelegate rdfs:label "hadDelegate" ;
-                 
-                 rdfs:isDefinedBy prov: ;
-                 
-                 owl:inverseOf prov:actedOnBehalfOf .
-
-
-
-###  http://www.w3.org/ns/prov#hadDerivation
-
-prov:hadDerivation rdfs:label "hadDerivation" ;
-                   
-                   rdfs:isDefinedBy prov: ;
-                   
-                   owl:inverseOf prov:wasDerivedFrom .
-
-
-
-###  http://www.w3.org/ns/prov#hadDictionaryMember
-
-prov:hadDictionaryMember rdf:type owl:ObjectProperty ;
-                         
-                         rdfs:label "hadDictionaryMember" ;
-                         
-                         prov:constraints "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#dictionary-constraints"^^xsd:anyURI ;
-                         
-                         prov:n "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#expression-dictionary-membership"^^xsd:anyURI ;
-                         
-                         prov:dm "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#term-dictionary-membership"^^xsd:anyURI ;
-                         
-                         prov:category "collections" ;
-                         
-                         prov:definition "Describes the key-entity pair that was member of a prov:Dictionary. A dictionary can have multiple members." ;
-                         
-                         prov:component "collections" ;
-                         
-                         rdfs:isDefinedBy prov: ;
-                         
-                         rdfs:domain prov:Dictionary ;
-                         
-                         rdfs:range prov:KeyEntityPair .
-
-
-
-###  http://www.w3.org/ns/prov#hadGeneration
-
-prov:hadGeneration rdf:type owl:ObjectProperty ;
-                   
-                   rdfs:label "hadGeneration" ;
-                   
-                   prov:category "qualified" ;
-                   
-                   prov:component "derivations" ;
-                   
-                   rdfs:comment "The _optional_ Generation involved in an Entity's Derivation."@en ;
-                   
-                   prov:inverse "generatedAsDerivation" ;
-                   
-                   rdfs:domain prov:Derivation ;
-                   
-                   rdfs:range prov:Generation ;
-                   
-                   prov:sharesDefinitionWith prov:Generation ;
-                   
-                   rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#hadInfluence
-
-prov:hadInfluence rdfs:label "hadInfluence" ;
-                  
-                  rdfs:isDefinedBy prov: ;
-                  
-                  owl:inverseOf prov:influencer .
-
-
-
-###  http://www.w3.org/ns/prov#hadMember
-
-prov:hadMember rdf:type owl:ObjectProperty ;
-               
-               rdfs:label "hadMember" ;
-               
-               prov:component "expanded" ;
-               
-               prov:inverse "wasMemberOf" ;
-               
-               prov:category "expanded" ;
-               
-               rdfs:domain prov:Collection ;
-               
-               prov:sharesDefinitionWith prov:Collection ;
-               
-               rdfs:range prov:Entity ;
-               
-               rdfs:subPropertyOf prov:wasInfluencedBy ;
-               
-               rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-[ rdf:type owl:Axiom ;
-  prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-collection" ;
-  rdfs:comment "A collection is an entity that provides a structure to some constituents, which are themselves entities. These constituents are said to be member of the collections."@en ;
-  owl:annotatedProperty rdfs:range ;
-  owl:annotatedTarget prov:Entity ;
-  owl:annotatedSource prov:hadMember
-] .
-
-
-
-###  http://www.w3.org/ns/prov#hadPlan
-
-prov:hadPlan rdf:type owl:ObjectProperty ;
-             
-             rdfs:label "hadPlan" ;
-             
-             rdfs:comment "The _optional_ Plan adopted by an Agent in Association with some Activity. Plan specifications are out of the scope of this specification."@en ;
-             
-             prov:inverse "wasPlanOf" ;
-             
-             prov:component "agents-responsibility" ;
-             
-             prov:category "qualified" ;
-             
-             rdfs:domain prov:Association ;
-             
-             rdfs:range prov:Plan ;
-             
-             prov:sharesDefinitionWith prov:Plan ;
-             
-             rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#hadPrimarySource
-
-prov:hadPrimarySource rdf:type owl:ObjectProperty ;
-                      
-                      rdfs:label "hadPrimarySource" ;
-                      
-                      prov:category "expanded" ;
-                      
-                      prov:component "derivations" ;
-                      
-                      prov:inverse "wasPrimarySourceOf" ;
-                      
-                      rdfs:domain prov:Entity ;
-                      
-                      rdfs:range prov:Entity ;
-                      
-                      prov:qualifiedForm prov:PrimarySource ,
-                                         prov:qualifiedPrimarySource ;
-                      
-                      rdfs:subPropertyOf prov:wasDerivedFrom ;
-                      
-                      rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
-                      
-                      owl:propertyChainAxiom ( prov:qualifiedPrimarySource
-                                               prov:entity
-                                             ) .
-[ rdf:type owl:Axiom ;
-  rdfs:comment "hadPrimarySource property is a particular case of wasDerivedFrom (see http://www.w3.org/TR/prov-dm/#term-original-source) that aims to give credit to the source that originated some information." ;
-  owl:annotatedProperty rdfs:subPropertyOf ;
-  owl:annotatedSource prov:hadPrimarySource ;
-  owl:annotatedTarget prov:wasDerivedFrom
-] .
-
-
-
-###  http://www.w3.org/ns/prov#hadRevision
-
-prov:hadRevision rdfs:label "hadRevision" ;
-                 
-                 rdfs:isDefinedBy prov: ;
-                 
-                 owl:inverseOf prov:wasRevisionOf .
-
-
-
-###  http://www.w3.org/ns/prov#hadRole
-
-prov:hadRole rdf:type owl:ObjectProperty ;
-             
-             rdfs:label "hadRole" ;
-             
-             rdfs:comment "This property has multiple RDFS domains to suit multiple OWL Profiles. See <a href=\"#owl-profile\">PROV-O OWL Profile</a>." ;
-             
-             prov:category "qualified" ;
-             
-             prov:component "agents-responsibility" ;
-             
-             rdfs:comment "The _optional_ Role that an Entity assumed in the context of an Activity. For example, :baking prov:used :spoon; prov:qualified [ a prov:Usage; prov:entity :spoon; prov:hadRole roles:mixing_implement ]."@en ;
-             
-             prov:inverse "wasRoleIn" ;
-             
-             prov:editorsDefinition "prov:hadRole references the Role (i.e. the function of an entity with respect to an activity), in the context of an instantaneous usage, generation, association, start, and end."@en ;
-             
-             rdfs:domain prov:Influence ;
-             
-             prov:sharesDefinitionWith prov:Role ;
-             
-             rdfs:range prov:Role ;
-             
-             rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
-             
-             rdfs:domain [ rdf:type owl:Class ;
-                           owl:unionOf ( prov:Association
-                                         prov:InstantaneousEvent
-                                       )
-                         ] .
-
-
-
-###  http://www.w3.org/ns/prov#hadUsage
-
-prov:hadUsage rdf:type owl:ObjectProperty ;
-              
-              rdfs:label "hadUsage" ;
-              
-              prov:category "qualified" ;
-              
-              rdfs:comment "The _optional_ Usage involved in an Entity's Derivation."@en ;
-              
-              prov:component "derivations" ;
-              
-              prov:inverse "wasUsedInDerivation" ;
-              
-              rdfs:isDefinedBy prov: ;
-              
-              rdfs:domain prov:Derivation ;
-              
-              rdfs:range prov:Usage ;
-              
-              prov:sharesDefinitionWith prov:Usage ;
-              
-              rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#has_anchor
-
-prov:has_anchor rdf:type owl:ObjectProperty ;
-                
-                rdfs:label "has_anchor" ;
-                
-                prov:aq "http://www.w3.org/TR/2013/NOTE-prov-aq-20130430/#resource-represented-as-html"^^xsd:anyURI ;
-                
-                rdfs:comment "Indicates anchor URI for a potentially dynamic resource instance."@en ;
-                
-                prov:inverse "anchorOf" ;
-                
-                prov:category "access-and-query" ;
-                
-                rdfs:isDefinedBy prov: .
-
-
-
-###  http://www.w3.org/ns/prov#has_provenance
-
-prov:has_provenance rdf:type owl:ObjectProperty ;
-                    
-                    rdfs:label "has_provenance" ;
-                    
-                    prov:aq "http://www.w3.org/TR/2013/NOTE-prov-aq-20130430/#resource-represented-as-html"^^xsd:anyURI ;
-                    
-                    prov:category "access-and-query" ;
-                    
-                    prov:inverse "provenanceOf" ;
-                    
-                    rdfs:comment "Indicates a provenance-URI for a resource; the resource identified by this property presents a provenance record about its subject or anchor resource."@en ;
-                    
-                    rdfs:isDefinedBy prov: .
-
-
-
-###  http://www.w3.org/ns/prov#has_query_service
-
-prov:has_query_service rdf:type owl:ObjectProperty ;
-                       
-                       rdfs:label "hasProvenanceService" ;
-                       
-                       prov:aq "http://www.w3.org/TR/2013/NOTE-prov-aq-20130430/"^^xsd:anyURI ;
-                       
-                       rdfs:comment "Indicates a provenance query service that can access provenance related to its subject or anchor resource."@en ;
-                       
-                       prov:inverse "provenanceQueryServiceOf" ;
-                       
-                       prov:category "access-and-query" ;
-                       
-                       rdfs:isDefinedBy prov: .
-
-
-
-###  http://www.w3.org/ns/prov#influenced
-
-prov:influenced rdf:type owl:ObjectProperty ;
-                
-                rdfs:label "influenced" ;
-                
-                prov:inverse "wasInfluencedBy" ;
-                
-                prov:component "agents-responsibility" ;
-                
-                prov:category "expanded" ;
-                
-                rdfs:isDefinedBy prov: ;
-                
-                prov:sharesDefinitionWith prov:Influence ;
-                
-                owl:inverseOf prov:wasInfluencedBy ;
-                
-                rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#influencer
-
-prov:influencer rdf:type owl:ObjectProperty ;
-                
-                rdfs:label "influencer" ;
-                
-                prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-influence"^^xsd:anyURI ;
-                
-                prov:inverse "hadInfluence" ;
-                
-                prov:category "qualified" ;
-                
-                rdfs:comment "Subproperties of prov:influencer are used to cite the object of an unqualified PROV-O triple whose predicate is a subproperty of prov:wasInfluencedBy (e.g. prov:used, prov:wasGeneratedBy). prov:influencer is used much like rdf:object is used."@en ;
-                
-                prov:editorialNote "This property and its subproperties are used in the same way as the rdf:object property, i.e. to reference the object of an unqualified prov:wasInfluencedBy or prov:influenced triple."@en ;
-                
-                prov:editorsDefinition "This property is used as part of the qualified influence pattern. Subclasses of prov:Influence use these subproperties to reference the resource (Entity, Agent, or Activity) whose influence is being qualified."@en ;
-                
-                rdfs:range owl:Thing ;
-                
-                rdfs:domain prov:Influence ;
-                
-                rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#informed
-
-prov:informed rdfs:label "informed" ;
-              
-              rdfs:isDefinedBy prov: ;
-              
-              owl:inverseOf prov:wasInformedBy .
-
-
-
-###  http://www.w3.org/ns/prov#insertedKeyEntityPair
-
-prov:insertedKeyEntityPair rdf:type owl:ObjectProperty ;
-                           
-                           rdfs:label "insertedKeyEntityPair" ;
-                           
-                           prov:constraints "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#dictionary-constraints"^^xsd:anyURI ;
-                           
-                           prov:n "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#expression-dictionary-insertion"^^xsd:anyURI ;
-                           
-                           prov:dm "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#term-dictionary-insertion"^^xsd:anyURI ;
-                           
-                           prov:definition "An object property to refer to the prov:KeyEntityPair inserted into a prov:Dictionary." ;
-                           
-                           prov:category "collections" ;
-                           
-                           prov:component "collections" ;
-                           
-                           rdfs:isDefinedBy prov: ;
-                           
-                           rdfs:domain prov:Insertion ;
-                           
-                           rdfs:range prov:KeyEntityPair .
-
-
-
-###  http://www.w3.org/ns/prov#invalidated
-
-prov:invalidated rdf:type owl:ObjectProperty ;
-                 
-                 rdfs:label "invalidated" ;
-                 
-                 prov:inverse "wasInvalidatedBy" ;
-                 
-                 prov:category "expanded" ;
-                 
-                 prov:component "entities-activities" ;
-                 
-                 prov:editorialNote "prov:invalidated is one of few inverse property defined, to allow Activity-oriented assertions in addition to Entity-oriented assertions."@en ;
-                 
-                 rdfs:isDefinedBy prov: ;
-                 
-                 rdfs:domain prov:Activity ;
-                 
-                 rdfs:range prov:Entity ;
-                 
-                 prov:sharesDefinitionWith prov:Invalidation ;
-                 
-                 rdfs:subPropertyOf prov:influenced ;
-                 
-                 owl:inverseOf prov:wasInvalidatedBy ;
-                 
-                 rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#locationOf
-
-prov:locationOf rdfs:label "locationOf" ;
-                
-                rdfs:isDefinedBy prov: ;
-                
-                owl:inverseOf prov:atLocation .
-
-
-
-###  http://www.w3.org/ns/prov#mentionOf
-
-prov:mentionOf rdf:type owl:ObjectProperty ;
-               
-               rdfs:label "mentionOf" ;
-               
-               prov:inverse "hadMention" ;
-               
-               rdfs:comment """prov:mentionOf is used to specialize an entity as described in another bundle. It is to be used in conjuction with prov:asInBundle.
-
-prov:asInBundle is used to cite the Bundle in which the generalization was mentioned."""@en ;
-               
-               rdfs:range prov:Entity ;
-               
-               rdfs:domain prov:Entity ;
-               
-               rdfs:subPropertyOf prov:specializationOf ;
-               
-               rdfs:isDefinedBy <http://www.w3.org/ns/prov-links#> .
-
-
-
-###  http://www.w3.org/ns/prov#pairEntity
-
-prov:pairEntity rdf:type owl:FunctionalProperty ,
-                         owl:ObjectProperty ;
-                
-                rdfs:label "pairKey" ;
-                
-                prov:constraints "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#dictionary-constraints"^^xsd:anyURI ;
-                
-                prov:n "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#expression-dictionary-membership"^^xsd:anyURI ;
-                
-                prov:dm "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#term-dictionary-membership"^^xsd:anyURI ;
-                
-                prov:definition "The entity of a prov:KeyEntityPair, which is an element of a prov:Dictionary." ;
-                
-                prov:component "collections" ;
-                
-                prov:category "collections" ;
-                
-                rdfs:isDefinedBy prov: ;
-                
-                rdfs:range prov:Entity ;
-                
-                rdfs:domain prov:KeyEntityPair .
-
-
-
-###  http://www.w3.org/ns/prov#pingback
-
-prov:pingback rdf:type owl:ObjectProperty ;
-              
-              rdfs:label "provenance pingback" ;
-              
-              prov:aq "http://www.w3.org/TR/2013/NOTE-prov-aq-20130430/#provenance-pingback"^^xsd:anyURI ;
-              
-              rdfs:comment "Relates a resource to a provenance pingback service that may receive additional provenance links about the resource."@en ;
-              
-              prov:category "access-and-query" ;
-              
-              rdfs:isDefinedBy prov: .
-
-
-
-###  http://www.w3.org/ns/prov#qualifiedAssociation
-
-prov:qualifiedAssociation rdf:type owl:ObjectProperty ;
-                          
-                          rdfs:label "qualifiedAssociation" ;
-                          
-                          rdfs:comment "If this Activity prov:wasAssociatedWith Agent :ag, then it can qualify the Association using prov:qualifiedAssociation [ a prov:Association;  prov:agent :ag; :foo :bar ]."@en ;
-                          
-                          prov:inverse "qualifiedAssociationOf" ;
-                          
-                          prov:component "agents-responsibility" ;
-                          
-                          prov:category "qualified" ;
-                          
-                          rdfs:domain prov:Activity ;
-                          
-                          prov:sharesDefinitionWith prov:Association ;
-                          
-                          rdfs:range prov:Association ;
-                          
-                          rdfs:subPropertyOf prov:qualifiedInfluence ;
-                          
-                          prov:unqualifiedForm prov:wasAssociatedWith ;
-                          
-                          rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#qualifiedAssociationOf
-
-prov:qualifiedAssociationOf rdfs:label "qualifiedAssociationOf" ;
-                            
-                            rdfs:isDefinedBy prov: ;
-                            
-                            owl:inverseOf prov:qualifiedAssociation .
-
-
-
-###  http://www.w3.org/ns/prov#qualifiedAttribution
-
-prov:qualifiedAttribution rdf:type owl:ObjectProperty ;
-                          
-                          rdfs:label "qualifiedAttribution" ;
-                          
-                          prov:component "agents-responsibility" ;
-                          
-                          rdfs:comment "If this Entity prov:wasAttributedTo Agent :ag, then it can qualify how it was influenced using prov:qualifiedAttribution [ a prov:Attribution;  prov:agent :ag; :foo :bar ]."@en ;
-                          
-                          prov:category "qualified" ;
-                          
-                          prov:inverse "qualifiedAttributionOf" ;
-                          
-                          rdfs:range prov:Attribution ;
-                          
-                          prov:sharesDefinitionWith prov:Attribution ;
-                          
-                          rdfs:domain prov:Entity ;
-                          
-                          rdfs:subPropertyOf prov:qualifiedInfluence ;
-                          
-                          prov:unqualifiedForm prov:wasAttributedTo ;
-                          
-                          rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#qualifiedAttributionOf
-
-prov:qualifiedAttributionOf rdfs:label "qualifiedAttributionOf" ;
-                            
-                            rdfs:isDefinedBy prov: ;
-                            
-                            owl:inverseOf prov:qualifiedAttribution .
-
-
-
-###  http://www.w3.org/ns/prov#qualifiedCommunication
-
-prov:qualifiedCommunication rdf:type owl:ObjectProperty ;
-                            
-                            rdfs:label "qualifiedCommunication" ;
-                            
-                            prov:inverse "qualifiedCommunicationOf" ;
-                            
-                            prov:component "entities-activities" ;
-                            
-                            rdfs:comment "If this Activity prov:wasInformedBy Activity :a, then it can qualify how it was influenced using prov:qualifiedCommunication [ a prov:Communication;  prov:activity :a; :foo :bar ]."@en ;
-                            
-                            prov:category "qualified" ;
-                            
-                            rdfs:domain prov:Activity ;
-                            
-                            prov:qualifiedForm prov:Communication ;
-                            
-                            rdfs:range prov:Communication ;
-                            
-                            prov:sharesDefinitionWith prov:Communication ;
-                            
-                            rdfs:subPropertyOf prov:qualifiedInfluence ;
-                            
-                            rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#qualifiedCommunicationOf
-
-prov:qualifiedCommunicationOf rdfs:label "qualifiedCommunicationOf" ;
-                              
-                              rdfs:isDefinedBy prov: ;
-                              
-                              owl:inverseOf prov:qualifiedCommunication .
-
-
-
-###  http://www.w3.org/ns/prov#qualifiedDelegation
-
-prov:qualifiedDelegation rdf:type owl:ObjectProperty ;
-                         
-                         rdfs:label "qualifiedDelegation" ;
-                         
-                         rdfs:comment "If this Agent prov:actedOnBehalfOf Agent :ag, then it can qualify how with prov:qualifiedResponsibility [ a prov:Responsibility;  prov:agent :ag; :foo :bar ]."@en ;
-                         
-                         prov:component "agents-responsibility" ;
-                         
-                         prov:inverse "qualifiedDelegationOf" ;
-                         
-                         prov:category "qualified" ;
-                         
-                         rdfs:domain prov:Agent ;
-                         
-                         rdfs:range prov:Delegation ;
-                         
-                         prov:sharesDefinitionWith prov:Delegation ;
-                         
-                         prov:unqualifiedForm prov:actedOnBehalfOf ;
-                         
-                         rdfs:subPropertyOf prov:qualifiedInfluence ;
-                         
-                         rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#qualifiedDelegationOf
-
-prov:qualifiedDelegationOf rdfs:label "qualifiedDelegationOf" ;
-                           
-                           rdfs:isDefinedBy prov: ;
-                           
-                           owl:inverseOf prov:qualifiedDelegation .
-
-
-
-###  http://www.w3.org/ns/prov#qualifiedDerivation
-
-prov:qualifiedDerivation rdf:type owl:ObjectProperty ;
-                         
-                         rdfs:label "qualifiedDerivation" ;
-                         
-                         prov:component "derivations" ;
-                         
-                         prov:category "qualified" ;
-                         
-                         rdfs:comment "If this Entity prov:wasDerivedFrom Entity :e, then it can qualify how it was derived using prov:qualifiedDerivation [ a prov:Derivation;  prov:entity :e; :foo :bar ]."@en ;
-                         
-                         prov:inverse "qualifiedDerivationOf" ;
-                         
-                         prov:sharesDefinitionWith prov:Derivation ;
-                         
-                         rdfs:range prov:Derivation ;
-                         
-                         rdfs:domain prov:Entity ;
-                         
-                         rdfs:subPropertyOf prov:qualifiedInfluence ;
-                         
-                         prov:unqualifiedForm prov:wasDerivedFrom ;
-                         
-                         rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#qualifiedDerivationOf
-
-prov:qualifiedDerivationOf rdfs:label "qualifiedDerivationOf" ;
-                           
-                           rdfs:isDefinedBy prov: ;
-                           
-                           owl:inverseOf prov:qualifiedDerivation .
-
-
-
-###  http://www.w3.org/ns/prov#qualifiedEnd
-
-prov:qualifiedEnd rdf:type owl:ObjectProperty ;
-                  
-                  rdfs:label "qualifiedEnd" ;
-                  
-                  prov:category "qualified" ;
-                  
-                  rdfs:comment "If this Activity prov:wasEndedBy Entity :e1, then it can qualify how it was ended using prov:qualifiedEnd [ a prov:End;  prov:entity :e1; :foo :bar ]."@en ;
-                  
-                  prov:component "entities-activities" ;
-                  
-                  prov:inverse "qualifiedEndOf" ;
-                  
-                  rdfs:domain prov:Activity ;
-                  
-                  prov:sharesDefinitionWith prov:End ;
-                  
-                  rdfs:range prov:End ;
-                  
-                  rdfs:subPropertyOf prov:qualifiedInfluence ;
-                  
-                  prov:unqualifiedForm prov:wasEndedBy ;
-                  
-                  rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#qualifiedEndOf
-
-prov:qualifiedEndOf rdfs:label "qualifiedEndOf" ;
-                    
-                    rdfs:isDefinedBy prov: ;
-                    
-                    owl:inverseOf prov:qualifiedEnd .
-
-
-
-###  http://www.w3.org/ns/prov#qualifiedGeneration
-
-prov:qualifiedGeneration rdf:type owl:ObjectProperty ;
-                         
-                         rdfs:label "qualifiedGeneration" ;
-                         
-                         prov:component "entities-activities" ;
-                         
-                         prov:inverse "qualifiedGenerationOf" ;
-                         
-                         rdfs:comment "If this Activity prov:generated Entity :e, then it can qualify how it performed the Generation using prov:qualifiedGeneration [ a prov:Generation;  prov:entity :e; :foo :bar ]."@en ;
-                         
-                         prov:category "qualified" ;
-                         
-                         rdfs:domain prov:Entity ;
-                         
-                         rdfs:range prov:Generation ;
-                         
-                         prov:sharesDefinitionWith prov:Generation ;
-                         
-                         rdfs:subPropertyOf prov:qualifiedInfluence ;
-                         
-                         prov:unqualifiedForm prov:wasGeneratedBy ;
-                         
-                         rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#qualifiedGenerationOf
-
-prov:qualifiedGenerationOf rdfs:label "qualifiedGenerationOf" ;
-                           
-                           rdfs:isDefinedBy prov: ;
-                           
-                           owl:inverseOf prov:qualifiedGeneration .
-
-
-
-###  http://www.w3.org/ns/prov#qualifiedInfluence
-
-prov:qualifiedInfluence rdf:type owl:ObjectProperty ;
-                        
-                        rdfs:label "qualifiedInfluence" ;
-                        
-                        prov:category "qualified" ;
-                        
-                        prov:inverse "qualifiedInfluenceOf" ;
-                        
-                        prov:component "derivations" ;
-                        
-                        rdfs:comment "Because prov:qualifiedInfluence is a broad relation, the more specific relations (qualifiedCommunication, qualifiedDelegation, qualifiedEnd, etc.) should be used when applicable."@en ;
-                        
-                        prov:sharesDefinitionWith prov:Influence ;
-                        
-                        rdfs:range prov:Influence ;
-                        
-                        prov:unqualifiedForm prov:wasInfluencedBy ;
-                        
-                        rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
-                        
-                        rdfs:domain [ rdf:type owl:Class ;
-                                      owl:unionOf ( prov:Activity
-                                                    prov:Agent
-                                                    prov:Entity
-                                                  )
-                                    ] .
-
-
-
-###  http://www.w3.org/ns/prov#qualifiedInfluenceOf
-
-prov:qualifiedInfluenceOf rdfs:label "qualifiedInfluenceOf" ;
-                          
-                          rdfs:isDefinedBy prov: ;
-                          
-                          owl:inverseOf prov:qualifiedInfluence .
-
-
-
-###  http://www.w3.org/ns/prov#qualifiedInsertion
-
-prov:qualifiedInsertion rdf:type owl:ObjectProperty ;
-                        
-                        rdfs:label "qualifiedInsertion" ;
-                        
-                        prov:constraints "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#dictionary-constraints"^^xsd:anyURI ;
-                        
-                        prov:n "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#expression-dictionary-insertion"^^xsd:anyURI ;
-                        
-                        prov:dm "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#term-dictionary-insertion"^^xsd:anyURI ;
-                        
-                        prov:component "collections" ;
-                        
-                        prov:category "collections" ;
-                        
-                        prov:definition "prov:qualifiedInsertion shows the details of an insertion, in particular the inserted key-entity pairs." ;
-                        
-                        rdfs:isDefinedBy prov: ;
-                        
-                        rdfs:domain prov:Dictionary ;
-                        
-                        rdfs:range prov:Insertion ;
-                        
-                        rdfs:subPropertyOf prov:qualifiedDerivation .
-
-
-
-###  http://www.w3.org/ns/prov#qualifiedInvalidation
-
-prov:qualifiedInvalidation rdf:type owl:ObjectProperty ;
-                           
-                           rdfs:label "qualifiedInvalidation" ;
-                           
-                           prov:category "qualified" ;
-                           
-                           prov:inverse "qualifiedInvalidationOf" ;
-                           
-                           rdfs:comment "If this Entity prov:wasInvalidatedBy Activity :a, then it can qualify how it was invalidated using prov:qualifiedInvalidation [ a prov:Invalidation;  prov:activity :a; :foo :bar ]."@en ;
-                           
-                           prov:component "entities-activities" ;
-                           
-                           rdfs:domain prov:Entity ;
-                           
-                           prov:sharesDefinitionWith prov:Invalidation ;
-                           
-                           rdfs:range prov:Invalidation ;
-                           
-                           rdfs:subPropertyOf prov:qualifiedInfluence ;
-                           
-                           prov:unqualifiedForm prov:wasInvalidatedBy ;
-                           
-                           rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#qualifiedInvalidationOf
-
-prov:qualifiedInvalidationOf rdfs:label "qualifiedInvalidationOf" ;
-                             
-                             rdfs:isDefinedBy prov: ;
-                             
-                             owl:inverseOf prov:qualifiedInvalidation .
-
-
-
-###  http://www.w3.org/ns/prov#qualifiedPrimarySource
-
-prov:qualifiedPrimarySource rdf:type owl:ObjectProperty ;
-                            
-                            rdfs:label "qualifiedPrimarySource" ;
-                            
-                            prov:component "derivations" ;
-                            
-                            prov:category "qualified" ;
-                            
-                            rdfs:comment "If this Entity prov:hadPrimarySource Entity :e, then it can qualify how using prov:qualifiedPrimarySource [ a prov:PrimarySource; prov:entity :e; :foo :bar ]."@en ;
-                            
-                            prov:inverse "qualifiedSourceOf" ;
-                            
-                            rdfs:domain prov:Entity ;
-                            
-                            prov:sharesDefinitionWith prov:PrimarySource ;
-                            
-                            rdfs:range prov:PrimarySource ;
-                            
-                            prov:unqualifiedForm prov:hadPrimarySource ;
-                            
-                            rdfs:subPropertyOf prov:qualifiedInfluence ;
-                            
-                            rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#qualifiedQuotation
-
-prov:qualifiedQuotation rdf:type owl:ObjectProperty ;
-                        
-                        rdfs:label "qualifiedQuotation" ;
-                        
-                        prov:component "derivations" ;
-                        
-                        prov:category "qualified" ;
-                        
-                        rdfs:comment "If this Entity prov:wasQuotedFrom Entity :e, then it can qualify how using prov:qualifiedQuotation [ a prov:Quotation;  prov:entity :e; :foo :bar ]."@en ;
-                        
-                        prov:inverse "qualifiedQuotationOf" ;
-                        
-                        rdfs:domain prov:Entity ;
-                        
-                        rdfs:range prov:Quotation ;
-                        
-                        prov:sharesDefinitionWith prov:Quotation ;
-                        
-                        rdfs:subPropertyOf prov:qualifiedInfluence ;
-                        
-                        prov:unqualifiedForm prov:wasQuotedFrom ;
-                        
-                        rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#qualifiedQuotationOf
-
-prov:qualifiedQuotationOf rdfs:label "qualifiedQuotationOf" ;
-                          
-                          rdfs:isDefinedBy prov: ;
-                          
-                          owl:inverseOf prov:qualifiedQuotation .
-
-
-
-###  http://www.w3.org/ns/prov#qualifiedRemoval
-
-prov:qualifiedRemoval rdf:type owl:ObjectProperty ;
-                      
-                      rdfs:label "qualifiedRemoval" ;
-                      
-                      prov:constraints "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#dictionary-constraints"^^xsd:anyURI ;
-                      
-                      prov:n "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#expression-dictionary-removal"^^xsd:anyURI ;
-                      
-                      prov:dm "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#term-dictionary-removal"^^xsd:anyURI ;
-                      
-                      prov:category "collections" ;
-                      
-                      prov:definition "prov:qualifiedRemoval shows the details of a removal, in particular the removed keys." ;
-                      
-                      prov:component "collections" ;
-                      
-                      rdfs:isDefinedBy prov: ;
-                      
-                      rdfs:domain prov:Dictionary ;
-                      
-                      rdfs:range prov:Removal ;
-                      
-                      rdfs:subPropertyOf prov:qualifiedDerivation .
-
-
-
-###  http://www.w3.org/ns/prov#qualifiedRevision
-
-prov:qualifiedRevision rdf:type owl:ObjectProperty ;
-                       
-                       rdfs:label "qualifiedRevision" ;
-                       
-                       prov:category "qualified" ;
-                       
-                       prov:inverse "revisedEntity" ;
-                       
-                       rdfs:comment "If this Entity prov:wasRevisionOf Entity :e, then it can qualify how it was revised using prov:qualifiedRevision [ a prov:Revision;  prov:entity :e; :foo :bar ]."@en ;
-                       
-                       prov:component "derivations" ;
-                       
-                       rdfs:domain prov:Entity ;
-                       
-                       prov:sharesDefinitionWith prov:Revision ;
-                       
-                       rdfs:range prov:Revision ;
-                       
-                       rdfs:subPropertyOf prov:qualifiedInfluence ;
-                       
-                       prov:unqualifiedForm prov:wasRevisionOf ;
-                       
-                       rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#qualifiedSourceOf
-
-prov:qualifiedSourceOf rdfs:label "qualifiedSourceOf" ;
-                       
-                       rdfs:isDefinedBy prov: ;
-                       
-                       owl:inverseOf prov:qualifiedPrimarySource .
-
-
-
-###  http://www.w3.org/ns/prov#qualifiedStart
-
-prov:qualifiedStart rdf:type owl:ObjectProperty ;
-                    
-                    rdfs:label "qualifiedStart" ;
-                    
-                    prov:component "entities-activities" ;
-                    
-                    rdfs:comment "If this Activity prov:wasStartedBy Entity :e1, then it can qualify how it was started using prov:qualifiedStart [ a prov:Start;  prov:entity :e1; :foo :bar ]."@en ;
-                    
-                    prov:inverse "qualifiedStartOf" ;
-                    
-                    prov:category "qualified" ;
-                    
-                    rdfs:domain prov:Activity ;
-                    
-                    rdfs:range prov:Start ;
-                    
-                    prov:sharesDefinitionWith prov:Start ;
-                    
-                    rdfs:subPropertyOf prov:qualifiedInfluence ;
-                    
-                    prov:unqualifiedForm prov:wasStartedBy ;
-                    
-                    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#qualifiedStartOf
-
-prov:qualifiedStartOf rdfs:label "qualifiedStartOf" ;
-                      
-                      rdfs:isDefinedBy prov: ;
-                      
-                      owl:inverseOf prov:qualifiedStart .
-
-
-
-###  http://www.w3.org/ns/prov#qualifiedUsage
-
-prov:qualifiedUsage rdf:type owl:ObjectProperty ;
-                    
-                    rdfs:label "qualifiedUsage" ;
-                    
-                    rdfs:comment "If this Activity prov:used Entity :e, then it can qualify how it used it using prov:qualifiedUsage [ a prov:Usage; prov:entity :e; :foo :bar ]."@en ;
-                    
-                    prov:category "qualified" ;
-                    
-                    prov:component "entities-activities" ;
-                    
-                    prov:inverse "qualifiedUsingActivity" ;
-                    
-                    rdfs:domain prov:Activity ;
-                    
-                    rdfs:range prov:Usage ;
-                    
-                    prov:sharesDefinitionWith prov:Usage ;
-                    
-                    rdfs:subPropertyOf prov:qualifiedInfluence ;
-                    
-                    prov:unqualifiedForm prov:used ;
-                    
-                    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#qualifiedUsingActivity
-
-prov:qualifiedUsingActivity rdfs:label "qualifiedUsingActivity" ;
-                            
-                            rdfs:isDefinedBy prov: ;
-                            
-                            owl:inverseOf prov:qualifiedUsage .
-
-
-
-###  http://www.w3.org/ns/prov#quotedAs
-
-prov:quotedAs rdfs:label "quotedAs" ;
-              
-              rdfs:isDefinedBy prov: ;
-              
-              owl:inverseOf prov:wasQuotedFrom .
-
-
-
-###  http://www.w3.org/ns/prov#revisedEntity
-
-prov:revisedEntity rdfs:label "revisedEntity" ;
-                   
-                   rdfs:isDefinedBy prov: ;
-                   
-                   owl:inverseOf prov:qualifiedRevision .
-
-
-
-###  http://www.w3.org/ns/prov#specializationOf
-
-prov:specializationOf rdf:type owl:ObjectProperty ;
-                      
-                      rdfs:label "specializationOf" ;
-                      
-                      prov:constraints "http://www.w3.org/TR/2012/WD-prov-dm-20120703/prov-constraints.html#prov-dm-constraints-fig"^^xsd:anyURI ;
-                      
-                      prov:dm "http://www.w3.org/TR/2012/WD-prov-dm-20120703/prov-dm.html#term-specialization"^^xsd:anyURI ;
-                      
-                      prov:n "http://www.w3.org/TR/2012/WD-prov-dm-20120703/prov-n.html#expression-specialization"^^xsd:anyURI ;
-                      
-                      prov:constraints "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
-                      
-                      prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-specialization"^^xsd:anyURI ;
-                      
-                      prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-specialization"^^xsd:anyURI ;
-                      
-                      prov:definition "An entity that is a specialization of another shares all aspects of the latter, and additionally presents more specific aspects of the same thing as the latter. In particular, the lifetime of the entity being specialized contains that of any specialization. Examples of aspects include a time period, an abstraction, and a context associated with the entity."@en ;
-                      
-                      prov:category "expanded" ;
-                      
-                      prov:inverse "generalizationOf" ;
-                      
-                      prov:component "alternate" ;
-                      
-                      rdfs:subPropertyOf owl:topObjectProperty ;
-                      
-                      rdfs:isDefinedBy prov: ;
-                      
-                      rdfs:domain prov:Entity ;
-                      
-                      rdfs:range prov:Entity ;
-                      
-                      rdfs:subPropertyOf prov:alternateOf ;
-                      
-                      rdfs:seeAlso prov:alternateOf ;
-                      
-                      rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#started
-
-prov:started rdfs:label "started" ;
-             
-             rdfs:isDefinedBy prov: ;
-             
-             owl:inverseOf prov:wasStartedBy .
-
-
-
-###  http://www.w3.org/ns/prov#used
-
-prov:used rdf:type owl:ObjectProperty ;
-          
-          rdfs:label "used" ;
-          
-          prov:category "starting-point" ;
-          
-          rdfs:comment "A prov:Entity that was used by this prov:Activity. For example, :baking prov:used :spoon, :egg, :oven ."@en ;
-          
-          prov:component "entities-activities" ;
-          
-          prov:inverse "wasUsedBy" ;
-          
-          rdfs:domain prov:Activity ;
-          
-          rdfs:range prov:Entity ;
-          
-          prov:qualifiedForm prov:Usage ,
-                             prov:qualifiedUsage ;
-          
-          rdfs:subPropertyOf prov:wasInfluencedBy ;
-          
-          rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
-          
-          owl:propertyChainAxiom ( prov:qualifiedUsage
-                                   prov:entity
-                                 ) .
-
-
-
-###  http://www.w3.org/ns/prov#wasActivityOfInfluence
-
-prov:wasActivityOfInfluence rdfs:label "wasActivityOfInfluence" ;
-                            
-                            rdfs:isDefinedBy prov: ;
-                            
-                            owl:inverseOf prov:hadActivity .
-
-
-
-###  http://www.w3.org/ns/prov#wasAssociateFor
-
-prov:wasAssociateFor rdfs:label "wasAssociateFor" ;
-                     
-                     rdfs:isDefinedBy prov: ;
-                     
-                     owl:inverseOf prov:wasAssociatedWith .
-
-
-
-###  http://www.w3.org/ns/prov#wasAssociatedWith
-
-prov:wasAssociatedWith rdf:type owl:ObjectProperty ;
-                       
-                       rdfs:label "wasAssociatedWith" ;
-                       
-                       prov:component "agents-responsibility" ;
-                       
-                       prov:category "starting-point" ;
-                       
-                       rdfs:comment "An prov:Agent that had some (unspecified) responsibility for the occurrence of this prov:Activity."@en ;
-                       
-                       prov:inverse "wasAssociateFor" ;
-                       
-                       rdfs:domain prov:Activity ;
-                       
-                       rdfs:range prov:Agent ;
-                       
-                       prov:qualifiedForm prov:Association ,
-                                          prov:qualifiedAssociation ;
-                       
-                       rdfs:subPropertyOf prov:wasInfluencedBy ;
-                       
-                       rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
-                       
-                       owl:propertyChainAxiom ( prov:qualifiedAssociation
-                                                prov:agent
-                                              ) .
-
-
-
-###  http://www.w3.org/ns/prov#wasAttributedTo
-
-prov:wasAttributedTo rdf:type owl:ObjectProperty ;
-                     
-                     rdfs:label "wasAttributedTo" ;
-                     
-                     prov:inverse "contributed" ;
-                     
-                     rdfs:comment "Attribution is the ascribing of an entity to an agent."@en ;
-                     
-                     prov:category "starting-point" ;
-                     
-                     prov:component "agents-responsibility" ;
-                     
-                     prov:definition "Attribution is the ascribing of an entity to an agent."@en ;
-                     
-                     rdfs:range prov:Agent ;
-                     
-                     prov:qualifiedForm prov:Attribution ;
-                     
-                     rdfs:domain prov:Entity ;
-                     
-                     prov:qualifiedForm prov:qualifiedAttribution ;
-                     
-                     rdfs:subPropertyOf prov:wasInfluencedBy ;
-                     
-                     rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
-                     
-                     owl:propertyChainAxiom ( prov:qualifiedAttribution
-                                              prov:agent
-                                            ) .
-[ rdf:type owl:Axiom ;
-  prov:definition "IF wasAttributedTo(e2,ag1,aAttr) holds, THEN wasInfluencedBy(e2,ag1) also holds. " ;
-  rdfs:comment "Attribution is a particular case of trace (see http://www.w3.org/TR/prov-dm/#concept-trace), in the sense that it links an entity to the agent that ascribed it." ;
-  owl:annotatedProperty rdfs:subPropertyOf ;
-  owl:annotatedSource prov:wasAttributedTo ;
-  owl:annotatedTarget prov:wasInfluencedBy
-] .
-
-
-
-###  http://www.w3.org/ns/prov#wasDerivedFrom
-
-prov:wasDerivedFrom rdf:type owl:ObjectProperty ;
-                    
-                    rdfs:label "wasDerivedFrom" ;
-                    
-                    prov:inverse "hadDerivation" ;
-                    
-                    prov:category "starting-point" ;
-                    
-                    prov:definition "A derivation is a transformation of an entity into another, an update of an entity resulting in a new one, or the construction of a new entity based on a pre-existing entity."@en ;
-                    
-                    rdfs:comment "The more specific subproperties of prov:wasDerivedFrom (i.e., prov:wasQuotedFrom, prov:wasRevisionOf, prov:hadPrimarySource) should be used when applicable."@en ;
-                    
-                    prov:component "derivations" ;
-                    
-                    prov:qualifiedForm prov:Derivation ;
-                    
-                    rdfs:domain prov:Entity ;
-                    
-                    rdfs:range prov:Entity ;
-                    
-                    prov:qualifiedForm prov:qualifiedDerivation ;
-                    
-                    rdfs:subPropertyOf prov:wasInfluencedBy ;
-                    
-                    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
-                    
-                    owl:propertyChainAxiom ( prov:qualifiedDerivation
-                                             prov:entity
-                                           ) .
-[ rdf:type owl:Axiom ;
-  rdfs:comment "Derivation is a particular case of trace (see http://www.w3.org/TR/prov-dm/#term-trace), since it links an entity to another entity that contributed to its existence." ;
-  owl:annotatedProperty rdfs:subPropertyOf ;
-  owl:annotatedSource prov:wasDerivedFrom ;
-  owl:annotatedTarget prov:wasInfluencedBy
-] .
-
-
-
-###  http://www.w3.org/ns/prov#wasEndedBy
-
-prov:wasEndedBy rdf:type owl:ObjectProperty ;
-                
-                rdfs:label "wasEndedBy" ;
-                
-                prov:inverse "ended" ;
-                
-                prov:category "expanded" ;
-                
-                prov:component "entities-activities" ;
-                
-                rdfs:comment "End is when an activity is deemed to have ended. An end may refer to an entity, known as trigger, that terminated the activity."@en ;
-                
-                rdfs:domain prov:Activity ;
-                
-                prov:qualifiedForm prov:End ;
-                
-                rdfs:range prov:Entity ;
-                
-                prov:qualifiedForm prov:qualifiedEnd ;
-                
-                rdfs:subPropertyOf prov:wasInfluencedBy ;
-                
-                rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
-                
-                owl:propertyChainAxiom ( prov:qualifiedEnd
-                                         prov:entity
-                                       ) .
-
-
-
-###  http://www.w3.org/ns/prov#wasGeneratedBy
-
-prov:wasGeneratedBy rdf:type owl:ObjectProperty ;
-                    
-                    rdfs:label "wasGeneratedBy" ;
-                    
-                    prov:category "starting-point" ;
-                    
-                    prov:inverse "generated" ;
-                    
-                    prov:component "entities-activities" ;
-                    
-                    rdfs:isDefinedBy prov: ;
-                    
-                    rdfs:range prov:Activity ;
-                    
-                    rdfs:domain prov:Entity ;
-                    
-                    prov:qualifiedForm prov:Generation ,
-                                       prov:qualifiedGeneration ;
-                    
-                    rdfs:subPropertyOf prov:wasInfluencedBy ;
-                    
-                    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
-                    
-                    owl:propertyChainAxiom ( prov:qualifiedGeneration
-                                             prov:activity
-                                           ) .
-
-
-
-###  http://www.w3.org/ns/prov#wasInfluencedBy
-
-prov:wasInfluencedBy rdf:type owl:ObjectProperty ;
-                     
-                     rdfs:label "wasInfluencedBy" ;
-                     
-                     rdfs:comment "Because prov:wasInfluencedBy is a broad relation, its more specific subproperties (e.g. prov:wasInformedBy, prov:actedOnBehalfOf, prov:wasEndedBy, etc.) should be used when applicable."@en ;
-                     
-                     prov:category "qualified" ;
-                     
-                     prov:component "agents-responsibility" ;
-                     
-                     prov:inverse "influenced" ;
-                     
-                     prov:editorialNote """The sub-properties of prov:wasInfluencedBy can be elaborated in more detail using the Qualification Pattern. For example, the binary relation :baking prov:used :spoon can be qualified by asserting :baking prov:qualifiedUsage [ a prov:Usage; prov:entity :spoon; prov:atLocation :kitchen ] .
+       prov:activity prov:activity1;
+       prov:customValue 1337 .
+
+Note how the value of the unqualified influence (prov:wasGeneratedBy prov:activity1) is mirrored as the value of the prov:activity (or prov:entity, or prov:agent) property on the influence class."""@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:subPropertyOf rdfs:seeAlso .
+
+prov:qualifiedGeneration
+    a owl:ObjectProperty ;
+    rdfs:comment "If this Activity prov:generated Entity prov:e, then it can qualify how it performed the Generation using prov:qualifiedGeneration [ a prov:Generation;  prov:entity prov:e; prov:foo prov:bar ]."@en ;
+    rdfs:domain prov:Entity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "qualifiedGeneration" ;
+    rdfs:range prov:Generation ;
+    rdfs:subPropertyOf prov:qualifiedInfluence ;
+    prov:category "qualified" ;
+    prov:component "entities-activities" ;
+    prov:inverse "qualifiedGenerationOf" ;
+    prov:sharesDefinitionWith prov:Generation ;
+    prov:unqualifiedForm prov:wasGeneratedBy .
+
+prov:qualifiedInfluence
+    a owl:ObjectProperty ;
+    rdfs:comment "Because prov:qualifiedInfluence is a broad relation, the more specific relations (qualifiedCommunication, qualifiedDelegation, qualifiedEnd, etc.) should be used when applicable."@en ;
+    rdfs:domain [
+        a owl:Class ;
+        owl:unionOf (:Activity
+            prov:Agent
+            prov:Entity
+        )
+    ] ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "qualifiedInfluence" ;
+    rdfs:range prov:Influence ;
+    prov:category "qualified" ;
+    prov:component "derivations" ;
+    prov:inverse "qualifiedInfluenceOf" ;
+    prov:sharesDefinitionWith prov:Influence ;
+    prov:unqualifiedForm prov:wasInfluencedBy .
+
+prov:qualifiedInvalidation
+    a owl:ObjectProperty ;
+    rdfs:comment "If this Entity prov:wasInvalidatedBy Activity prov:a, then it can qualify how it was invalidated using prov:qualifiedInvalidation [ a prov:Invalidation;  prov:activity prov:a; prov:foo prov:bar ]."@en ;
+    rdfs:domain prov:Entity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "qualifiedInvalidation" ;
+    rdfs:range prov:Invalidation ;
+    rdfs:subPropertyOf prov:qualifiedInfluence ;
+    prov:category "qualified" ;
+    prov:component "entities-activities" ;
+    prov:inverse "qualifiedInvalidationOf" ;
+    prov:sharesDefinitionWith prov:Invalidation ;
+    prov:unqualifiedForm prov:wasInvalidatedBy .
+
+prov:qualifiedPrimarySource
+    a owl:ObjectProperty ;
+    rdfs:comment "If this Entity prov:hadPrimarySource Entity prov:e, then it can qualify how using prov:qualifiedPrimarySource [ a prov:PrimarySource; prov:entity prov:e; prov:foo prov:bar ]."@en ;
+    rdfs:domain prov:Entity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "qualifiedPrimarySource" ;
+    rdfs:range prov:PrimarySource ;
+    rdfs:subPropertyOf prov:qualifiedInfluence ;
+    prov:category "qualified" ;
+    prov:component "derivations" ;
+    prov:inverse "qualifiedSourceOf" ;
+    prov:sharesDefinitionWith prov:PrimarySource ;
+    prov:unqualifiedForm prov:hadPrimarySource .
+
+prov:qualifiedQuotation
+    a owl:ObjectProperty ;
+    rdfs:comment "If this Entity prov:wasQuotedFrom Entity prov:e, then it can qualify how using prov:qualifiedQuotation [ a prov:Quotation;  prov:entity prov:e; prov:foo prov:bar ]."@en ;
+    rdfs:domain prov:Entity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "qualifiedQuotation" ;
+    rdfs:range prov:Quotation ;
+    rdfs:subPropertyOf prov:qualifiedInfluence ;
+    prov:category "qualified" ;
+    prov:component "derivations" ;
+    prov:inverse "qualifiedQuotationOf" ;
+    prov:sharesDefinitionWith prov:Quotation ;
+    prov:unqualifiedForm prov:wasQuotedFrom .
+
+prov:qualifiedRevision
+    a owl:ObjectProperty ;
+    rdfs:comment "If this Entity prov:wasRevisionOf Entity prov:e, then it can qualify how it was revised using prov:qualifiedRevision [ a prov:Revision;  prov:entity prov:e; prov:foo prov:bar ]."@en ;
+    rdfs:domain prov:Entity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "qualifiedRevision" ;
+    rdfs:range prov:Revision ;
+    rdfs:subPropertyOf prov:qualifiedInfluence ;
+    prov:category "qualified" ;
+    prov:component "derivations" ;
+    prov:inverse "revisedEntity" ;
+    prov:sharesDefinitionWith prov:Revision ;
+    prov:unqualifiedForm prov:wasRevisionOf .
+
+prov:qualifiedStart
+    a owl:ObjectProperty ;
+    rdfs:comment "If this Activity prov:wasStartedBy Entity prov:e1, then it can qualify how it was started using prov:qualifiedStart [ a prov:Start;  prov:entity prov:e1; prov:foo prov:bar ]."@en ;
+    rdfs:domain prov:Activity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "qualifiedStart" ;
+    rdfs:range prov:Start ;
+    rdfs:subPropertyOf prov:qualifiedInfluence ;
+    prov:category "qualified" ;
+    prov:component "entities-activities" ;
+    prov:inverse "qualifiedStartOf" ;
+    prov:sharesDefinitionWith prov:Start ;
+    prov:unqualifiedForm prov:wasStartedBy .
+
+prov:qualifiedUsage
+    a owl:ObjectProperty ;
+    rdfs:comment "If this Activity prov:used Entity prov:e, then it can qualify how it used it using prov:qualifiedUsage [ a prov:Usage; prov:entity prov:e; prov:foo prov:bar ]."@en ;
+    rdfs:domain prov:Activity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "qualifiedUsage" ;
+    rdfs:range prov:Usage ;
+    rdfs:subPropertyOf prov:qualifiedInfluence ;
+    prov:category "qualified" ;
+    prov:component "entities-activities" ;
+    prov:inverse "qualifiedUsingActivity" ;
+    prov:sharesDefinitionWith prov:Usage ;
+    prov:unqualifiedForm prov:used .
+
+prov:sharesDefinitionWith
+    a owl:AnnotationProperty ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:subPropertyOf rdfs:seeAlso .
+
+prov:specializationOf
+    a owl:AnnotationProperty, owl:ObjectProperty ;
+    rdfs:domain prov:Entity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "specializationOf" ;
+    rdfs:range prov:Entity ;
+    rdfs:seeAlso prov:alternateOf ;
+    rdfs:subPropertyOf prov:alternateOf ;
+    prov:category "expanded" ;
+    prov:component "alternate" ;
+    prov:constraints "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
+    prov:definition "An entity that is a specialization of another shares all aspects of the latter, and additionally presents more specific aspects of the same thing as the latter. In particular, the lifetime of the entity being specialized contains that of any specialization. Examples of aspects include a time period, an abstraction, and a context associated with the entity."@en ;
+    prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-specialization"^^xsd:anyURI ;
+    prov:inverse "generalizationOf" ;
+    prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-specialization"^^xsd:anyURI .
+
+prov:startedAtTime
+    a owl:DatatypeProperty ;
+    rdfs:comment "The time at which an activity started. See also prov:endedAtTime."@en ;
+    rdfs:domain prov:Activity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "startedAtTime" ;
+    rdfs:range xsd:dateTime ;
+    prov:category "starting-point" ;
+    prov:component "entities-activities" ;
+    prov:editorialNote "It is the intent that the property chain holds: (prov:qualifiedStart o prov:atTime) rdfs:subPropertyOf prov:startedAtTime."@en ;
+    prov:qualifiedForm prov:Start, prov:atTime .
+
+prov:todo
+    a owl:AnnotationProperty .
+
+prov:unqualifiedForm
+    a owl:AnnotationProperty ;
+    rdfs:comment "Classes and properties used to qualify relationships are annotated with prov:unqualifiedForm to indicate the property used to assert an unqualified provenance relation."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:subPropertyOf rdfs:seeAlso .
+
+prov:used
+    a owl:ObjectProperty ;
+    rdfs:comment "A prov:Entity that was used by this prov:Activity. For example, prov:baking prov:used prov:spoon, prov:egg, prov:oven ."@en ;
+    rdfs:domain prov:Activity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "used" ;
+    rdfs:range prov:Entity ;
+    rdfs:subPropertyOf prov:wasInfluencedBy ;
+    owl:propertyChainAxiom (:qualifiedUsage
+        prov:entity
+    ) ;
+    prov:category "starting-point" ;
+    prov:component "entities-activities" ;
+    prov:inverse "wasUsedBy" ;
+    prov:qualifiedForm prov:Usage, prov:qualifiedUsage .
+
+prov:value
+    a owl:DatatypeProperty ;
+    rdfs:domain prov:Entity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "value" ;
+    prov:category "expanded" ;
+    prov:component "entities-activities" ;
+    prov:definition "Provides a value that is a direct representation of an entity."@en ;
+    prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-attribute-value"^^xsd:anyURI ;
+    prov:editorialNote "The editor's definition comes from http://www.w3.org/TR/rdf-primer/#rdfvalue", "This property serves the same purpose as rdf:value, but has been reintroduced to avoid some of the definitional ambiguity in the RDF specification (specifically, 'may be used in describing structured values')."@en .
+
+prov:wasAssociatedWith
+    a owl:ObjectProperty ;
+    rdfs:comment "An prov:Agent that had some (unspecified) responsibility for the occurrence of this prov:Activity."@en ;
+    rdfs:domain prov:Activity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "wasAssociatedWith" ;
+    rdfs:range prov:Agent ;
+    rdfs:subPropertyOf prov:wasInfluencedBy ;
+    owl:propertyChainAxiom (:qualifiedAssociation
+        prov:agent
+    ) ;
+    prov:category "starting-point" ;
+    prov:component "agents-responsibility" ;
+    prov:inverse "wasAssociateFor" ;
+    prov:qualifiedForm prov:Association, prov:qualifiedAssociation .
+
+prov:wasAttributedTo
+    a owl:ObjectProperty ;
+    rdfs:comment "Attribution is the ascribing of an entity to an agent."@en ;
+    rdfs:domain prov:Entity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "wasAttributedTo" ;
+    rdfs:range prov:Agent ;
+    rdfs:subPropertyOf prov:wasInfluencedBy ;
+    owl:propertyChainAxiom (:qualifiedAttribution
+        prov:agent
+    ) ;
+    prov:category "starting-point" ;
+    prov:component "agents-responsibility" ;
+    prov:definition "Attribution is the ascribing of an entity to an agent."@en ;
+    prov:inverse "contributed" ;
+    prov:qualifiedForm prov:Attribution, prov:qualifiedAttribution .
+
+prov:wasDerivedFrom
+    a owl:ObjectProperty ;
+    rdfs:comment "The more specific subproperties of prov:wasDerivedFrom (i.e., prov:wasQuotedFrom, prov:wasRevisionOf, prov:hadPrimarySource) should be used when applicable."@en ;
+    rdfs:domain prov:Entity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "wasDerivedFrom" ;
+    rdfs:range prov:Entity ;
+    rdfs:subPropertyOf prov:wasInfluencedBy ;
+    owl:propertyChainAxiom (:qualifiedDerivation
+        prov:entity
+    ) ;
+    prov:category "starting-point" ;
+    prov:component "derivations" ;
+    prov:definition "A derivation is a transformation of an entity into another, an update of an entity resulting in a new one, or the construction of a new entity based on a pre-existing entity."@en ;
+    prov:inverse "hadDerivation" ;
+    prov:qualifiedForm prov:Derivation, prov:qualifiedDerivation .
+
+prov:wasEndedBy
+    a owl:ObjectProperty ;
+    rdfs:comment "End is when an activity is deemed to have ended. An end may refer to an entity, known as trigger, that terminated the activity."@en ;
+    rdfs:domain prov:Activity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "wasEndedBy" ;
+    rdfs:range prov:Entity ;
+    rdfs:subPropertyOf prov:wasInfluencedBy ;
+    owl:propertyChainAxiom (:qualifiedEnd
+        prov:entity
+    ) ;
+    prov:category "expanded" ;
+    prov:component "entities-activities" ;
+    prov:inverse "ended" ;
+    prov:qualifiedForm prov:End, prov:qualifiedEnd .
+
+prov:wasGeneratedBy
+    a owl:ObjectProperty ;
+    rdfs:domain prov:Entity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "wasGeneratedBy" ;
+    rdfs:range prov:Activity ;
+    rdfs:subPropertyOf prov:wasInfluencedBy ;
+    owl:propertyChainAxiom (:qualifiedGeneration
+        prov:activity
+    ) ;
+    prov:category "starting-point" ;
+    prov:component "entities-activities" ;
+    prov:inverse "generated" ;
+    prov:qualifiedForm prov:Generation, prov:qualifiedGeneration .
+
+prov:wasInfluencedBy
+    a owl:ObjectProperty ;
+    rdfs:comment "Because prov:wasInfluencedBy is a broad relation, its more specific subproperties (e.g. prov:wasInformedBy, prov:actedOnBehalfOf, prov:wasEndedBy, etc.) should be used when applicable."@en, "This property has multiple RDFS domains to suit multiple OWL Profiles. See <a href=\"#owl-profile\">PROV-O OWL Profile</a>." ;
+    rdfs:domain [
+        a owl:Class ;
+        owl:unionOf (:Activity
+            prov:Agent
+            prov:Entity
+        )
+    ] ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "wasInfluencedBy" ;
+    rdfs:range [
+        a owl:Class ;
+        owl:unionOf (:Activity
+            prov:Agent
+            prov:Entity
+        )
+    ] ;
+    prov:category "qualified" ;
+    prov:component "agents-responsibility" ;
+    prov:editorialNote """The sub-properties of prov:wasInfluencedBy can be elaborated in more detail using the Qualification Pattern. For example, the binary relation prov:baking prov:used prov:spoon can be qualified by asserting prov:baking prov:qualifiedUsage [ a prov:Usage; prov:entity prov:spoon; prov:atLocation prov:kitchen ] .
 
 Subproperties of prov:wasInfluencedBy may also be asserted directly without being qualified.
 
 prov:wasInfluencedBy should not be used without also using one of its subproperties. 
 """@en ;
-                     
-                     rdfs:comment "This property has multiple RDFS domains to suit multiple OWL Profiles. See <a href=\"#owl-profile\">PROV-O OWL Profile</a>." ;
-                     
-                     rdfs:isDefinedBy prov: ;
-                     
-                     prov:qualifiedForm prov:Influence ;
-                     
-                     prov:sharesDefinitionWith prov:Influence ;
-                     
-                     prov:qualifiedForm prov:qualifiedInfluence ;
-                     
-                     rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
-                     
-                     rdfs:domain [ rdf:type owl:Class ;
-                                   owl:unionOf ( prov:Activity
-                                                 prov:Agent
-                                                 prov:Entity
-                                               )
-                                 ] ;
-                     
-                     rdfs:range [ rdf:type owl:Class ;
-                                  owl:unionOf ( prov:Activity
-                                                prov:Agent
-                                                prov:Entity
-                                              )
-                                ] .
-[ rdf:type owl:Axiom ;
-  prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-influence" ;
-  prov:definition "influencer: an identifier (o1) for an ancestor entity, activity, or agent that the former depends on;" ;
-  owl:annotatedProperty rdfs:range ;
-  owl:annotatedSource prov:wasInfluencedBy ;
-  owl:annotatedTarget [ rdf:type owl:Class ;
-                        owl:unionOf ( prov:Activity
-                                      prov:Agent
-                                      prov:Entity
-                                    )
-                      ]
-] .
-[ rdf:type owl:Axiom ;
-  prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-influence" ;
-  prov:definition "influencee: an identifier (o2) for an entity, activity, or agent; " ;
-  owl:annotatedProperty rdfs:domain ;
-  owl:annotatedSource prov:wasInfluencedBy ;
-  owl:annotatedTarget [ rdf:type owl:Class ;
-                        owl:unionOf ( prov:Activity
-                                      prov:Agent
-                                      prov:Entity
-                                    )
-                      ]
-] .
+    prov:inverse "influenced" ;
+    prov:qualifiedForm prov:Influence, prov:qualifiedInfluence ;
+    prov:sharesDefinitionWith prov:Influence .
 
+prov:wasInformedBy
+    a owl:ObjectProperty ;
+    rdfs:comment "An activity a2 is dependent on or informed by another activity a1, by way of some unspecified entity that is generated by a1 and used by a2."@en ;
+    rdfs:domain prov:Activity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "wasInformedBy" ;
+    rdfs:range prov:Activity ;
+    rdfs:subPropertyOf prov:wasInfluencedBy ;
+    owl:propertyChainAxiom (:qualifiedCommunication
+        prov:activity
+    ) ;
+    prov:category "starting-point" ;
+    prov:component "entities-activities" ;
+    prov:inverse "informed" ;
+    prov:qualifiedForm prov:Communication, prov:qualifiedCommunication .
 
+prov:wasInvalidatedBy
+    a owl:ObjectProperty ;
+    rdfs:domain prov:Entity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "wasInvalidatedBy" ;
+    rdfs:range prov:Activity ;
+    rdfs:subPropertyOf prov:wasInfluencedBy ;
+    owl:propertyChainAxiom (:qualifiedInvalidation
+        prov:activity
+    ) ;
+    prov:category "expanded" ;
+    prov:component "entities-activities" ;
+    prov:inverse "invalidated" ;
+    prov:qualifiedForm prov:Invalidation, prov:qualifiedInvalidation .
 
-###  http://www.w3.org/ns/prov#wasInformedBy
+prov:wasQuotedFrom
+    a owl:ObjectProperty ;
+    rdfs:comment "An entity is derived from an original entity by copying, or 'quoting', some or all of it."@en ;
+    rdfs:domain prov:Entity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "wasQuotedFrom" ;
+    rdfs:range prov:Entity ;
+    rdfs:subPropertyOf prov:wasDerivedFrom ;
+    owl:propertyChainAxiom (:qualifiedQuotation
+        prov:entity
+    ) ;
+    prov:category "expanded" ;
+    prov:component "derivations" ;
+    prov:inverse "quotedAs" ;
+    prov:qualifiedForm prov:Quotation, prov:qualifiedQuotation .
 
-prov:wasInformedBy rdf:type owl:ObjectProperty ;
-                   
-                   rdfs:label "wasInformedBy" ;
-                   
-                   rdfs:comment "An activity a2 is dependent on or informed by another activity a1, by way of some unspecified entity that is generated by a1 and used by a2."@en ;
-                   
-                   prov:category "starting-point" ;
-                   
-                   prov:component "entities-activities" ;
-                   
-                   prov:inverse "informed" ;
-                   
-                   rdfs:range prov:Activity ;
-                   
-                   rdfs:domain prov:Activity ;
-                   
-                   prov:qualifiedForm prov:Communication ,
-                                      prov:qualifiedCommunication ;
-                   
-                   rdfs:subPropertyOf prov:wasInfluencedBy ;
-                   
-                   rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
-                   
-                   owl:propertyChainAxiom ( prov:qualifiedCommunication
-                                            prov:activity
-                                          ) .
+prov:wasRevisionOf
+    a owl:AnnotationProperty, owl:ObjectProperty ;
+    rdfs:comment "A revision is a derivation that revises an entity into a revised version."@en ;
+    rdfs:domain prov:Entity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "wasRevisionOf" ;
+    rdfs:range prov:Entity ;
+    rdfs:subPropertyOf prov:wasDerivedFrom ;
+    owl:propertyChainAxiom (:qualifiedRevision
+        prov:entity
+    ) ;
+    prov:category "expanded" ;
+    prov:component "derivations" ;
+    prov:inverse "hadRevision" ;
+    prov:qualifiedForm prov:Revision, prov:qualifiedRevision .
 
+prov:wasStartedBy
+    a owl:ObjectProperty ;
+    rdfs:comment "Start is when an activity is deemed to have started. A start may refer to an entity, known as trigger, that initiated the activity."@en ;
+    rdfs:domain prov:Activity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "wasStartedBy" ;
+    rdfs:range prov:Entity ;
+    rdfs:subPropertyOf prov:wasInfluencedBy ;
+    owl:propertyChainAxiom (:qualifiedStart
+        prov:entity
+    ) ;
+    prov:category "expanded" ;
+    prov:component "entities-activities" ;
+    prov:inverse "started" ;
+    prov:qualifiedForm prov:Start, prov:qualifiedStart .
 
+<http://www.w3.org/ns/prov-o#>
+    a owl:Ontology ;
+    rdfs:comment """This document is published by the Provenance Working Group (http://www.w3.org/2011/prov/wiki/Main_Page). 
 
-###  http://www.w3.org/ns/prov#wasInvalidatedBy
+If you wish to make comments regarding this document, please send them to public-prov-comments@w3.org (subscribe public-prov-comments-request@w3.org, archives http://lists.w3.org/Archives/Public/public-prov-comments/). All feedback is welcome."""@en ;
+    rdfs:label "W3C PROVenance Interchange Ontology (PROV-O)"@en ;
+    rdfs:seeAlso <http://www.w3.org/TR/prov-o/>, <http://www.w3.org/ns/prov> ;
+    owl:versionIRI <http://www.w3.org/ns/prov-o-20130430> ;
+    owl:versionInfo "Recommendation version 2013-04-30"@en ;
+    prov:specializationOf <http://www.w3.org/ns/prov-o> ;
+    prov:wasRevisionOf <http://www.w3.org/ns/prov-o-20120312> .
 
-prov:wasInvalidatedBy rdf:type owl:ObjectProperty ;
-                      
-                      rdfs:label "wasInvalidatedBy" ;
-                      
-                      prov:component "entities-activities" ;
-                      
-                      prov:category "expanded" ;
-                      
-                      prov:inverse "invalidated" ;
-                      
-                      rdfs:isDefinedBy prov: ;
-                      
-                      rdfs:range prov:Activity ;
-                      
-                      rdfs:domain prov:Entity ;
-                      
-                      prov:qualifiedForm prov:Invalidation ,
-                                         prov:qualifiedInvalidation ;
-                      
-                      rdfs:subPropertyOf prov:wasInfluencedBy ;
-                      
-                      rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
-                      
-                      owl:propertyChainAxiom ( prov:qualifiedInvalidation
-                                               prov:activity
-                                             ) .
+[]
+    a owl:Axiom ;
+    rdfs:comment "A collection is an entity that provides a structure to some constituents, which are themselves entities. These constituents are said to be member of the collections."@en ;
+    owl:annotatedProperty rdfs:range ;
+    owl:annotatedSource prov:hadMember ;
+    owl:annotatedTarget prov:Entity ;
+    prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-collection" .
 
+[]
+    a owl:Axiom ;
+    rdfs:comment "hadPrimarySource property is a particular case of wasDerivedFrom (see http://www.w3.org/TR/prov-dm/#term-original-source) that aims to give credit to the source that originated some information." ;
+    owl:annotatedProperty rdfs:subPropertyOf ;
+    owl:annotatedSource prov:hadPrimarySource ;
+    owl:annotatedTarget prov:wasDerivedFrom .
 
+[]
+    a owl:Axiom ;
+    rdfs:comment "Attribution is a particular case of trace (see http://www.w3.org/TR/prov-dm/#concept-trace), in the sense that it links an entity to the agent that ascribed it." ;
+    owl:annotatedProperty rdfs:subPropertyOf ;
+    owl:annotatedSource prov:wasAttributedTo ;
+    owl:annotatedTarget prov:wasInfluencedBy ;
+    prov:definition "IF wasAttributedTo(e2,ag1,aAttr) holds, THEN wasInfluencedBy(e2,ag1) also holds. " .
 
-###  http://www.w3.org/ns/prov#wasMemberOf
+[]
+    a owl:Axiom ;
+    rdfs:comment "Derivation is a particular case of trace (see http://www.w3.org/TR/prov-dm/#term-trace), since it links an entity to another entity that contributed to its existence." ;
+    owl:annotatedProperty rdfs:subPropertyOf ;
+    owl:annotatedSource prov:wasDerivedFrom ;
+    owl:annotatedTarget prov:wasInfluencedBy .
 
-prov:wasMemberOf rdfs:label "wasMemberOf" ;
-                 
-                 rdfs:isDefinedBy prov: ;
-                 
-                 owl:inverseOf prov:hadMember .
+[]
+    a owl:Axiom ;
+    owl:annotatedProperty rdfs:range ;
+    owl:annotatedSource prov:wasInfluencedBy ;
+    owl:annotatedTarget [
+        a owl:Class ;
+        owl:unionOf (:Activity
+            prov:Agent
+            prov:Entity
+        )
+    ] ;
+    prov:definition "influencer: an identifier (o1) for an ancestor entity, activity, or agent that the former depends on;" ;
+    prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-influence" .
 
+[]
+    a owl:Axiom ;
+    owl:annotatedProperty rdfs:domain ;
+    owl:annotatedSource prov:wasInfluencedBy ;
+    owl:annotatedTarget [
+        a owl:Class ;
+        owl:unionOf (:Activity
+            prov:Agent
+            prov:Entity
+        )
+    ] ;
+    prov:definition "influencee: an identifier (o2) for an entity, activity, or agent; " ;
+    prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-influence" .
 
+[]
+    a owl:Axiom ;
+    rdfs:comment "Quotation is a particular case of derivation (see http://www.w3.org/TR/prov-dm/#term-quotation) in which an entity is derived from an original entity by copying, or \"quoting\", some or all of it. " ;
+    owl:annotatedProperty rdfs:subPropertyOf ;
+    owl:annotatedSource prov:wasQuotedFrom ;
+    owl:annotatedTarget prov:wasDerivedFrom .
 
-###  http://www.w3.org/ns/prov#wasPlanOf
-
-prov:wasPlanOf rdfs:label "wasPlanOf" ;
-               
-               rdfs:isDefinedBy prov: ;
-               
-               owl:inverseOf prov:hadPlan .
-
-
-
-###  http://www.w3.org/ns/prov#wasPrimarySourceOf
-
-prov:wasPrimarySourceOf rdfs:label "wasPrimarySourceOf" ;
-                        
-                        rdfs:isDefinedBy prov: ;
-                        
-                        owl:inverseOf prov:hadPrimarySource .
-
-
-
-###  http://www.w3.org/ns/prov#wasQuotedFrom
-
-prov:wasQuotedFrom rdf:type owl:ObjectProperty ;
-                   
-                   rdfs:label "wasQuotedFrom" ;
-                   
-                   rdfs:comment "An entity is derived from an original entity by copying, or 'quoting', some or all of it."@en ;
-                   
-                   prov:component "derivations" ;
-                   
-                   prov:category "expanded" ;
-                   
-                   prov:inverse "quotedAs" ;
-                   
-                   rdfs:domain prov:Entity ;
-                   
-                   rdfs:range prov:Entity ;
-                   
-                   prov:qualifiedForm prov:Quotation ,
-                                      prov:qualifiedQuotation ;
-                   
-                   rdfs:subPropertyOf prov:wasDerivedFrom ;
-                   
-                   rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
-                   
-                   owl:propertyChainAxiom ( prov:qualifiedQuotation
-                                            prov:entity
-                                          ) .
-[ rdf:type owl:Axiom ;
-  rdfs:comment "Quotation is a particular case of derivation (see http://www.w3.org/TR/prov-dm/#term-quotation) in which an entity is derived from an original entity by copying, or \"quoting\", some or all of it. " ;
-  owl:annotatedProperty rdfs:subPropertyOf ;
-  owl:annotatedTarget prov:wasDerivedFrom ;
-  owl:annotatedSource prov:wasQuotedFrom
-] .
-
-
-
-###  http://www.w3.org/ns/prov#wasRevisionOf
-
-prov:wasRevisionOf rdf:type owl:ObjectProperty ;
-                   
-                   rdfs:label "wasRevisionOf" ;
-                   
-                   prov:component "derivations" ;
-                   
-                   prov:category "expanded" ;
-                   
-                   prov:inverse "hadRevision" ;
-                   
-                   rdfs:comment "A revision is a derivation that revises an entity into a revised version."@en ;
-                   
-                   rdfs:range prov:Entity ;
-                   
-                   rdfs:domain prov:Entity ;
-                   
-                   prov:qualifiedForm prov:Revision ,
-                                      prov:qualifiedRevision ;
-                   
-                   rdfs:subPropertyOf prov:wasDerivedFrom ;
-                   
-                   rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
-                   
-                   owl:propertyChainAxiom ( prov:qualifiedRevision
-                                            prov:entity
-                                          ) .
-[ rdf:type owl:Axiom ;
-  rdfs:comment """Revision is a derivation (see http://www.w3.org/TR/prov-dm/#term-Revision). Moreover, according to 
+[]
+    a owl:Axiom ;
+    rdfs:comment """Revision is a derivation (see http://www.w3.org/TR/prov-dm/#term-Revision). Moreover, according to 
 http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#term-Revision 23 April 2012 'wasRevisionOf is a strict sub-relation of wasDerivedFrom since two entities e2 and e1 may satisfy wasDerivedFrom(e2,e1) without being a variant of each other.'""" ;
-  owl:annotatedProperty rdfs:subPropertyOf ;
-  owl:annotatedTarget prov:wasDerivedFrom ;
-  owl:annotatedSource prov:wasRevisionOf
-] .
-
-
-
-###  http://www.w3.org/ns/prov#wasRoleIn
-
-prov:wasRoleIn rdfs:label "wasRoleIn" ;
-               
-               rdfs:isDefinedBy prov: ;
-               
-               owl:inverseOf prov:hadRole .
-
-
-
-###  http://www.w3.org/ns/prov#wasStartedBy
-
-prov:wasStartedBy rdf:type owl:ObjectProperty ;
-                  
-                  rdfs:label "wasStartedBy" ;
-                  
-                  prov:category "expanded" ;
-                  
-                  prov:component "entities-activities" ;
-                  
-                  rdfs:comment "Start is when an activity is deemed to have started. A start may refer to an entity, known as trigger, that initiated the activity."@en ;
-                  
-                  prov:inverse "started" ;
-                  
-                  rdfs:domain prov:Activity ;
-                  
-                  rdfs:range prov:Entity ;
-                  
-                  prov:qualifiedForm prov:Start ,
-                                     prov:qualifiedStart ;
-                  
-                  rdfs:subPropertyOf prov:wasInfluencedBy ;
-                  
-                  rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
-                  
-                  owl:propertyChainAxiom ( prov:qualifiedStart
-                                           prov:entity
-                                         ) .
-
-
-
-###  http://www.w3.org/ns/prov#wasUsedBy
-
-prov:wasUsedBy rdfs:label "wasUsedBy" ;
-               
-               rdfs:isDefinedBy prov: ;
-               
-               owl:inverseOf prov:used .
-
-
-
-###  http://www.w3.org/ns/prov#wasUsedInDerivation
-
-prov:wasUsedInDerivation rdfs:label "wasUsedInDerivation" ;
-                         
-                         rdfs:isDefinedBy prov: ;
-                         
-                         owl:inverseOf prov:hadUsage .
-
-
-
-
-
-#################################################################
-#
-#    Data properties
-#
-#################################################################
-
-
-###  http://www.w3.org/ns/prov#atTime
-
-prov:atTime rdf:type owl:DatatypeProperty ;
-            
-            rdfs:label "atTime" ;
-            
-            prov:category "qualified" ;
-            
-            prov:component "entities-activities" ;
-            
-            rdfs:comment "The time at which an InstantaneousEvent occurred, in the form of xsd:dateTime."@en ;
-            
-            rdfs:range xsd:dateTime ;
-            
-            rdfs:domain prov:InstantaneousEvent ;
-            
-            prov:sharesDefinitionWith prov:InstantaneousEvent ;
-            
-            prov:unqualifiedForm prov:endedAtTime ,
-                                 prov:generatedAtTime ,
-                                 prov:invalidatedAtTime ,
-                                 prov:startedAtTime ;
-            
-            rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#endedAtTime
-
-prov:endedAtTime rdf:type owl:DatatypeProperty ;
-                 
-                 rdfs:label "endedAtTime" ;
-                 
-                 prov:category "starting-point" ;
-                 
-                 prov:component "entities-activities" ;
-                 
-                 prov:editorialNote "It is the intent that the property chain holds: (prov:qualifiedEnd o prov:atTime) rdfs:subPropertyOf prov:endedAtTime."@en ;
-                 
-                 rdfs:comment "The time at which an activity ended. See also prov:startedAtTime."@en ;
-                 
-                 rdfs:range xsd:dateTime ;
-                 
-                 rdfs:domain prov:Activity ;
-                 
-                 prov:qualifiedForm prov:End ,
-                                    prov:atTime ;
-                 
-                 rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#generatedAtTime
-
-prov:generatedAtTime rdf:type owl:DatatypeProperty ;
-                     
-                     rdfs:label "generatedAtTime" ;
-                     
-                     prov:editorialNote "It is the intent that the property chain holds: (prov:qualifiedGeneration o prov:atTime) rdfs:subPropertyOf prov:generatedAtTime."@en ;
-                     
-                     prov:category "expanded" ;
-                     
-                     prov:component "entities-activities" ;
-                     
-                     rdfs:comment "The time at which an entity was completely created and is available for use."@en ;
-                     
-                     rdfs:range xsd:dateTime ;
-                     
-                     rdfs:domain prov:Entity ;
-                     
-                     prov:qualifiedForm prov:Generation ,
-                                        prov:atTime ;
-                     
-                     rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#invalidatedAtTime
-
-prov:invalidatedAtTime rdf:type owl:DatatypeProperty ;
-                       
-                       rdfs:label "invalidatedAtTime" ;
-                       
-                       prov:category "expanded" ;
-                       
-                       prov:editorialNote "It is the intent that the property chain holds: (prov:qualifiedInvalidation o prov:atTime) rdfs:subPropertyOf prov:invalidatedAtTime."@en ;
-                       
-                       rdfs:comment "The time at which an entity was invalidated (i.e., no longer usable)."@en ;
-                       
-                       prov:component "entities-activities" ;
-                       
-                       rdfs:range xsd:dateTime ;
-                       
-                       rdfs:domain prov:Entity ;
-                       
-                       prov:qualifiedForm prov:Invalidation ,
-                                          prov:atTime ;
-                       
-                       rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#pairKey
-
-prov:pairKey rdf:type owl:DatatypeProperty ,
-                      owl:FunctionalProperty ;
-             
-             rdfs:label "pairKey" ;
-             
-             prov:constraints "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#dictionary-constraints"^^xsd:anyURI ;
-             
-             prov:n "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#expression-dictionary-membership"^^xsd:anyURI ;
-             
-             prov:dm "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#term-dictionary-membership"^^xsd:anyURI ;
-             
-             prov:definition "The key of a prov:KeyEntityPair, which is an element of a prov:Dictionary." ;
-             
-             prov:category "collections" ;
-             
-             prov:component "collections" ;
-             
-             rdfs:range rdfs:Literal ;
-             
-             rdfs:isDefinedBy prov: ;
-             
-             rdfs:domain prov:KeyEntityPair .
-
-
-
-###  http://www.w3.org/ns/prov#provenanceUriTemplate
-
-prov:provenanceUriTemplate rdf:type owl:DatatypeProperty ;
-                           
-                           rdfs:label "provenanceUriTemplate" ;
-                           
-                           prov:aq "http://www.w3.org/TR/2013/NOTE-prov-aq-20130430/"^^xsd:anyURI ;
-                           
-                           prov:category "access-and-query" ;
-                           
-                           rdfs:comment "Relates a provenance service to a URI template string for constructing provenance-URIs."@en ;
-                           
-                           rdfs:isDefinedBy prov: .
-
-
-
-###  http://www.w3.org/ns/prov#removedKey
-
-prov:removedKey rdf:type owl:DatatypeProperty ;
-                
-                rdfs:label "removedKey" ;
-                
-                prov:constraints "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#dictionary-constraints"^^xsd:anyURI ;
-                
-                prov:n "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#expression-dictionary-removal"^^xsd:anyURI ;
-                
-                prov:dm "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#term-dictionary-removal"^^xsd:anyURI ;
-                
-                prov:definition "The key removed in a Removal." ;
-                
-                prov:component "collections" ;
-                
-                prov:category "collections" ;
-                
-                rdfs:range rdfs:Literal ;
-                
-                rdfs:isDefinedBy prov: ;
-                
-                rdfs:domain prov:Removal .
-
-
-
-###  http://www.w3.org/ns/prov#startedAtTime
-
-prov:startedAtTime rdf:type owl:DatatypeProperty ;
-                   
-                   rdfs:label "startedAtTime" ;
-                   
-                   prov:category "starting-point" ;
-                   
-                   prov:component "entities-activities" ;
-                   
-                   prov:editorialNote "It is the intent that the property chain holds: (prov:qualifiedStart o prov:atTime) rdfs:subPropertyOf prov:startedAtTime."@en ;
-                   
-                   rdfs:comment "The time at which an activity started. See also prov:endedAtTime."@en ;
-                   
-                   rdfs:range xsd:dateTime ;
-                   
-                   rdfs:domain prov:Activity ;
-                   
-                   prov:qualifiedForm prov:Start ,
-                                      prov:atTime ;
-                   
-                   rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#value
-
-prov:value rdf:type owl:DatatypeProperty ;
-           
-           rdfs:label "value" ;
-           
-           prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-attribute-value"^^xsd:anyURI ;
-           
-           prov:definition "Provides a value that is a direct representation of an entity."@en ;
-           
-           prov:editorialNote "The editor's definition comes from http://www.w3.org/TR/rdf-primer/#rdfvalue" ,
-                              "This property serves the same purpose as rdf:value, but has been reintroduced to avoid some of the definitional ambiguity in the RDF specification (specifically, 'may be used in describing structured values')."@en ;
-           
-           prov:component "entities-activities" ;
-           
-           prov:category "expanded" ;
-           
-           rdfs:domain prov:Entity ;
-           
-           rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-
-
-#################################################################
-#
-#    Classes
-#
-#################################################################
-
-
-###  http://www.w3.org/2002/07/owl#Thing
-
-owl:Thing rdf:type owl:Class .
-
-
-
-###  http://www.w3.org/ns/prov#Accept
-
-prov:Accept rdf:type owl:Class ;
-            
-            rdfs:label "Accept"@en ;
-            
-            rdfs:subClassOf prov:Activity ;
-            
-            prov:definition "Activity that identifies the acceptance of a resource (e.g., an article in a conference)"@en .
-
-
-
-###  http://www.w3.org/ns/prov#Activity
-
-prov:Activity rdf:type owl:Class ;
-              
-              rdfs:label "Activity" ;
-              
-              owl:disjointWith prov:Entity ;
-              
-              prov:constraints "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
-              
-              prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Activity"^^xsd:anyURI ;
-              
-              prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Activity"^^xsd:anyURI ;
-              
-              prov:category "starting-point" ;
-              
-              prov:component "entities-activities" ;
-              
-              prov:definition "An activity is something that occurs over a period of time and acts upon or with entities; it may include consuming, processing, transforming, modifying, relocating, using, or generating entities." ;
-              
-              rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#ActivityInfluence
-
-prov:ActivityInfluence rdf:type owl:Class ;
-                       
-                       rdfs:label "ActivityInfluence" ;
-                       
-                       rdfs:subClassOf prov:Influence ,
-                                       [ rdf:type owl:Restriction ;
-                                         owl:onProperty prov:hadActivity ;
-                                         owl:maxCardinality "0"^^xsd:nonNegativeInteger
-                                       ] ;
-                       
-                       owl:disjointWith prov:EntityInfluence ;
-                       
-                       rdfs:comment "ActivityInfluence provides additional descriptions of an Activity's binary influence upon any other kind of resource. Instances of ActivityInfluence use the prov:activity property to cite the influencing Activity."@en ;
-                       
-                       prov:category "qualified" ;
-                       
-                       prov:editorsDefinition "ActivitiyInfluence is the capacity of an activity to have an effect on the character, development, or behavior of another by means of generation, invalidation, communication, or other."@en ;
-                       
-                       rdfs:comment "It is not recommended that the type ActivityInfluence be asserted without also asserting one of its more specific subclasses."@en ;
-                       
-                       rdfs:seeAlso prov:activity ;
-                       
-                       rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#Agent
-
-prov:Agent rdf:type owl:Class ;
-           
-           rdfs:label "Agent" ;
-           
-           owl:disjointWith prov:InstantaneousEvent ;
-           
-           prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-agent"^^xsd:anyURI ;
-           
-           prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Agent"^^xsd:anyURI ;
-           
-           prov:definition "An agent is something that bears some form of responsibility for an activity taking place, for the existence of an entity, or for another agent's activity. "@en ;
-           
-           prov:category "starting-point" ;
-           
-           prov:component "agents-responsibility" ;
-           
-           rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#AgentInfluence
-
-prov:AgentInfluence rdf:type owl:Class ;
-                    
-                    rdfs:label "AgentInfluence" ;
-                    
-                    rdfs:subClassOf prov:Influence ;
-                    
-                    prov:editorsDefinition "AgentInfluence is the capacity of an agent to have an effect on the character, development, or behavior of another by means of attribution, association, delegation, or other."@en ;
-                    
-                    rdfs:comment "AgentInfluence provides additional descriptions of an Agent's binary influence upon any other kind of resource. Instances of AgentInfluence use the prov:agent property to cite the influencing Agent."@en ;
-                    
-                    prov:category "qualified" ;
-                    
-                    rdfs:comment "It is not recommended that the type AgentInfluence be asserted without also asserting one of its more specific subclasses."@en ;
-                    
-                    rdfs:seeAlso prov:agent ;
-                    
-                    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#Association
-
-prov:Association rdf:type owl:Class ;
-                 
-                 rdfs:label "Association" ;
-                 
-                 rdfs:subClassOf prov:AgentInfluence ;
-                 
-                 prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Association"^^xsd:anyURI ;
-                 
-                 prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Association"^^xsd:anyURI ;
-                 
-                 prov:component "agents-responsibility" ;
-                 
-                 prov:definition "An activity association is an assignment of responsibility to an agent for an activity, indicating that the agent had a role in the activity. It further allows for a plan to be specified, which is the plan intended by the agent to achieve some goals in the context of this activity."@en ;
-                 
-                 rdfs:comment "An instance of prov:Association provides additional descriptions about the binary prov:wasAssociatedWith relation from an prov:Activity to some prov:Agent that had some responsiblity for it. For example, :baking prov:wasAssociatedWith :baker; prov:qualifiedAssociation [ a prov:Association; prov:agent :baker; :foo :bar ]."@en ;
-                 
-                 prov:category "qualified" ;
-                 
-                 prov:unqualifiedForm prov:wasAssociatedWith ;
-                 
-                 rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#Attribution
-
-prov:Attribution rdf:type owl:Class ;
-                 
-                 rdfs:label "Attribution" ;
-                 
-                 rdfs:subClassOf prov:AgentInfluence ;
-                 
-                 prov:constraints "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
-                 
-                 prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-attribution"^^xsd:anyURI ;
-                 
-                 prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-attribution"^^xsd:anyURI ;
-                 
-                 prov:component "agents-responsibility" ;
-                 
-                 prov:definition """Attribution is the ascribing of an entity to an agent.
-
-When an entity e is attributed to agent ag, entity e was generated by some unspecified activity that in turn was associated to agent ag. Thus, this relation is useful when the activity is not known, or irrelevant."""@en ;
-                 
-                 prov:category "qualified" ;
-                 
-                 rdfs:comment "An instance of prov:Attribution provides additional descriptions about the binary prov:wasAttributedTo relation from an prov:Entity to some prov:Agent that had some responsible for it. For example, :cake prov:wasAttributedTo :baker; prov:qualifiedAttribution [ a prov:Attribution; prov:entity :baker; :foo :bar ]."@en ;
-                 
-                 prov:unqualifiedForm prov:wasAttributedTo ;
-                 
-                 rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#Bundle
-
-prov:Bundle rdf:type owl:Class ;
-            
-            rdfs:label "Bundle" ;
-            
-            rdfs:subClassOf prov:Entity ;
-            
-            prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-bundle-entity"^^xsd:anyURI ;
-            
-            prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-bundle-declaration"^^xsd:anyURI ;
-            
-            prov:definition "A bundle is a named set of provenance descriptions, and is itself an Entity, so allowing provenance of provenance to be expressed."@en ;
-            
-            rdfs:comment "Note that there are kinds of bundles (e.g. handwritten letters, audio recordings, etc.) that are not expressed in PROV-O, but can be still be described by PROV-O."@en ;
-            
-            prov:category "expanded" ;
-            
-            rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#Collection
-
-prov:Collection rdf:type owl:Class ;
-                
-                rdfs:label "Collection" ;
-                
-                rdfs:subClassOf prov:Entity ;
-                
-                prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-collection"^^xsd:anyURI ;
-                
-                prov:category "expanded" ;
-                
-                prov:definition "A collection is an entity that provides a structure to some constituents, which are themselves entities. These constituents are said to be member of the collections."@en ;
-                
-                prov:component "collections" ;
-                
-                rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#Communication
-
-prov:Communication rdf:type owl:Class ;
-                   
-                   rdfs:label "Communication" ;
-                   
-                   rdfs:subClassOf prov:ActivityInfluence ;
-                   
-                   prov:constraints "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
-                   
-                   prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Communication"^^xsd:anyURI ;
-                   
-                   prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-wasInformedBy"^^xsd:anyURI ;
-                   
-                   prov:category "qualified" ;
-                   
-                   prov:definition "Communication is the exchange of an entity by two activities, one activity using the entity generated by the other." ;
-                   
-                   prov:component "entities-activities" ;
-                   
-                   rdfs:comment "An instance of prov:Communication provides additional descriptions about the binary prov:wasInformedBy relation from an informed prov:Activity to the prov:Activity that informed it. For example, :you_jumping_off_bridge prov:wasInformedBy :everyone_else_jumping_off_bridge; prov:qualifiedCommunication [ a prov:Communication; prov:activity :everyone_else_jumping_off_bridge; :foo :bar ]."@en ;
-                   
-                   prov:unqualifiedForm prov:wasInformedBy ;
-                   
-                   rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#Contribute
-
-prov:Contribute rdf:type owl:Class ;
-                
-                rdfs:label """Contribute
-"""@en ;
-                
-                rdfs:subClassOf prov:Activity ;
-                
-                prov:definition "Activity that identifies any contribution of an agent to a resource. "@en .
-
-
-
-###  http://www.w3.org/ns/prov#Contributor
-
-prov:Contributor rdf:type owl:Class ;
-                 
-                 rdfs:label "Contributor"@en ;
-                 
-                 rdfs:subClassOf prov:Role ;
-                 
-                 prov:definition "Role with the function of having responsibility for making contributions to a resource. The Agent assigned to this role is associated with a Modify or Create Activities"@en .
-
-
-
-###  http://www.w3.org/ns/prov#Copyright
-
-prov:Copyright rdf:type owl:Class ;
-               
-               rdfs:label "Copyright"@en ;
-               
-               rdfs:subClassOf prov:Activity ;
-               
-               prov:definition "Activity that identifies the Copyrighting activity associated to a resource."@en .
-
-
-
-###  http://www.w3.org/ns/prov#Create
-
-prov:Create rdf:type owl:Class ;
-            
-            rdfs:label "Create"@en ;
-            
-            rdfs:subClassOf prov:Contribute ;
-            
-            prov:definition "Activity that identifies the creation of a resource"@en .
-
-
-
-###  http://www.w3.org/ns/prov#Creator
-
-prov:Creator rdf:type owl:Class ;
-             
-             rdfs:label "Creator"@en ;
-             
-             rdfs:subClassOf prov:Contributor ;
-             
-             prov:definition "Role with the function of creating a resource. The Agent assigned to this role is associated with a Create Activity"@en .
-
-
-
-###  http://www.w3.org/ns/prov#Delegation
-
-prov:Delegation rdf:type owl:Class ;
-                
-                rdfs:label "Delegation" ;
-                
-                rdfs:subClassOf prov:AgentInfluence ;
-                
-                prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-delegation"^^xsd:anyURI ;
-                
-                prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-delegation"^^xsd:anyURI ;
-                
-                prov:component "agents-responsibility" ;
-                
-                prov:category "qualified" ;
-                
-                rdfs:comment "An instance of prov:Delegation provides additional descriptions about the binary prov:actedOnBehalfOf relation from a performing prov:Agent to some prov:Agent for whom it was performed. For example, :mixing prov:wasAssociatedWith :toddler . :toddler prov:actedOnBehalfOf :mother; prov:qualifiedDelegation [ a prov:Delegation; prov:entity :mother; :foo :bar ]."@en ;
-                
-                prov:definition """Delegation is the assignment of authority and responsibility to an agent (by itself or by another agent) to carry out a specific activity as a delegate or representative, while the agent it acts on behalf of retains some responsibility for the outcome of the delegated work.
-
-For example, a student acted on behalf of his supervisor, who acted on behalf of the department chair, who acted on behalf of the university; all those agents are responsible in some way for the activity that took place but we do not say explicitly who bears responsibility and to what degree."""@en ;
-                
-                prov:unqualifiedForm prov:actedOnBehalfOf ;
-                
-                rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#Derivation
-
-prov:Derivation rdf:type owl:Class ;
-                
-                rdfs:label "Derivation" ;
-                
-                rdfs:subClassOf prov:EntityInfluence ;
-                
-                prov:constraints "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
-                
-                prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Derivation"^^xsd:anyURI ;
-                
-                prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#Derivation-Relation"^^xsd:anyURI ;
-                
-                prov:category "qualified" ;
-                
-                prov:component "derivations" ;
-                
-                prov:definition "A derivation is a transformation of an entity into another, an update of an entity resulting in a new one, or the construction of a new entity based on a pre-existing entity."@en ;
-                
-                rdfs:comment "An instance of prov:Derivation provides additional descriptions about the binary prov:wasDerivedFrom relation from some derived prov:Entity to another prov:Entity from which it was derived. For example, :chewed_bubble_gum prov:wasDerivedFrom :unwrapped_bubble_gum; prov:qualifiedDerivation [ a prov:Derivation; prov:entity :unwrapped_bubble_gum; :foo :bar ]."@en ,
-                             "The more specific forms of prov:Derivation (i.e., prov:Revision, prov:Quotation, prov:PrimarySource) should be asserted if they apply."@en ;
-                
-                prov:unqualifiedForm prov:wasDerivedFrom ;
-                
-                rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#Dictionary
-
-prov:Dictionary rdf:type owl:Class ;
-                
-                rdfs:label "Dictionary" ;
-                
-                prov:dm "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#dictionary-conceptual-definition"^^xsd:anyURI ;
-                
-                prov:constraints "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#dictionary-constraints"^^xsd:anyURI ;
-                
-                prov:n "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#expression-dictionary"^^xsd:anyURI ;
-                
-                prov:definition "A dictionary is an entity that provides a structure to some constituents, which are themselves entities. These constituents are said to be member of the dictionary." ;
-                
-                rdfs:comment "A given dictionary forms a given structure for its members. A different structure (obtained either by insertion or removal of members) constitutes a different dictionary." ,
-                             "This concept allows for the provenance of the dictionary, but also of its constituents to be expressed. Such a notion of dictionary corresponds to a wide variety of concrete data structures, such as a maps or associative arrays." ;
-                
-                prov:category "collections" ;
-                
-                prov:component "collections" ;
-                
-                rdfs:isDefinedBy prov: .
-
-
-
-###  http://www.w3.org/ns/prov#DirectQueryService
-
-prov:DirectQueryService rdf:type owl:Class ;
-                        
-                        rdfs:label "ProvenanceService" ;
-                        
-                        rdfs:subClassOf prov:SoftwareAgent ;
-                        
-                        prov:aq "http://www.w3.org/TR/2013/NOTE-prov-aq-20130430/#provenance-query-service-discovery"^^xsd:anyURI ;
-                        
-                        prov:category "access-and-query" ;
-                        
-                        rdfs:comment "Type for a generic provenance query service. Mainly for use in RDF provenance query service descriptions, to facilitate discovery in linked data environments." ;
-                        
-                        rdfs:isDefinedBy prov: .
-
-
-
-###  http://www.w3.org/ns/prov#EmptyCollection
-
-prov:EmptyCollection rdf:type owl:Class ;
-                     
-                     rdfs:label "EmptyCollection"@en ;
-                     
-                     rdfs:subClassOf prov:Collection ;
-                     
-                     prov:category "expanded" ;
-                     
-                     prov:definition "An empty collection is a collection without members."@en ;
-                     
-                     prov:component "collections" ;
-                     
-                     rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#EmptyDictionary
-
-prov:EmptyDictionary rdf:type owl:Class ;
-                     
-                     rdfs:label "Empty Dictionary" ;
-                     
-                     rdfs:subClassOf prov:Dictionary ,
-                                     prov:EmptyCollection ;
-                     
-                     prov:dm "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#dictionary-conceptual-definition"^^xsd:anyURI ;
-                     
-                     prov:constraints "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#dictionary-constraints"^^xsd:anyURI ;
-                     
-                     prov:n "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#expression-dictionary"^^xsd:anyURI ;
-                     
-                     prov:component "collections" ;
-                     
-                     prov:definition "An empty dictionary (i.e. has no members)." ;
-                     
-                     prov:category "collections" ;
-                     
-                     rdfs:isDefinedBy prov: .
-
-
-
-###  http://www.w3.org/ns/prov#End
-
-prov:End rdf:type owl:Class ;
-         
-         rdfs:label "End" ;
-         
-         rdfs:subClassOf prov:EntityInfluence ,
-                         prov:InstantaneousEvent ;
-         
-         prov:constraints "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
-         
-         prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-End"^^xsd:anyURI ;
-         
-         prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-End"^^xsd:anyURI ;
-         
-         prov:component "entities-activities" ;
-         
-         rdfs:comment "An instance of prov:End provides additional descriptions about the binary prov:wasEndedBy relation from some ended prov:Activity to an prov:Entity that ended it. For example, :ball_game prov:wasEndedBy :buzzer; prov:qualifiedEnd [ a prov:End; prov:entity :buzzer; :foo :bar; prov:atTime '2012-03-09T08:05:08-05:00'^^xsd:dateTime ]."@en ;
-         
-         prov:definition "End is when an activity is deemed to have been ended by an entity, known as trigger. The activity no longer exists after its end. Any usage, generation, or invalidation involving an activity precedes the activity's end. An end may refer to a trigger entity that terminated the activity, or to an activity, known as ender that generated the trigger."@en ;
-         
-         prov:category "qualified" ;
-         
-         prov:unqualifiedForm prov:wasEndedBy ;
-         
-         rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#Entity
-
-prov:Entity rdf:type owl:Class ;
-            
-            rdfs:label "Entity" ;
-            
-            owl:disjointWith prov:InstantaneousEvent ;
-            
-            prov:constraints "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
-            
-            prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-entity"^^xsd:anyURI ;
-            
-            prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Entity"^^xsd:anyURI ;
-            
-            prov:definition "An entity is a physical, digital, conceptual, or other kind of thing with some fixed aspects; entities may be real or imaginary. "@en ;
-            
-            prov:component "entities-activities" ;
-            
-            prov:category "starting-point" ;
-            
-            rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#EntityInfluence
-
-prov:EntityInfluence rdf:type owl:Class ;
-                     
-                     rdfs:label "EntityInfluence" ;
-                     
-                     rdfs:subClassOf prov:Influence ;
-                     
-                     prov:editorsDefinition "EntityInfluence is the capacity of an entity to have an effect on the character, development, or behavior of another by means of usage, start, end, derivation, or other. "@en ;
-                     
-                     rdfs:comment "EntityInfluence provides additional descriptions of an Entity's binary influence upon any other kind of resource. Instances of EntityInfluence use the prov:entity property to cite the influencing Entity."@en ,
-                                  "It is not recommended that the type EntityInfluence be asserted without also asserting one of its more specific subclasses."@en ;
-                     
-                     prov:category "qualified" ;
-                     
-                     rdfs:seeAlso prov:entity ;
-                     
-                     rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#Generation
-
-prov:Generation rdf:type owl:Class ;
-                
-                rdfs:label "Generation" ;
-                
-                rdfs:subClassOf prov:ActivityInfluence ,
-                                prov:InstantaneousEvent ;
-                
-                prov:constraints "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
-                
-                prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Generation"^^xsd:anyURI ;
-                
-                prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Generation"^^xsd:anyURI ;
-                
-                prov:component "entities-activities" ;
-                
-                rdfs:comment "An instance of prov:Generation provides additional descriptions about the binary prov:wasGeneratedBy relation from a generated prov:Entity to the prov:Activity that generated it. For example, :cake prov:wasGeneratedBy :baking; prov:qualifiedGeneration [ a prov:Generation; prov:activity :baking; :foo :bar ]."@en ;
-                
-                prov:definition "Generation is the completion of production of a new entity by an activity. This entity did not exist before generation and becomes available for usage after this generation."@en ;
-                
-                prov:category "qualified" ;
-                
-                prov:unqualifiedForm prov:wasGeneratedBy ;
-                
-                rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#Influence
-
-prov:Influence rdf:type owl:Class ;
-               
-               rdfs:label "Influence" ;
-               
-               prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-influence"^^xsd:anyURI ;
-               
-               prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-influence"^^xsd:anyURI ;
-               
-               prov:category "qualified" ;
-               
-               rdfs:comment "An instance of prov:Influence provides additional descriptions about the binary prov:wasInfluencedBy relation from some influenced Activity, Entity, or Agent to the influencing Activity, Entity, or Agent. For example, :stomach_ache prov:wasInfluencedBy :spoon; prov:qualifiedInfluence [ a prov:Influence; prov:entity :spoon; :foo :bar ] . Because prov:Influence is a broad relation, the more specific relations (Communication, Delegation, End, etc.) should be used when applicable."@en ,
-                            "Because prov:Influence is a broad relation, its most specific subclasses (e.g. prov:Communication, prov:Delegation, prov:End, prov:Revision, etc.) should be used when applicable."@en ;
-               
-               prov:definition "Influence is the capacity of an entity, activity, or agent to have an effect on the character, development, or behavior of another by means of usage, start, end, generation, invalidation, communication, derivation, attribution, association, or delegation."@en ;
-               
-               prov:component "derivations" ;
-               
-               prov:unqualifiedForm prov:wasInfluencedBy ;
-               
-               rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#Insertion
-
-prov:Insertion rdf:type owl:Class ;
-               
-               rdfs:label "Insertion" ;
-               
-               rdfs:subClassOf prov:Derivation ,
-                               [ rdf:type owl:Restriction ;
-                                 owl:onProperty prov:dictionary ;
-                                 owl:cardinality "1"^^xsd:nonNegativeInteger
-                               ] ,
-                               [ rdf:type owl:Restriction ;
-                                 owl:onProperty prov:insertedKeyEntityPair ;
-                                 owl:minCardinality "1"^^xsd:nonNegativeInteger
-                               ] ;
-               
-               prov:constraints "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#dictionary-constraints"^^xsd:anyURI ;
-               
-               prov:n "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#expression-dictionary-insertion"^^xsd:anyURI ;
-               
-               prov:dm "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#term-dictionary-insertion"^^xsd:anyURI ;
-               
-               prov:definition "Insertion is a derivation that describes the transformation of a dictionary into another, by insertion of one or more key-entity pairs." ;
-               
-               prov:category "collections" ;
-               
-               prov:component "collections" ;
-               
-               rdfs:isDefinedBy prov: ;
-               
-               prov:unqualifiedForm prov:derivedByInsertionFrom .
-
-
-
-###  http://www.w3.org/ns/prov#InstantaneousEvent
-
-prov:InstantaneousEvent rdf:type owl:Class ;
-                        
-                        rdfs:label "InstantaneousEvent" ;
-                        
-                        prov:constraints "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#dfn-event"^^xsd:anyURI ;
-                        
-                        prov:definition "The PROV data model is implicitly based on a notion of instantaneous events (or just events), that mark transitions in the world. Events include generation, usage, or invalidation of entities, as well as starting or ending of activities. This notion of event is not first-class in the data model, but it is useful for explaining its other concepts and its semantics."@en ;
-                        
-                        prov:component "entities-activities" ;
-                        
-                        prov:category "qualified" ;
-                        
-                        rdfs:comment "An instantaneous event, or event for short, happens in the world and marks a change in the world, in its activities and in its entities. The term 'event' is commonly used in process algebra with a similar meaning. Events represent communications or interactions; they are assumed to be atomic and instantaneous."@en ;
-                        
-                        rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#Invalidation
-
-prov:Invalidation rdf:type owl:Class ;
-                  
-                  rdfs:label "Invalidation" ;
-                  
-                  rdfs:subClassOf prov:ActivityInfluence ,
-                                  prov:InstantaneousEvent ;
-                  
-                  prov:constraints "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
-                  
-                  prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Invalidation"^^xsd:anyURI ;
-                  
-                  prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Invalidation"^^xsd:anyURI ;
-                  
-                  prov:component "entities-activities" ;
-                  
-                  prov:definition "Invalidation is the start of the destruction, cessation, or expiry of an existing entity by an activity. The entity is no longer available for use (or further invalidation) after invalidation. Any generation or usage of an entity precedes its invalidation." ;
-                  
-                  prov:category "qualified" ;
-                  
-                  rdfs:comment "An instance of prov:Invalidation provides additional descriptions about the binary prov:wasInvalidatedBy relation from an invalidated prov:Entity to the prov:Activity that invalidated it. For example, :uncracked_egg prov:wasInvalidatedBy :baking; prov:qualifiedInvalidation [ a prov:Invalidation; prov:activity :baking; :foo :bar ]."@en ;
-                  
-                  prov:unqualifiedForm prov:wasInvalidatedBy ;
-                  
-                  rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#KeyEntityPair
-
-prov:KeyEntityPair rdf:type owl:Class ;
-                   
-                   rdfs:label "Key-Entity Pair" ;
-                   
-                   rdfs:subClassOf [ rdf:type owl:Restriction ;
-                                     owl:onProperty prov:pairKey ;
-                                     owl:cardinality "1"^^xsd:nonNegativeInteger
-                                   ] ,
-                                   [ rdf:type owl:Restriction ;
-                                     owl:onProperty prov:pairEntity ;
-                                     owl:cardinality "1"^^xsd:nonNegativeInteger
-                                   ] ;
-                   
-                   prov:constraints "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#dictionary-constraints"^^xsd:anyURI ;
-                   
-                   prov:n "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#expression-dictionary-membership"^^xsd:anyURI ;
-                   
-                   prov:dm "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#term-dictionary-membership"^^xsd:anyURI ;
-                   
-                   prov:definition "A key-entity pair. Part of a prov:Dictionary through prov:hadDictionaryMember. The key is any RDF Literal, the value is a prov:Entity." ;
-                   
-                   prov:category "collections" ;
-                   
-                   prov:component "collections" ;
-                   
-                   rdfs:isDefinedBy prov: .
-
-
-
-###  http://www.w3.org/ns/prov#Location
-
-prov:Location rdf:type owl:Class ;
-              
-              rdfs:label "Location" ;
-              
-              prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-attribute-location"^^xsd:anyURI ;
-              
-              prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-attribute"^^xsd:anyURI ;
-              
-              prov:definition "A location can be an identifiable geographic place (ISO 19112), but it can also be a non-geographic place such as a directory, row, or column. As such, there are numerous ways in which location can be expressed, such as by a coordinate, address, landmark, and so forth."@en ;
-              
-              prov:category "expanded" ;
-              
-              rdfs:seeAlso prov:atLocation ;
-              
-              rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#Modify
-
-prov:Modify rdf:type owl:Class ;
-            
-            rdfs:label "Modify"@en ;
-            
-            rdfs:subClassOf prov:Activity ;
-            
-            prov:definition "Activity that identifies the modification of a resource. "@en .
-
-
-
-###  http://www.w3.org/ns/prov#Organization
-
-prov:Organization rdf:type owl:Class ;
-                  
-                  rdfs:label "Organization" ;
-                  
-                  rdfs:subClassOf prov:Agent ;
-                  
-                  prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-agent"^^xsd:anyURI ;
-                  
-                  prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-types"^^xsd:anyURI ;
-                  
-                  prov:definition "An organization is a social or legal institution such as a company, society, etc." ;
-                  
-                  prov:category "expanded" ;
-                  
-                  prov:component "agents-responsibility" ;
-                  
-                  rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#Person
-
-prov:Person rdf:type owl:Class ;
-            
-            rdfs:label "Person" ;
-            
-            rdfs:subClassOf prov:Agent ;
-            
-            prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-agent"^^xsd:anyURI ;
-            
-            prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-types"^^xsd:anyURI ;
-            
-            prov:component "agents-responsibility" ;
-            
-            prov:definition "Person agents are people."@en ;
-            
-            prov:category "expanded" ;
-            
-            rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#Plan
-
-prov:Plan rdf:type owl:Class ;
-          
-          rdfs:label "Plan" ;
-          
-          rdfs:subClassOf prov:Entity ;
-          
-          prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Association"^^xsd:anyURI ;
-          
-          prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Association"^^xsd:anyURI ;
-          
-          prov:definition "A plan is an entity that represents a set of actions or steps intended by one or more agents to achieve some goals." ;
-          
-          prov:component "agents-responsibility" ;
-          
-          prov:category "qualified" ,
-                        "expanded" ;
-          
-          rdfs:comment "There exist no prescriptive requirement on the nature of plans, their representation, the actions or steps they consist of, or their intended goals. Since plans may evolve over time, it may become necessary to track their provenance, so plans themselves are entities. Representing the plan explicitly in the provenance can be useful for various tasks: for example, to validate the execution as represented in the provenance record, to manage expectation failures, or to provide explanations."@en ;
-          
-          rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#PrimarySource
-
-prov:PrimarySource rdf:type owl:Class ;
-                   
-                   rdfs:label "PrimarySource" ;
-                   
-                   rdfs:subClassOf prov:Derivation ;
-                   
-                   prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-primary-source"^^xsd:anyURI ;
-                   
-                   prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-original-source"^^xsd:anyURI ;
-                   
-                   prov:category "qualified" ;
-                   
-                   prov:definition """A primary source for a topic refers to something produced by some agent with direct experience and knowledge about the topic, at the time of the topic's study, without benefit from hindsight.
-
-Because of the directness of primary sources, they 'speak for themselves' in ways that cannot be captured through the filter of secondary sources. As such, it is important for secondary sources to reference those primary sources from which they were derived, so that their reliability can be investigated.
-
-A primary source relation is a particular case of derivation of secondary materials from their primary sources. It is recognized that the determination of primary sources can be up to interpretation, and should be done according to conventions accepted within the application's domain."""@en ;
-                   
-                   rdfs:comment "An instance of prov:PrimarySource provides additional descriptions about the binary prov:hadPrimarySource relation from some secondary prov:Entity to an earlier, primary prov:Entity. For example, :blog prov:hadPrimarySource :newsArticle; prov:qualifiedPrimarySource [ a prov:PrimarySource; prov:entity :newsArticle; :foo :bar ] ."@en ;
-                   
-                   prov:component "derivations" ;
-                   
-                   prov:unqualifiedForm prov:hadPrimarySource ;
-                   
-                   rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#Publish
-
-prov:Publish rdf:type owl:Class ;
-             
-             rdfs:label "Publish"@en ;
-             
-             rdfs:subClassOf prov:Activity ;
-             
-             prov:definition "Activity that identifies the publication of a resource"@en .
-
-
-
-###  http://www.w3.org/ns/prov#Publisher
-
-prov:Publisher rdf:type owl:Class ;
-               
-               rdfs:label "Publisher"@en ;
-               
-               rdfs:subClassOf prov:Role ;
-               
-               prov:definition "Role with the function of publishing a resource. The Agent assigned to this role is associated with a Publish Activity"@en .
-
-
-
-###  http://www.w3.org/ns/prov#Quotation
-
-prov:Quotation rdf:type owl:Class ;
-               
-               rdfs:label "Quotation" ;
-               
-               rdfs:subClassOf prov:Derivation ;
-               
-               prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-quotation"^^xsd:anyURI ;
-               
-               prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-quotation"^^xsd:anyURI ;
-               
-               prov:category "qualified" ;
-               
-               prov:component "derivations" ;
-               
-               prov:definition "A quotation is the repeat of (some or all of) an entity, such as text or image, by someone who may or may not be its original author. Quotation is a particular case of derivation."@en ;
-               
-               rdfs:comment "An instance of prov:Quotation provides additional descriptions about the binary prov:wasQuotedFrom relation from some taken prov:Entity from an earlier, larger prov:Entity. For example, :here_is_looking_at_you_kid prov:wasQuotedFrom :casablanca_script; prov:qualifiedQuotation [ a prov:Quotation; prov:entity :casablanca_script; :foo :bar ]."@en ;
-               
-               prov:unqualifiedForm prov:wasQuotedFrom ;
-               
-               rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#Removal
-
-prov:Removal rdf:type owl:Class ;
-             
-             rdfs:label "Removal" ;
-             
-             rdfs:subClassOf prov:Derivation ,
-                             [ rdf:type owl:Restriction ;
-                               owl:onProperty prov:removedKey ;
-                               owl:minCardinality "1"^^xsd:nonNegativeInteger
-                             ] ,
-                             [ rdf:type owl:Restriction ;
-                               owl:onProperty prov:dictionary ;
-                               owl:cardinality "1"^^xsd:nonNegativeInteger
-                             ] ;
-             
-             prov:constraints "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#dictionary-constraints"^^xsd:anyURI ;
-             
-             prov:n "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#expression-dictionary-removal"^^xsd:anyURI ;
-             
-             prov:dm "http://www.w3.org/TR/2013/NOTE-prov-dictionary-20130430/#term-dictionary-removal"^^xsd:anyURI ;
-             
-             prov:category "collections" ;
-             
-             prov:component "collections" ;
-             
-             prov:definition "Removal is a derivation that describes the transformation of a dictionary into another, by removing one or more keys." ;
-             
-             rdfs:isDefinedBy prov: ;
-             
-             prov:unqualifiedForm prov:derivedByRemovalFrom .
-
-
-
-###  http://www.w3.org/ns/prov#Replace
-
-prov:Replace rdf:type owl:Class ;
-             
-             rdfs:label "Replace"@en ;
-             
-             rdfs:subClassOf prov:Activity ;
-             
-             prov:definition "Activity that identifies the replacement of a resource."@en .
-
-
-
-###  http://www.w3.org/ns/prov#Revision
-
-prov:Revision rdf:type owl:Class ;
-              
-              rdfs:label "Revision" ;
-              
-              rdfs:subClassOf prov:Derivation ;
-              
-              prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-revision"^^xsd:anyURI ;
-              
-              prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Revision"^^xsd:anyURI ;
-              
-              prov:category "qualified" ;
-              
-              prov:component "derivations" ;
-              
-              prov:definition "A revision is a derivation for which the resulting entity is a revised version of some original. The implication here is that the resulting entity contains substantial content from the original. Revision is a particular case of derivation."@en ;
-              
-              rdfs:comment "An instance of prov:Revision provides additional descriptions about the binary prov:wasRevisionOf relation from some newer prov:Entity to an earlier prov:Entity. For example, :draft_2 prov:wasRevisionOf :draft_1; prov:qualifiedRevision [ a prov:Revision; prov:entity :draft_1; :foo :bar ]."@en ;
-              
-              prov:unqualifiedForm prov:wasRevisionOf ;
-              
-              rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#RightsAssignment
-
-prov:RightsAssignment rdf:type owl:Class ;
-                      
-                      rdfs:label "RightsAssignment"@en ;
-                      
-                      rdfs:subClassOf prov:Activity ;
-                      
-                      prov:definition "Activity that identifies the rights assignment of a resource."@en .
-
-
-
-###  http://www.w3.org/ns/prov#RightsHolder
-
-prov:RightsHolder rdf:type owl:Class ;
-                  
-                  rdfs:label "RightsHolder"@en ;
-                  
-                  rdfs:subClassOf prov:Role ;
-                  
-                  prov:definition "Role with the function of owning or managing rights over a resource. The Agent assigned to this role is associated with a RightsAssignment Activity"@en .
-
-
-
-###  http://www.w3.org/ns/prov#Role
-
-prov:Role rdf:type owl:Class ;
-          
-          rdfs:label "Role" ;
-          
-          prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-attribute-role"^^xsd:anyURI ;
-          
-          prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-attribute"^^xsd:anyURI ;
-          
-          prov:definition "A role is the function of an entity or agent with respect to an activity, in the context of a usage, generation, invalidation, association, start, and end."@en ;
-          
-          prov:category "qualified" ;
-          
-          prov:component "agents-responsibility" ;
-          
-          rdfs:seeAlso prov:hadRole ;
-          
-          rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#ServiceDescription
-
-prov:ServiceDescription rdf:type owl:Class ;
-                        
-                        rdfs:label "ServiceDescription" ;
-                        
-                        rdfs:subClassOf prov:SoftwareAgent ;
-                        
-                        prov:aq "http://www.w3.org/TR/2013/NOTE-prov-aq-20130430/#provenance-query-service-discovery"^^xsd:anyURI ;
-                        
-                        prov:category "access-and-query" ;
-                        
-                        rdfs:comment "Type for a generic provenance query service. Mainly for use in RDF provenance query service descriptions, to facilitate discovery in linked data environments." ;
-                        
-                        rdfs:isDefinedBy prov: .
-
-
-
-###  http://www.w3.org/ns/prov#SoftwareAgent
-
-prov:SoftwareAgent rdf:type owl:Class ;
-                   
-                   rdfs:label "SoftwareAgent" ;
-                   
-                   rdfs:subClassOf owl:Thing ,
-                                   prov:Agent ;
-                   
-                   prov:dm "http://www.w3.org/TR/2012/WD-prov-dm-20120703/prov-dm.html#term-agent"^^xsd:anyURI ;
-                   
-                   prov:n "http://www.w3.org/TR/2012/WD-prov-dm-20120703/prov-n.html#expression-types"^^xsd:anyURI ;
-                   
-                   prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-agent"^^xsd:anyURI ;
-                   
-                   prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-types"^^xsd:anyURI ;
-                   
-                   prov:category "expanded" ;
-                   
-                   prov:component "agents-responsibility" ;
-                   
-                   prov:definition "A software agent is running software."@en ;
-                   
-                   rdfs:isDefinedBy prov: ,
-                                    <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#Start
-
-prov:Start rdf:type owl:Class ;
-           
-           rdfs:label "Start" ;
-           
-           rdfs:subClassOf prov:EntityInfluence ,
-                           prov:InstantaneousEvent ;
-           
-           prov:constraints "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
-           
-           prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Start"^^xsd:anyURI ;
-           
-           prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Start"^^xsd:anyURI ;
-           
-           rdfs:comment "An instance of prov:Start provides additional descriptions about the binary prov:wasStartedBy relation from some started prov:Activity to an prov:Entity that started it. For example, :foot_race prov:wasStartedBy :bang; prov:qualifiedStart [ a prov:Start; prov:entity :bang; :foo :bar; prov:atTime '2012-03-09T08:05:08-05:00'^^xsd:dateTime ] ."@en ;
-           
-           prov:component "entities-activities" ;
-           
-           prov:category "qualified" ;
-           
-           prov:definition "Start is when an activity is deemed to have been started by an entity, known as trigger. The activity did not exist before its start. Any usage, generation, or invalidation involving an activity follows the activity's start. A start may refer to a trigger entity that set off the activity, or to an activity, known as starter, that generated the trigger."@en ;
-           
-           prov:unqualifiedForm prov:wasStartedBy ;
-           
-           rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
-
-
-
-###  http://www.w3.org/ns/prov#Submit
-
-prov:Submit rdf:type owl:Class ;
-            
-            rdfs:label "Submit"@en ;
-            
-            rdfs:subClassOf prov:Activity ;
-            
-            prov:definition "Activity that identifies the issuance (e.g., publication) of a resource. "@en .
-
-
-
-###  http://www.w3.org/ns/prov#Usage
-
-prov:Usage rdf:type owl:Class ;
-           
-           rdfs:label "Usage" ;
-           
-           rdfs:subClassOf prov:EntityInfluence ,
-                           prov:InstantaneousEvent ;
-           
-           prov:constraints "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
-           
-           prov:dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Usage"^^xsd:anyURI ;
-           
-           prov:n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Usage"^^xsd:anyURI ;
-           
-           prov:component "entities-activities" ;
-           
-           prov:definition "Usage is the beginning of utilizing an entity by an activity. Before usage, the activity had not begun to utilize this entity and could not have been affected by the entity."@en ;
-           
-           prov:category "qualified" ;
-           
-           rdfs:comment "An instance of prov:Usage provides additional descriptions about the binary prov:used relation from some prov:Activity to an prov:Entity that it used. For example, :keynote prov:used :podium; prov:qualifiedUsage [ a prov:Usage; prov:entity :podium; :foo :bar ]."@en ;
-           
-           prov:unqualifiedForm prov:used ;
-           
-           rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
+    owl:annotatedProperty rdfs:subPropertyOf ;
+    owl:annotatedSource prov:wasRevisionOf ;
+    owl:annotatedTarget prov:wasDerivedFrom .
 

--- a/scripts/Constants.py
+++ b/scripts/Constants.py
@@ -11,6 +11,7 @@ PROV = Namespace('http://www.w3.org/ns/prov#')
 NIDM = Namespace('http://purl.org/nidash/nidm#')
 
 NIIRI = Namespace('http://iri.nidash.org/')
+AFNI = Namespace('http://purl.org/nidash/afni#')
 SPM = Namespace('http://purl.org/nidash/spm#')
 FSL = Namespace('http://purl.org/nidash/fsl#')
 RDFS = Namespace('http://www.w3.org/2000/01/rdf-schema#')

--- a/scripts/OwlReader.py
+++ b/scripts/OwlReader.py
@@ -334,12 +334,16 @@ class OwlReader():
         examples = list(self.graph.objects(owl_term, OBO_EXAMPLE))
 
         for example in examples:
-            if base_repository is not None:
-                if example.startswith(base_repository):
-                    local_path = example.replace(base_repository, "./")
-                    fid_ex = open(local_path)
-                    example = fid_ex.read()
-                    fid_ex.close()
+            if (base_repository is not None) and \
+                    example.startswith(base_repository):
+                local_path = example.replace(base_repository, "./")
+                fid_ex = open(local_path)
+                example = fid_ex.read()
+                fid_ex.close()
+            elif example.startswith("http"):
+                # Read file from url
+                example = urllib.urlopen(example).read()
+
             example_list.append(example)
 
         return example_list

--- a/scripts/OwlReader.py
+++ b/scripts/OwlReader.py
@@ -8,8 +8,17 @@
 from rdflib import RDF, term
 from rdflib.graph import Graph
 from Constants import *
-import urllib
+import urllib2
 import warnings
+import vcr
+import os
+import logging
+
+RELPATH = os.path.dirname(os.path.abspath(__file__))
+NIDM_PATH = os.path.dirname(RELPATH)
+
+logging.basicConfig(filename='debug.log', level=logging.DEBUG, filemode='w')
+logger = logging.getLogger(__name__)
 
 
 class OwlReader():
@@ -200,7 +209,7 @@ class OwlReader():
         # Read owl (turtle) file
         owl_graph = Graph()
         if self.file[0:4] == "http":
-            owl_txt = urllib.urlopen(self.file).read()
+            owl_txt = urllib2.urlopen(self.file).read()
         else:
             owl_txt = open(self.file, 'r').read()
 
@@ -217,7 +226,7 @@ class OwlReader():
                 # Read owl (turtle) file
                 import_graph = Graph()
                 if self.file[0:4] == "http":
-                    import_txt = urllib.urlopen(import_file).read()
+                    import_txt = urllib2.urlopen(import_file).read()
                 else:
                     import_txt = open(import_file, 'r').read()
 
@@ -341,8 +350,11 @@ class OwlReader():
                 example = fid_ex.read()
                 fid_ex.close()
             elif example.startswith("http"):
-                # Read file from url
-                example = urllib.urlopen(example).read()
+                with vcr.use_cassette(
+                        os.path.join(NIDM_PATH, 'vcr_cassettes/synopsis.yaml'),
+                        record_mode='new_episodes'):
+                    # Read file from url
+                    example = urllib2.urlopen(example).read()
 
             example_list.append(example)
 

--- a/test/test_specifications.py
+++ b/test/test_specifications.py
@@ -23,8 +23,10 @@ sys.path.append(script_path)
 from create_results_specification import main as create_res_spec
 from create_expe_specification import main as create_expe_spec
 
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(filename='debug.log', level=logging.DEBUG, filemode='w')
 logger = logging.getLogger(__name__)
+logger.info(' ---------- Debug log ----------')
+
 
 class TestSpecifications(unittest.TestCase):
 

--- a/vcr_cassettes/synopsis.yaml
+++ b/vcr_cassettes/synopsis.yaml
@@ -16230,4 +16230,1171 @@ interactions:
       x-frame-options: [SAMEORIGIN]
       x-ua-compatible: [IE=Edge]
     status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [!!python/unicode raw.githubusercontent.com]
+      User-Agent: [Python-urllib/2.7]
+    method: GET
+    uri: https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/CoordinateSpace.txt
+  response:
+    body: {string: !!python/unicode "@prefix nidm_CoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000016>
+        .\n@prefix nidm_voxelToWorldMapping: <http://purl.org/nidash/nidm#NIDM_0000132>
+        .\n@prefix nidm_voxelUnits: <http://purl.org/nidash/nidm#NIDM_0000133> .\n@prefix
+        nidm_voxelSize: <http://purl.org/nidash/nidm#NIDM_0000131> .\n@prefix nidm_inWorldCoordinateSystem:
+        <http://purl.org/nidash/nidm#NIDM_0000105> .\n@prefix nidm_MNICoordinateSystem:
+        <http://purl.org/nidash/nidm#NIDM_0000051> .\n@prefix nidm_numberOfDimensions:
+        <http://purl.org/nidash/nidm#NIDM_0000112> .\n@prefix nidm_dimensionsInVoxels:
+        <http://purl.org/nidash/nidm#NIDM_0000090> .\n\n\nniiri:coordinate_space_id_1
+        a prov:Entity , nidm_CoordinateSpace: ;\n\trdfs:label \"Coordinate space 1\"
+        ;\n\tnidm_voxelToWorldMapping: \"[[-3, 0, 0, 78],[0, 3, 0, -112],[0, 0, 3,
+        -50],[0, 0, 0, 1]]\"^^xsd:string ;\n\tnidm_voxelUnits: \"['mm', 'mm', 'mm']\"^^xsd:string
+        ;\n\tnidm_voxelSize: \"[3, 3, 3]\"^^xsd:string ;\n\tnidm_inWorldCoordinateSystem:
+        nidm_MNICoordinateSystem: ;\n\tnidm_numberOfDimensions: \"3\"^^xsd:int ;\n\tnidm_dimensionsInVoxels:
+        \"[53,63,46]\"^^xsd:string ."}
+    headers:
+      accept-ranges: [bytes]
+      access-control-allow-origin: ['https://render.githubusercontent.com']
+      cache-control: [max-age=300]
+      connection: [close]
+      content-length: ['1068']
+      content-security-policy: [default-src 'none']
+      content-type: [text/plain; charset=utf-8]
+      date: ['Wed, 06 May 2015 16:05:24 GMT']
+      etag: ['"7f331c17f82406912dfee0d5db638ce43bb5fd7f"']
+      expires: ['Wed, 06 May 2015 16:10:24 GMT']
+      source-age: ['220']
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization,Accept-Encoding']
+      via: [1.1 varnish]
+      x-cache: [HIT]
+      x-cache-hits: ['1']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-served-by: [cache-sea1926-SEA]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [!!python/unicode raw.githubusercontent.com]
+      User-Agent: [Python-urllib/2.7]
+    method: GET
+    uri: https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/ModelParametersEstimation.txt
+  response:
+    body: {string: !!python/unicode "@prefix nidm_ModelParametersEstimation: <http://purl.org/nidash/nidm#NIDM_0000056>
+        .\n@prefix nidm_withEstimationMethod: <http://purl.org/nidash/nidm#NIDM_0000134>
+        .\n@prefix obo_ordinaryleastsquaresestimation: <http://purl.obolibrary.org/obo/STATO_0000370>
+        .\n\n\nniiri:model_pe_id prov:used niiri:error_model_id ;\n\ta prov:Activity
+        , nidm_ModelParametersEstimation: ;\n\trdfs:label \"Model parameters estimation\"
+        ;\n\tnidm_withEstimationMethod: obo_ordinaryleastsquaresestimation: ; # obo:'ordinary
+        least squares estimation'\n\tprov:used niiri:design_matrix_id ;\n    prov:used
+        niiri:data_id ;\n    prov:used niiri:error_model_id ;\n    prov:wasAssociatedWith
+        niiri:software_id ."}
+    headers:
+      accept-ranges: [bytes]
+      access-control-allow-origin: ['https://render.githubusercontent.com']
+      cache-control: [max-age=300]
+      connection: [close]
+      content-length: ['665']
+      content-security-policy: [default-src 'none']
+      content-type: [text/plain; charset=utf-8]
+      date: ['Wed, 06 May 2015 16:05:25 GMT']
+      etag: ['"641447d2a3cb175f731a2b6528579c1226a15187"']
+      expires: ['Wed, 06 May 2015 16:10:25 GMT']
+      source-age: ['220']
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization,Accept-Encoding']
+      via: [1.1 varnish]
+      x-cache: [HIT]
+      x-cache-hits: ['1']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-served-by: [cache-sea1920-SEA]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [!!python/unicode raw.githubusercontent.com]
+      User-Agent: [Python-urllib/2.7]
+    method: GET
+    uri: https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/Data.txt
+  response:
+    body: {string: !!python/unicode "@prefix nidm_DataScaling: <http://purl.org/nidash/nidm#NIDM_0000018>
+        .\n@prefix nidm_grandMeanScaling: <http://purl.org/nidash/nidm#NIDM_0000096>
+        .\n@prefix nidm_targetIntensity: <http://purl.org/nidash/nidm#NIDM_0000124>
+        .\n\n\nniiri:data_id a prov:Entity , nidm_DataScaling: , prov:Collection ;\n
+        \   rdfs:label \"Data\" ;\n    nidm_grandMeanScaling: \"true\"^^xsd:boolean
+        ;\n    nidm_targetIntensity: \"100\"^^xsd:float ."}
+    headers:
+      accept-ranges: [bytes]
+      access-control-allow-origin: ['https://render.githubusercontent.com']
+      cache-control: [max-age=300]
+      connection: [close]
+      content-length: ['409']
+      content-security-policy: [default-src 'none']
+      content-type: [text/plain; charset=utf-8]
+      date: ['Wed, 06 May 2015 16:05:27 GMT']
+      etag: ['"0270aca3a7e0ae572b9897b9cf39ec55ae5debc3"']
+      expires: ['Wed, 06 May 2015 16:10:27 GMT']
+      source-age: ['221']
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization,Accept-Encoding']
+      via: [1.1 varnish]
+      x-cache: [HIT]
+      x-cache-hits: ['1']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-served-by: [cache-sea1922-SEA]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [!!python/unicode raw.githubusercontent.com]
+      User-Agent: [Python-urllib/2.7]
+    method: GET
+    uri: https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/DesignMatrix.txt
+  response:
+    body: {string: !!python/unicode "@prefix nidm_DesignMatrix: <http://purl.org/nidash/nidm#NIDM_0000019>
+        .\n\n\nniiri:design_matrix_id a prov:Entity , nidm_DesignMatrix: ;\n\trdfs:label
+        \"Design Matrix\" ;\n\tprov:atLocation \"file:///path/to/DesignMatrix.csv\"^^xsd:anyURI
+        ;\n\tdct:format \"text/csv\"^^xsd:string ;\n\tnfo:fileName \"DesignMatrix.csv\"^^xsd:string
+        ;\n\tdc:description niiri:design_matrix_png_id ."}
+    headers:
+      accept-ranges: [bytes]
+      access-control-allow-origin: ['https://render.githubusercontent.com']
+      cache-control: [max-age=300]
+      connection: [close]
+      content-length: ['358']
+      content-security-policy: [default-src 'none']
+      content-type: [text/plain; charset=utf-8]
+      date: ['Wed, 06 May 2015 16:05:28 GMT']
+      etag: ['"229c00adf7e969e2f915514aa199d25cbea5c3eb"']
+      expires: ['Wed, 06 May 2015 16:10:28 GMT']
+      source-age: ['221']
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization,Accept-Encoding']
+      via: [1.1 varnish]
+      x-cache: [HIT]
+      x-cache-hits: ['1']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-served-by: [cache-sea1922-SEA]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [!!python/unicode raw.githubusercontent.com]
+      User-Agent: [Python-urllib/2.7]
+    method: GET
+    uri: https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/FSL_DriftModel.txt
+  response:
+    body: {string: !!python/unicode "@prefix fsl_GaussianRunningLineDriftModel: <http://purl.org/nidash/fsl#FSL_0000002>
+        .\n@prefix fsl_driftCutoffPeriod: <http://purl.org/nidash/fsl#FSL_0000004>
+        .\n\n\nniiri:drift_model_id a prov:Entity , fsl_GaussianRunningLineDriftModel:
+        ;\n\trdfs:label \"FSL's Gaussian Running Line Drift Model\" ;\n\tfsl_driftCutoffPeriod:
+        2 ."}
+    headers:
+      accept-ranges: [bytes]
+      access-control-allow-origin: ['https://render.githubusercontent.com']
+      cache-control: [max-age=300]
+      connection: [close]
+      content-length: ['319']
+      content-security-policy: [default-src 'none']
+      content-type: [text/plain; charset=utf-8]
+      date: ['Wed, 06 May 2015 16:05:29 GMT']
+      etag: ['"512dc90c165a9611e493620045348dd3b941a301"']
+      expires: ['Wed, 06 May 2015 16:10:29 GMT']
+      source-age: ['221']
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization,Accept-Encoding']
+      via: [1.1 varnish]
+      x-cache: [HIT]
+      x-cache-hits: ['1']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-served-by: [cache-sea1926-SEA]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [!!python/unicode raw.githubusercontent.com]
+      User-Agent: [Python-urllib/2.7]
+    method: GET
+    uri: https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/SPM_DriftModel.txt
+  response:
+    body: {string: !!python/unicode "@prefix spm_DCTDriftModel: <http://purl.org/nidash/spm#SPM_0000002>
+        .\n@prefix spm_SPMsDriftCutoffPeriod: <http://purl.org/nidash/spm#SPM_0000001>
+        .\n\n\nniiri:drift_model_id a prov:Entity , spm_DCTDriftModel: ;\n\trdfs:label
+        \"SPM's DCT Drift Model\" ;\n\tspm_SPMsDriftCutoffPeriod: 2 ."}
+    headers:
+      accept-ranges: [bytes]
+      access-control-allow-origin: ['https://render.githubusercontent.com']
+      cache-control: [max-age=300]
+      connection: [close]
+      content-length: ['277']
+      content-security-policy: [default-src 'none']
+      content-type: [text/plain; charset=utf-8]
+      date: ['Wed, 06 May 2015 16:05:30 GMT']
+      etag: ['"534102d5e22f64bf3a46914183b998ff67e9dd32"']
+      expires: ['Wed, 06 May 2015 16:10:30 GMT']
+      source-age: ['221']
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization,Accept-Encoding']
+      via: [1.1 varnish]
+      x-cache: [HIT]
+      x-cache-hits: ['1']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-served-by: [cache-sea1925-SEA]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [!!python/unicode raw.githubusercontent.com]
+      User-Agent: [Python-urllib/2.7]
+    method: GET
+    uri: https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/ErrorModel.txt
+  response:
+    body: {string: !!python/unicode "@prefix nidm_ErrorModel: <http://purl.org/nidash/nidm#NIDM_0000023>
+        .\n@prefix nidm_hasErrorDistribution: <http://purl.org/nidash/nidm#NIDM_0000101>
+        .\n@prefix nidm_GaussianDistribution: <http://purl.org/nidash/nidm#NIDM_0000032>
+        .\n@prefix nidm_errorVarianceHomogeneous: <http://purl.org/nidash/nidm#NIDM_0000094>
+        .\n@prefix nidm_varianceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000126>
+        .\n@prefix nidm_IndependentParameter: <http://purl.org/nidash/nidm#NIDM_0000073>
+        .\n@prefix nidm_hasErrorDependence: <http://purl.org/nidash/nidm#NIDM_0000100>
+        .\n@prefix nidm_IndependentError: <http://purl.org/nidash/nidm#NIDM_0000048>
+        .\n@prefix nidm_dependenceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000089>
+        .\n\n\nniiri:error_model_id a prov:Entity , nidm_ErrorModel: ;\n    nidm_hasErrorDistribution:
+        nidm_GaussianDistribution: ;\n    nidm_errorVarianceHomogeneous: \"true\"^^xsd:boolean
+        ;\n    nidm_varianceMapWiseDependence: nidm_IndependentParameter: ;\n    nidm_hasErrorDependence:
+        nidm_IndependentError: ;\n    nidm_dependenceMapWiseDependence: nidm_IndependentParameter:
+        ."}
+    headers:
+      accept-ranges: [bytes]
+      access-control-allow-origin: ['https://render.githubusercontent.com']
+      cache-control: [max-age=300]
+      connection: [close]
+      content-length: ['1080']
+      content-security-policy: [default-src 'none']
+      content-type: [text/plain; charset=utf-8]
+      date: ['Wed, 06 May 2015 16:05:31 GMT']
+      etag: ['"fe0013655f1d5be6f8c742ecdbcb292c0a93ab69"']
+      expires: ['Wed, 06 May 2015 16:10:31 GMT']
+      source-age: ['222']
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization,Accept-Encoding']
+      via: [1.1 varnish]
+      x-cache: [HIT]
+      x-cache-hits: ['1']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-served-by: [cache-sea1924-SEA]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [!!python/unicode raw.githubusercontent.com]
+      User-Agent: [Python-urllib/2.7]
+    method: GET
+    uri: https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/GrandMeanMap.txt
+  response:
+    body: {string: !!python/unicode "@prefix nidm_GrandMeanMap: <http://purl.org/nidash/nidm#NIDM_0000033>
+        .\n@prefix nidm_maskedMedian: <http://purl.org/nidash/nidm#NIDM_0000107> .\n@prefix
+        nidm_inCoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000104> .\n\n\nniiri:grand_mean_map_id
+        a prov:Entity , nidm_GrandMeanMap: ;\n\trdfs:label \"Grand Mean Map\" ;\n\tprov:atLocation
+        \"file:///path/to/GrandMean.nii.gz\"^^xsd:anyURI ;\n\tnfo:fileName \"GrandMean.nii.gz\"^^xsd:string
+        ;\n\tdct:format \"image/nifti\"^^xsd:string ;\n\tnidm_maskedMedian: \"115\"^^xsd:float
+        ;\n\tnidm_inCoordinateSpace: niiri:coordinate_space_id_1 ;\n\tcrypto:sha512
+        \"e43b6e01b0463fe7d40782137867a...\"^^xsd:string ;\n    prov:wasGeneratedBy
+        niiri:model_pe_id ."}
+    headers:
+      accept-ranges: [bytes]
+      access-control-allow-origin: ['https://render.githubusercontent.com']
+      cache-control: [max-age=300]
+      connection: [close]
+      content-length: ['669']
+      content-security-policy: [default-src 'none']
+      content-type: [text/plain; charset=utf-8]
+      date: ['Wed, 06 May 2015 16:05:32 GMT']
+      etag: ['"7c9a20dfc6ba65cd6a45daa3021b8e72033a0b7e"']
+      expires: ['Wed, 06 May 2015 16:10:32 GMT']
+      source-age: ['222']
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization,Accept-Encoding']
+      via: [1.1 varnish]
+      x-cache: [HIT]
+      x-cache-hits: ['1']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-served-by: [cache-sea1924-SEA]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [!!python/unicode raw.githubusercontent.com]
+      User-Agent: [Python-urllib/2.7]
+    method: GET
+    uri: https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/MaskMap.txt
+  response:
+    body: {string: !!python/unicode "@prefix nidm_MaskMap: <http://purl.org/nidash/nidm#NIDM_0000054>
+        .\n@prefix nidm_isUserDefined: <http://purl.org/nidash/nidm#NIDM_0000106>
+        .\n@prefix nidm_inCoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000104>
+        .\n\n\nniiri:model_pe_id prov:used niiri:mask_id_2 .\nniiri:mask_id_2 a prov:Entity
+        , nidm_MaskMap: ;\n\trdfs:label \"Mask\" ;\n    nidm_isUserDefined: \"false\"^^xsd:boolean
+        ;\n\tprov:atLocation \"file:///path/to/Mask.nii.gz\"^^xsd:anyURI ;\n\tnfo:fileName
+        \"Mask.nii.gz\"^^xsd:string ;\n\tdct:format \"image/nifti\"^^xsd:string ;\n\tnidm_inCoordinateSpace:
+        niiri:coordinate_space_id_1 ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a...\"^^xsd:string
+        ."}
+    headers:
+      accept-ranges: [bytes]
+      access-control-allow-origin: ['https://render.githubusercontent.com']
+      cache-control: [max-age=300]
+      connection: [close]
+      content-length: ['642']
+      content-security-policy: [default-src 'none']
+      content-type: [text/plain; charset=utf-8]
+      date: ['Wed, 06 May 2015 16:05:33 GMT']
+      etag: ['"ca8b7c6e68a1962190b6b14387b93a2aa3e08a4a"']
+      expires: ['Wed, 06 May 2015 16:10:33 GMT']
+      source-age: ['222']
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization,Accept-Encoding']
+      via: [1.1 varnish]
+      x-cache: [HIT]
+      x-cache-hits: ['1']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-served-by: [cache-sea1924-SEA]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [!!python/unicode raw.githubusercontent.com]
+      User-Agent: [Python-urllib/2.7]
+    method: GET
+    uri: https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/ParameterEstimateMap.txt
+  response:
+    body: {string: !!python/unicode "@prefix nidm_ParameterEstimateMap: <http://purl.org/nidash/nidm#NIDM_0000061>
+        .\n@prefix nidm_inCoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000104>
+        .\n\n\nniiri:beta_map_id_1 a prov:Entity , nidm_ParameterEstimateMap: ;\n
+        \   rdfs:label \"Beta Map 1\" ;\n    nidm_inCoordinateSpace: niiri:coordinate_space_id_1
+        ;\n    prov:wasGeneratedBy niiri:model_pe_id ."}
+    headers:
+      accept-ranges: [bytes]
+      access-control-allow-origin: ['https://render.githubusercontent.com']
+      cache-control: [max-age=300]
+      connection: [close]
+      content-length: ['355']
+      content-security-policy: [default-src 'none']
+      content-type: [text/plain; charset=utf-8]
+      date: ['Wed, 06 May 2015 16:05:34 GMT']
+      etag: ['"95b0ebd0caf953672ce7cac9db9b004de2c2e2aa"']
+      expires: ['Wed, 06 May 2015 16:10:34 GMT']
+      source-age: ['222']
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization,Accept-Encoding']
+      via: [1.1 varnish]
+      x-cache: [HIT]
+      x-cache-hits: ['1']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-served-by: [cache-sea1923-SEA]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [!!python/unicode raw.githubusercontent.com]
+      User-Agent: [Python-urllib/2.7]
+    method: GET
+    uri: https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/ResidualMeanSquaresMap.txt
+  response:
+    body: {string: !!python/unicode "@prefix nidm_ResidualMeanSquaresMap: <http://purl.org/nidash/nidm#NIDM_0000066>
+        .\n@prefix nidm_inCoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000104>
+        .\n\n\nniiri:residual_mean_squares_map_id a prov:Entity , nidm_ResidualMeanSquaresMap:
+        ;\n\trdfs:label \"Residual Mean Squares Map\" ;\n\tprov:atLocation \"file:///path/to/ResidualMeanSquares.nii.gz\"^^xsd:anyURI
+        ;\n\tnfo:fileName \"ResidualMeanSquares.nii.gz\"^^xsd:string ;\n\tdct:format
+        \"image/nifti\"^^xsd:string ;\n\tnidm_inCoordinateSpace: niiri:coordinate_space_id_1
+        ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a...\"^^xsd:string ;\n    prov:wasGeneratedBy
+        niiri:model_pe_id ."}
+    headers:
+      accept-ranges: [bytes]
+      access-control-allow-origin: ['https://render.githubusercontent.com']
+      cache-control: [max-age=300]
+      connection: [close]
+      content-length: ['620']
+      content-security-policy: [default-src 'none']
+      content-type: [text/plain; charset=utf-8]
+      date: ['Wed, 06 May 2015 16:05:35 GMT']
+      etag: ['"221be0b7d1cbc86580825e91434f20f31082a43e"']
+      expires: ['Wed, 06 May 2015 16:10:35 GMT']
+      source-age: ['222']
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization,Accept-Encoding']
+      via: [1.1 varnish]
+      x-cache: [HIT]
+      x-cache-hits: ['1']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-served-by: [cache-sea1922-SEA]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [!!python/unicode raw.githubusercontent.com]
+      User-Agent: [Python-urllib/2.7]
+    method: GET
+    uri: https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/SPM_ReselsPerVoxelMap.txt
+  response:
+    body: {string: !!python/unicode "@prefix nidm_ReselsPerVoxelMap: <http://purl.org/nidash/nidm#NIDM_0000144>
+        .\n@prefix nidm_inCoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000104>
+        .\n\n\nniiri:resels_per_voxel_map_id a prov:Entity , nidm_ReselsPerVoxelMap:
+        ;\n\trdfs:label \"Resels per Voxel Map\" ;\n\tprov:atLocation \"file:///path/to/ReselsPerVoxel.nii.gz\"^^xsd:anyURI
+        ;\n\tnfo:fileName \"ReselsPerVoxel.nii.gz\"^^xsd:string ;\n\tdct:format \"image/nifti\"^^xsd:string
+        ;\n\tnidm_inCoordinateSpace: niiri:coordinate_space_id_1 ;\n\tcrypto:sha512
+        \"e43b6e01b0463fe7d40782137867a...\"^^xsd:string ;\n    prov:wasGeneratedBy
+        niiri:model_pe_id."}
+    headers:
+      accept-ranges: [bytes]
+      access-control-allow-origin: ['https://render.githubusercontent.com']
+      cache-control: [max-age=300]
+      connection: [close]
+      content-length: ['589']
+      content-security-policy: [default-src 'none']
+      content-type: [text/plain; charset=utf-8]
+      date: ['Wed, 06 May 2015 16:05:36 GMT']
+      etag: ['"194b59ca26b4271f9904f314a643daf345391c5d"']
+      expires: ['Wed, 06 May 2015 16:10:36 GMT']
+      source-age: ['222']
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization,Accept-Encoding']
+      via: [1.1 varnish]
+      x-cache: [HIT]
+      x-cache-hits: ['1']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-served-by: [cache-sea1924-SEA]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [!!python/unicode raw.githubusercontent.com]
+      User-Agent: [Python-urllib/2.7]
+    method: GET
+    uri: https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/ContrastEstimation.txt
+  response:
+    body: {string: !!python/unicode "@prefix nidm_ContrastEstimation: <http://purl.org/nidash/nidm#NIDM_0000001>
+        .\n\n\nniiri:contrast_estimation_id a prov:Activity , nidm_ContrastEstimation:
+        ;\n\trdfs:label \"Contrast estimation\" ;\n\tprov:used niiri:mask_id_2 , niiri:residual_mean_squares_map_id
+        , niiri:design_matrix_id , niiri:contrast_id, niiri:beta_map_id_1 ;\n    prov:wasAssociatedWith
+        niiri:software_id ."}
+    headers:
+      accept-ranges: [bytes]
+      access-control-allow-origin: ['https://render.githubusercontent.com']
+      cache-control: [max-age=300]
+      connection: [close]
+      content-length: ['368']
+      content-security-policy: [default-src 'none']
+      content-type: [text/plain; charset=utf-8]
+      date: ['Wed, 06 May 2015 16:05:37 GMT']
+      etag: ['"f516967de5e61d761cb779b12bf5c65f6ca6c2ad"']
+      expires: ['Wed, 06 May 2015 16:10:37 GMT']
+      source-age: ['223']
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization,Accept-Encoding']
+      via: [1.1 varnish]
+      x-cache: [HIT]
+      x-cache-hits: ['1']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-served-by: [cache-sea1920-SEA]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [!!python/unicode raw.githubusercontent.com]
+      User-Agent: [Python-urllib/2.7]
+    method: GET
+    uri: https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/ContrastWeights.txt
+  response:
+    body: {string: !!python/unicode "@prefix nidm_statisticType: <http://purl.org/nidash/nidm#NIDM_0000123>
+        .\n@prefix nidm_contrastName: <http://purl.org/nidash/nidm#NIDM_0000085> .\n@prefix
+        obo_contrastweightmatrix: <http://purl.obolibrary.org/obo/STATO_0000323> .\n@prefix
+        obo_tstatistic: <http://purl.obolibrary.org/obo/STATO_0000176> .\n\n\nniiri:contrast_id
+        a prov:Entity , obo_contrastweightmatrix: ;\n\trdfs:label \"Contrast: Listening
+        > Rest\" ;\n\tprov:value \"[1, 0, 0]\"^^xsd:string ;\n\tnidm_statisticType:
+        obo_tstatistic: ; # obo:'t-statistic'\n\tnidm_contrastName: \"listening >
+        rest\"^^xsd:string ."}
+    headers:
+      accept-ranges: [bytes]
+      access-control-allow-origin: ['https://render.githubusercontent.com']
+      cache-control: [max-age=300]
+      connection: [close]
+      content-length: ['557']
+      content-security-policy: [default-src 'none']
+      content-type: [text/plain; charset=utf-8]
+      date: ['Wed, 06 May 2015 16:05:39 GMT']
+      etag: ['"bc03f4208cae050eb2df35a501d1002f5b9162d0"']
+      expires: ['Wed, 06 May 2015 16:10:39 GMT']
+      source-age: ['223']
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization,Accept-Encoding']
+      via: [1.1 varnish]
+      x-cache: [HIT]
+      x-cache-hits: ['1']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-served-by: [cache-sea1921-SEA]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [!!python/unicode raw.githubusercontent.com]
+      User-Agent: [Python-urllib/2.7]
+    method: GET
+    uri: https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/ContrastMap.txt
+  response:
+    body: {string: !!python/unicode "@prefix nidm_ContrastMap: <http://purl.org/nidash/nidm#NIDM_0000002>
+        .\n@prefix nidm_contrastName: <http://purl.org/nidash/nidm#NIDM_0000085> .\n@prefix
+        nidm_inCoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000104> .\n\n\nniiri:contrast_map_id
+        a prov:Entity , nidm_ContrastMap: ;\n\trdfs:label \"Contrast Map: listening
+        > rest\" ;\n\tprov:atLocation \"file:///path/to/Contrast.nii.gz\"^^xsd:anyURI
+        ;\n\tdct:format \"image/nifti\"^^xsd:string ;\n\tnfo:fileName \"Contrast.nii.gz\"^^xsd:string
+        ;\n\tnidm_contrastName: \"listening > rest\"^^xsd:string ;\n\tnidm_inCoordinateSpace:
+        niiri:coordinate_space_id_1 ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a...\"^^xsd:string
+        ;\n    prov:wasGeneratedBy niiri:contrast_estimation_id .\n"}
+    headers:
+      accept-ranges: [bytes]
+      access-control-allow-origin: ['https://render.githubusercontent.com']
+      cache-control: [max-age=300]
+      connection: [close]
+      content-length: ['705']
+      content-security-policy: [default-src 'none']
+      content-type: [text/plain; charset=utf-8]
+      date: ['Wed, 06 May 2015 16:05:40 GMT']
+      etag: ['"d9f9423e0c1df60e493b7bbbbb38e95ff4717441"']
+      expires: ['Wed, 06 May 2015 16:10:40 GMT']
+      source-age: ['223']
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization,Accept-Encoding']
+      via: [1.1 varnish]
+      x-cache: [HIT]
+      x-cache-hits: ['1']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-served-by: [cache-sea1921-SEA]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [!!python/unicode raw.githubusercontent.com]
+      User-Agent: [Python-urllib/2.7]
+    method: GET
+    uri: https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/ContrastStandardErrorMap.txt
+  response:
+    body: {string: !!python/unicode "@prefix nidm_ContrastStandardErrorMap: <http://purl.org/nidash/nidm#NIDM_0000013>
+        .\n@prefix nidm_inCoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000104>
+        .\n\n\nniiri:contrast_standard_error_map_id a prov:Entity , nidm_ContrastStandardErrorMap:
+        ;\n\trdfs:label \"Contrast Standard Error Map\" ;\n\tprov:atLocation \"file:///path/to/ContrastStandardError.nii.gz\"^^xsd:anyURI
+        ;\n\tnfo:fileName \"ContrastStandardError.nii.gz\"^^xsd:string ;\n\tdct:format
+        \"image/nifti\"^^xsd:string ;\n\tnidm_inCoordinateSpace: niiri:coordinate_space_id_1
+        ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a...\"^^xsd:string ;\n    prov:wasGeneratedBy
+        niiri:contrast_estimation_id ."}
+    headers:
+      accept-ranges: [bytes]
+      access-control-allow-origin: ['https://render.githubusercontent.com']
+      cache-control: [max-age=300]
+      connection: [close]
+      content-length: ['643']
+      content-security-policy: [default-src 'none']
+      content-type: [text/plain; charset=utf-8]
+      date: ['Wed, 06 May 2015 16:05:41 GMT']
+      etag: ['"e6e1a724f184055f7e11d235e916201933710cd3"']
+      expires: ['Wed, 06 May 2015 16:10:41 GMT']
+      source-age: ['224']
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization,Accept-Encoding']
+      via: [1.1 varnish]
+      x-cache: [HIT]
+      x-cache-hits: ['1']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-served-by: [cache-sea1922-SEA]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [!!python/unicode raw.githubusercontent.com]
+      User-Agent: [Python-urllib/2.7]
+    method: GET
+    uri: https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/StatisticMap_T.txt
+  response:
+    body: {string: !!python/unicode "@prefix nidm_StatisticMap: <http://purl.org/nidash/nidm#NIDM_0000076>
+        .\n@prefix nidm_statisticType: <http://purl.org/nidash/nidm#NIDM_0000123>
+        .\n@prefix nidm_contrastName: <http://purl.org/nidash/nidm#NIDM_0000085> .\n@prefix
+        nidm_effectDegreesOfFreedom: <http://purl.org/nidash/nidm#NIDM_0000091> .\n@prefix
+        nidm_inCoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000104> .\n@prefix
+        nidm_errorDegreesOfFreedom: <http://purl.org/nidash/nidm#NIDM_0000093> .\n@prefix
+        obo_tstatistic: <http://purl.obolibrary.org/obo/STATO_0000176> .\n\n\nniiri:statistic_map_id
+        a prov:Entity , nidm_StatisticMap: ;\n\trdfs:label \"Statistic Map: listening
+        > rest\" ;\n\tprov:atLocation \"file:///path/to/TStatistic.nii.gz\"^^xsd:anyURI
+        ;\n\tnidm_statisticType: obo_tstatistic: ; # obo:'t-statistic'\n\tnfo:fileName
+        \"TStatistic.nii.gz\"^^xsd:string ;\n\tdct:format \"image/nifti\"^^xsd:string
+        ;\n\tnidm_contrastName: \"listening > rest\"^^xsd:string ;\n\tnidm_effectDegreesOfFreedom:
+        \"1\"^^xsd:float ;\n\tnidm_inCoordinateSpace: niiri:coordinate_space_id_1
+        ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a...\"^^xsd:string ;\n\tprov:wasGeneratedBy
+        niiri:contrast_estimation_id;\n    nidm_errorDegreesOfFreedom: \"72.9999999990787\"^^xsd:float
+        ."}
+    headers:
+      accept-ranges: [bytes]
+      access-control-allow-origin: ['https://render.githubusercontent.com']
+      cache-control: [max-age=300]
+      connection: [close]
+      content-length: ['1187']
+      content-security-policy: [default-src 'none']
+      content-type: [text/plain; charset=utf-8]
+      date: ['Wed, 06 May 2015 16:05:42 GMT']
+      etag: ['"0b0ba2bed7b46cef9726dbb652ada4fc372fb364"']
+      expires: ['Wed, 06 May 2015 16:10:42 GMT']
+      source-age: ['0']
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization,Accept-Encoding']
+      via: [1.1 varnish]
+      x-cache: [MISS]
+      x-cache-hits: ['0']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-served-by: [cache-sea1925-SEA]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [!!python/unicode raw.githubusercontent.com]
+      User-Agent: [Python-urllib/2.7]
+    method: GET
+    uri: https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/Inference.txt
+  response:
+    body: {string: !!python/unicode "@prefix nidm_Inference: <http://purl.org/nidash/nidm#NIDM_0000049>
+        .\n@prefix nidm_hasAlternativeHypothesis: <http://purl.org/nidash/nidm#NIDM_0000097>
+        .\n@prefix nidm_OneTailedTest: <http://purl.org/nidash/nidm#NIDM_0000060>
+        .\n\n\nniiri:inference_id a prov:Activity , nidm_Inference: ;\n\trdfs:label
+        \"Inference\" ;\n\tnidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;\n
+        \   prov:used niiri:statistic_map_id, niiri:height_threshold_id, niiri:extent_threshold_id,
+        niiri:peak_definition_criteria_id, niiri:cluster_definition_criteria_id, niiri:mask_id
+        ;\n    prov:wasAssociatedWith niiri:software_id ."}
+    headers:
+      accept-ranges: [bytes]
+      access-control-allow-origin: ['https://render.githubusercontent.com']
+      cache-control: [max-age=300]
+      connection: [close]
+      content-length: ['590']
+      content-security-policy: [default-src 'none']
+      content-type: [text/plain; charset=utf-8]
+      date: ['Wed, 06 May 2015 16:05:44 GMT']
+      etag: ['"ba7672871c19be5e7d0783e6eb21928c0053988b"']
+      expires: ['Wed, 06 May 2015 16:10:44 GMT']
+      source-age: ['0']
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization,Accept-Encoding']
+      via: [1.1 varnish]
+      x-cache: [MISS]
+      x-cache-hits: ['0']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-served-by: [cache-sea1925-SEA]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [!!python/unicode raw.githubusercontent.com]
+      User-Agent: [Python-urllib/2.7]
+    method: GET
+    uri: https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/ClusterDefinitionCriteria.txt
+  response:
+    body: {string: !!python/unicode "@prefix nidm_ClusterDefinitionCriteria: <http://purl.org/nidash/nidm#NIDM_0000007>
+        .\n@prefix nidm_hasConnectivityCriterion: <http://purl.org/nidash/nidm#NIDM_0000099>
+        .\n@prefix nidm_voxel18connected: <http://purl.org/nidash/nidm#NIDM_0000128>
+        .\n\n\nniiri:cluster_definition_criteria_id a prov:Entity , nidm_ClusterDefinitionCriteria:
+        ;\n\trdfs:label \"Cluster Connectivity Criterion: 18\" ;\n\tnidm_hasConnectivityCriterion:
+        nidm_voxel18connected: ."}
+    headers:
+      accept-ranges: [bytes]
+      access-control-allow-origin: ['https://render.githubusercontent.com']
+      cache-control: [max-age=300]
+      connection: [close]
+      content-length: ['441']
+      content-security-policy: [default-src 'none']
+      content-type: [text/plain; charset=utf-8]
+      date: ['Wed, 06 May 2015 16:05:45 GMT']
+      etag: ['"4370643007fa5684e3b3e8a61fb1d63f19d6d592"']
+      expires: ['Wed, 06 May 2015 16:10:45 GMT']
+      source-age: ['0']
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization,Accept-Encoding']
+      via: [1.1 varnish]
+      x-cache: [MISS]
+      x-cache-hits: ['0']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-served-by: [cache-sea1923-SEA]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [!!python/unicode raw.githubusercontent.com]
+      User-Agent: [Python-urllib/2.7]
+    method: GET
+    uri: https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/ClusterLabelsMap.txt
+  response:
+    body: {string: !!python/unicode "@prefix nidm_ClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000008>
+        .\n\n\nniiri:cluster_label_map_id a prov:Entity , nidm_ClusterLabelsMap: ;\n\tprov:atLocation
+        \"file:///path/to/ClusterLabels.nii.gz\"^^xsd:anyURI ;\n\tnfo:fileName \"ClusterLabels.nii.gz\"^^xsd:string
+        ;\n\tdct:format \"image/nifti\"^^xsd:string ."}
+    headers:
+      accept-ranges: [bytes]
+      access-control-allow-origin: ['https://render.githubusercontent.com']
+      cache-control: [max-age=300]
+      connection: [close]
+      content-length: ['306']
+      content-security-policy: [default-src 'none']
+      content-type: [text/plain; charset=utf-8]
+      date: ['Wed, 06 May 2015 16:05:46 GMT']
+      etag: ['"b501670d4790b7f8a8e9e7133b996fc664d2d7b8"']
+      expires: ['Wed, 06 May 2015 16:10:46 GMT']
+      source-age: ['0']
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization,Accept-Encoding']
+      via: [1.1 varnish]
+      x-cache: [MISS]
+      x-cache-hits: ['0']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-served-by: [cache-sea1920-SEA]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [!!python/unicode raw.githubusercontent.com]
+      User-Agent: [Python-urllib/2.7]
+    method: GET
+    uri: https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/Coordinate.txt
+  response:
+    body: {string: !!python/unicode "@prefix nidm_Coordinate: <http://purl.org/nidash/nidm#NIDM_0000015>
+        .\n@prefix nidm_coordinateVector: <http://purl.org/nidash/nidm#NIDM_0000086>
+        .\n\n\nniiri:coordinate_0001 a prov:Entity , prov:Location , nidm_Coordinate:
+        ;\n\trdfs:label \"Coordinate: 0001\" ;\n\tnidm_coordinateVector: \"[-60, -28,
+        13]\"^^xsd:string ."}
+    headers:
+      accept-ranges: [bytes]
+      access-control-allow-origin: ['https://render.githubusercontent.com']
+      cache-control: [max-age=300]
+      connection: [close]
+      content-length: ['308']
+      content-security-policy: [default-src 'none']
+      content-type: [text/plain; charset=utf-8]
+      date: ['Wed, 06 May 2015 16:05:48 GMT']
+      etag: ['"8cc7c07c2fc7f8281f27aaa6ea23d5c7e28f1ae2"']
+      expires: ['Wed, 06 May 2015 16:10:48 GMT']
+      source-age: ['0']
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization,Accept-Encoding']
+      via: [1.1 varnish]
+      x-cache: [MISS]
+      x-cache-hits: ['0']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-served-by: [cache-sea1925-SEA]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [!!python/unicode raw.githubusercontent.com]
+      User-Agent: [Python-urllib/2.7]
+    method: GET
+    uri: https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/DisplayMaskMap.txt
+  response:
+    body: {string: !!python/unicode "@prefix nidm_DisplayMaskMap: <http://purl.org/nidash/nidm#NIDM_0000020>
+        .\n@prefix nidm_inCoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000104>
+        .\n\n\nniiri:display_map_id a prov:Entity , nidm_DisplayMaskMap: ;\n\trdfs:label
+        \"Display Mask Map\" ;\n\tprov:atLocation \"file:///path/to/DisplayMask.nii.gz\"^^xsd:anyURI
+        ;\n\tdct:format \"image/nifti\"^^xsd:string ;\n    nfo:fileName \"DisplayMask.nii.gz\"^^xsd:string
+        ;\n\tnidm_inCoordinateSpace: niiri:coordinate_space_id_2 ;\n\tcrypto:sha512
+        \"e43b6e01b0463fe7d40782137867a...\"^^xsd:string ."}
+    headers:
+      accept-ranges: [bytes]
+      access-control-allow-origin: ['https://render.githubusercontent.com']
+      cache-control: [max-age=300]
+      connection: [close]
+      content-length: ['524']
+      content-security-policy: [default-src 'none']
+      content-type: [text/plain; charset=utf-8]
+      date: ['Wed, 06 May 2015 16:05:49 GMT']
+      etag: ['"465c396d862c05c7686c310297ebe43b2de31c18"']
+      expires: ['Wed, 06 May 2015 16:10:49 GMT']
+      source-age: ['0']
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization,Accept-Encoding']
+      via: [1.1 varnish]
+      x-cache: [MISS]
+      x-cache-hits: ['0']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-served-by: [cache-sea1921-SEA]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [!!python/unicode raw.githubusercontent.com]
+      User-Agent: [Python-urllib/2.7]
+    method: GET
+    uri: https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/ExcursionSetMap.txt
+  response:
+    body: {string: !!python/unicode "@prefix nidm_ExcursionSetMap: <http://purl.org/nidash/nidm#NIDM_0000025>
+        .\n@prefix nidm_hasClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000098>
+        .\n@prefix nidm_hasMaximumIntensityProjection: <http://purl.org/nidash/nidm#NIDM_0000138>
+        .\n@prefix nidm_inCoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000104>
+        .\n@prefix nidm_numberOfSignificantClusters: <http://purl.org/nidash/nidm#NIDM_0000111>
+        .\n@prefix nidm_pValue: <http://purl.org/nidash/nidm#NIDM_0000114> .\n\n\nniiri:excursion_set_map_id
+        a prov:Entity , nidm_ExcursionSetMap: ;\n\trdfs:label \"Excursion Set Map\"
+        ;\n\tprov:atLocation \"file:///path/to/ExcursionSetMap.nii.gz\"^^xsd:anyURI
+        ;\n\tdct:format \"image/nifti\"^^xsd:string ;\n\tnfo:fileName \"ExcursionSetMap.nii.gz\"^^xsd:string
+        ;\n\tnidm_hasClusterLabelsMap: niiri:cluster_label_map_id ;\n\tnidm_hasMaximumIntensityProjection:
+        niiri:maximum_intensity_projection_id ;\n\tnidm_inCoordinateSpace: niiri:coordinate_space_id_1
+        ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a...\"^^xsd:string ;\n\tnidm_numberOfSignificantClusters:
+        \"8\"^^xsd:int ;\n\tnidm_pValue: \"8.95949980872501e-14\"^^xsd:float ;\n\tprov:wasGeneratedBy
+        niiri:inference_id ."}
+    headers:
+      accept-ranges: [bytes]
+      access-control-allow-origin: ['https://render.githubusercontent.com']
+      cache-control: [max-age=300]
+      connection: [close]
+      content-length: ['1134']
+      content-security-policy: [default-src 'none']
+      content-type: [text/plain; charset=utf-8]
+      date: ['Wed, 06 May 2015 16:05:50 GMT']
+      etag: ['"d837a1aec8f8ecf9a84ec24ed228484f2f14c23a"']
+      expires: ['Wed, 06 May 2015 16:10:50 GMT']
+      source-age: ['0']
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization,Accept-Encoding']
+      via: [1.1 varnish]
+      x-cache: [MISS]
+      x-cache-hits: ['0']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-served-by: [cache-sea1924-SEA]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [!!python/unicode raw.githubusercontent.com]
+      User-Agent: [Python-urllib/2.7]
+    method: GET
+    uri: https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/ExtentThreshold.txt
+  response:
+    body: {string: !!python/unicode "@prefix nidm_ExtentThreshold: <http://purl.org/nidash/nidm#NIDM_0000026>
+        .\n@prefix nidm_clusterSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000084>
+        .\n@prefix nidm_clusterSizeInResels: <http://purl.org/nidash/nidm#NIDM_0000156>
+        .\n@prefix nidm_pValueUncorrected: <http://purl.org/nidash/nidm#NIDM_0000116>
+        .\n@prefix nidm_pValueFWER: <http://purl.org/nidash/nidm#NIDM_0000115> .\n\n\nniiri:extent_threshold_id
+        a prov:Entity , nidm_ExtentThreshold: ;\n\trdfs:label \"Extent Threshold:
+        k>=0\" ;\n\tnidm_clusterSizeInVoxels: \"0\"^^xsd:int ;\n\tnidm_clusterSizeInResels:
+        \"0\"^^xsd:float ;\n\tnidm_pValueUncorrected: \"1\"^^xsd:float ;\n\tnidm_pValueFWER:
+        \"1\"^^xsd:float ."}
+    headers:
+      accept-ranges: [bytes]
+      access-control-allow-origin: ['https://render.githubusercontent.com']
+      cache-control: [max-age=300]
+      connection: [close]
+      content-length: ['649']
+      content-security-policy: [default-src 'none']
+      content-type: [text/plain; charset=utf-8]
+      date: ['Wed, 06 May 2015 16:05:51 GMT']
+      etag: ['"93c59cf149842bb992f7860551220c41ab9f5415"']
+      expires: ['Wed, 06 May 2015 16:10:51 GMT']
+      source-age: ['0']
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization,Accept-Encoding']
+      via: [1.1 varnish]
+      x-cache: [MISS]
+      x-cache-hits: ['0']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-served-by: [cache-sea1925-SEA]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [!!python/unicode raw.githubusercontent.com]
+      User-Agent: [Python-urllib/2.7]
+    method: GET
+    uri: https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/HeightThreshold_P.txt
+  response:
+    body: {string: !!python/unicode "@prefix nidm_HeightThreshold: <http://purl.org/nidash/nidm#NIDM_0000034>
+        .\n@prefix nidm_userSpecifiedThresholdType: <http://purl.org/nidash/nidm#NIDM_0000125>
+        .\n@prefix nidm_pValueUncorrected: <http://purl.org/nidash/nidm#NIDM_0000116>
+        .\n@prefix nidm_pValueFWER: <http://purl.org/nidash/nidm#NIDM_0000115> .\n\n\nniiri:height_threshold_id
+        a prov:Entity , nidm_HeightThreshold: ;\n\trdfs:label \"Height Threshold:
+        p<0.05 (FWE)\" ;\n\tnidm_userSpecifiedThresholdType: \"p-value FWE\"^^xsd:string
+        ;\n\tprov:value \"5.23529984739211\"^^xsd:float ;\n    nidm_pValueUncorrected:
+        \"7.62276079258051e-07\"^^xsd:float ;\n\tnidm_pValueFWER: \"0.05\"^^xsd:float
+        ."}
+    headers:
+      accept-ranges: [bytes]
+      access-control-allow-origin: ['https://render.githubusercontent.com']
+      cache-control: [max-age=300]
+      connection: [close]
+      content-length: ['630']
+      content-security-policy: [default-src 'none']
+      content-type: [text/plain; charset=utf-8]
+      date: ['Wed, 06 May 2015 16:05:53 GMT']
+      etag: ['"1aafb47422bbf6d86fb20ea51b716211de1f7219"']
+      expires: ['Wed, 06 May 2015 16:10:53 GMT']
+      source-age: ['0']
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization,Accept-Encoding']
+      via: [1.1 varnish]
+      x-cache: [MISS]
+      x-cache-hits: ['0']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-served-by: [cache-sea1926-SEA]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [!!python/unicode raw.githubusercontent.com]
+      User-Agent: [Python-urllib/2.7]
+    method: GET
+    uri: https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/Peak_ValueP.txt
+  response:
+    body: {string: !!python/unicode "@prefix nidm_Peak: <http://purl.org/nidash/nidm#NIDM_0000062>
+        .\n@prefix nidm_pValueUncorrected: <http://purl.org/nidash/nidm#NIDM_0000116>
+        .\n@prefix nidm_equivalentZStatistic: <http://purl.org/nidash/nidm#NIDM_0000092>
+        .\n@prefix nidm_pValueFWER: <http://purl.org/nidash/nidm#NIDM_0000115> .\n@prefix
+        nidm_qValueFDR: <http://purl.org/nidash/nidm#NIDM_0000119> .\n\n\nniiri:peak_0001
+        a prov:Entity , nidm_Peak: ;\n    rdfs:label \"Peak 0001\" ;\n    prov:atLocation
+        niiri:coordinate_0001 ;\n    nidm_pValueUncorrected: \"4.44089209850063e-16\"^^xsd:float
+        ;\n    nidm_equivalentZStatistic: \"INF\"^^xsd:float ;\n    prov:wasDerivedFrom
+        niiri:significant_cluster_0001 ;\n    prov:value \"13.9346199035645\"^^xsd:float
+        ;\n\tnidm_pValueFWER: \"0\"^^xsd:float ;\n\tnidm_qValueFDR: \"6.3705194444993e-11\"^^xsd:float
+        ."}
+    headers:
+      accept-ranges: [bytes]
+      access-control-allow-origin: ['https://render.githubusercontent.com']
+      cache-control: [max-age=300]
+      connection: [close]
+      content-length: ['784']
+      content-security-policy: [default-src 'none']
+      content-type: [text/plain; charset=utf-8]
+      date: ['Wed, 06 May 2015 16:05:54 GMT']
+      etag: ['"5e836134abe86b80326cd3191436958ea056aa1f"']
+      expires: ['Wed, 06 May 2015 16:10:54 GMT']
+      source-age: ['0']
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization,Accept-Encoding']
+      via: [1.1 varnish]
+      x-cache: [MISS]
+      x-cache-hits: ['0']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-served-by: [cache-sea1923-SEA]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [!!python/unicode raw.githubusercontent.com]
+      User-Agent: [Python-urllib/2.7]
+    method: GET
+    uri: https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/PeakDefinitionCriteria_MaxPeaks.txt
+  response:
+    body: {string: !!python/unicode "@prefix nidm_PeakDefinitionCriteria: <http://purl.org/nidash/nidm#NIDM_0000063>
+        .\n@prefix nidm_minDistanceBetweenPeaks: <http://purl.org/nidash/nidm#NIDM_0000109>
+        .\n@prefix nidm_maxNumberOfPeaksPerCluster: <http://purl.org/nidash/nidm#NIDM_0000108>
+        .\n\n\nniiri:peak_definition_criteria_id a prov:Entity , nidm_PeakDefinitionCriteria:
+        ;\n\trdfs:label \"Peak Definition Criteria\" ;\n\tnidm_minDistanceBetweenPeaks:
+        \"8.0\"^^xsd:float ;\n    nidm_maxNumberOfPeaksPerCluster: \"3\"^^xsd:int
+        ."}
+    headers:
+      accept-ranges: [bytes]
+      access-control-allow-origin: ['https://render.githubusercontent.com']
+      cache-control: [max-age=300]
+      connection: [close]
+      content-length: ['476']
+      content-security-policy: [default-src 'none']
+      content-type: [text/plain; charset=utf-8]
+      date: ['Wed, 06 May 2015 16:05:55 GMT']
+      etag: ['"87464520b868d5ec86c9ee243e8a397fcacbe827"']
+      expires: ['Wed, 06 May 2015 16:10:55 GMT']
+      source-age: ['0']
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization,Accept-Encoding']
+      via: [1.1 varnish]
+      x-cache: [MISS]
+      x-cache-hits: ['0']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-served-by: [cache-sea1924-SEA]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [!!python/unicode raw.githubusercontent.com]
+      User-Agent: [Python-urllib/2.7]
+    method: GET
+    uri: https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/SearchSpaceMaskMap.txt
+  response:
+    body: {string: !!python/unicode "@prefix nidm_SearchSpaceMaskMap: <http://purl.org/nidash/nidm#NIDM_0000068>
+        .\n@prefix nidm_inCoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000104>
+        .\n@prefix nidm_expectedNumberOfVoxelsPerCluster: <http://purl.org/nidash/nidm#NIDM_0000143>
+        .\n@prefix nidm_expectedNumberOfClusters: <http://purl.org/nidash/nidm#NIDM_0000141>
+        .\n@prefix nidm_heightCriticalThresholdFWE05: <http://purl.org/nidash/nidm#NIDM_0000147>
+        .\n@prefix nidm_heightCriticalThresholdFDR05: <http://purl.org/nidash/nidm#NIDM_0000146>
+        .\n@prefix nidm_searchVolumeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000121>
+        .\n@prefix nidm_searchVolumeInUnits: <http://purl.org/nidash/nidm#NIDM_0000136>
+        .\n@prefix nidm_reselSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000148>
+        .\n@prefix nidm_searchVolumeInResels: <http://purl.org/nidash/nidm#NIDM_0000149>
+        .\n@prefix nidm_randomFieldStationarity: <http://purl.org/nidash/nidm#NIDM_0000120>
+        .\n@prefix spm_smallestSignificantClusterSizeInVoxelsFWE05: <http://purl.org/nidash/spm#SPM_0000014>
+        .\n@prefix spm_smallestSignificantClusterSizeInVoxelsFDR05: <http://purl.org/nidash/spm#SPM_0000013>
+        .\n@prefix spm_searchVolumeReselsGeometry: <http://purl.org/nidash/spm#SPM_0000010>
+        .\n@prefix spm_noiseFWHMInVoxels: <http://purl.org/nidash/spm#SPM_0000009>
+        .\n@prefix spm_noiseFWHMInUnits: <http://purl.org/nidash/spm#SPM_0000007>
+        .\n\n\nniiri:search_space_mask_id a prov:Entity , nidm_SearchSpaceMaskMap:
+        ;\n\trdfs:label \"Search Space Mask Map\" ;\n\tprov:atLocation \"file:///path/to/SearchSpaceMask.nii.gz\"^^xsd:anyURI
+        ;\n\tnfo:fileName \"SearchSpaceMask.nii.gz\"^^xsd:string ;\n\tdct:format \"image/nifti\"^^xsd:string
+        ;\n\tnidm_inCoordinateSpace: niiri:coordinate_space_id_2 ;\n\tnidm_expectedNumberOfVoxelsPerCluster:
+        \"0.553331387916112\"^^xsd:float ;\n\tnidm_expectedNumberOfClusters: \"0.0889172687960151\"^^xsd:float
+        ;\n\tnidm_heightCriticalThresholdFWE05: \"5.23529984739211\"^^xsd:float ;\n\tnidm_heightCriticalThresholdFDR05:
+        \"6.22537899017334\"^^xsd:float ;\n\tspm_smallestSignificantClusterSizeInVoxelsFWE05:
+        \"1\"^^xsd:int ;\n\tspm_smallestSignificantClusterSizeInVoxelsFDR05: \"3\"^^xsd:int
+        ;\n\tnidm_searchVolumeInVoxels: \"65593\"^^xsd:int ;\n\tnidm_searchVolumeInUnits:
+        \"1771011\"^^xsd:float ;\n\tnidm_reselSizeInVoxels: \"22.9229643140043\"^^xsd:float
+        ;\n\tnidm_searchVolumeInResels: \"2552.68032521656\"^^xsd:float ;\n\tspm_searchVolumeReselsGeometry:
+        \"[3, 72.3216126440484, 850.716735116472, 2552.68032521656]\"^^xsd:string
+        ;\n\tspm_noiseFWHMInVoxels: \"[2.95881189165801, 2.96628446669584, 2.61180425626264]\"^^xsd:string
+        ;\n\tspm_noiseFWHMInUnits: \"[8.87643567497404, 8.89885340008753, 7.83541276878791]\"^^xsd:string
+        ;\n\tnidm_randomFieldStationarity: \"false\"^^xsd:boolean ;\n\tcrypto:sha512
+        \"e43b6e01b0463fe7d40782137867a...\"^^xsd:string ;\n\tprov:wasGeneratedBy
+        niiri:inference_id ."}
+    headers:
+      accept-ranges: [bytes]
+      access-control-allow-origin: ['https://render.githubusercontent.com']
+      cache-control: [max-age=300]
+      connection: [close]
+      content-length: ['2740']
+      content-security-policy: [default-src 'none']
+      content-type: [text/plain; charset=utf-8]
+      date: ['Wed, 06 May 2015 16:05:56 GMT']
+      etag: ['"22dd24a142d3e9809064c6962557337a762617f5"']
+      expires: ['Wed, 06 May 2015 16:10:56 GMT']
+      source-age: ['0']
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization,Accept-Encoding']
+      via: [1.1 varnish]
+      x-cache: [MISS]
+      x-cache-hits: ['0']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-served-by: [cache-sea1927-SEA]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [!!python/unicode raw.githubusercontent.com]
+      User-Agent: [Python-urllib/2.7]
+    method: GET
+    uri: https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_1.0.0/nidm/nidm-results/terms/examples/SignificantCluster.txt
+  response:
+    body: {string: !!python/unicode "@prefix nidm_SignificantCluster: <http://purl.org/nidash/nidm#NIDM_0000070>
+        .\n@prefix nidm_clusterSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000084>
+        .\n@prefix nidm_clusterLabelId: <http://purl.org/nidash/nidm#NIDM_0000082>
+        .\n@prefix nidm_clusterSizeInResels: <http://purl.org/nidash/nidm#NIDM_0000156>
+        .\n@prefix nidm_pValueUncorrected: <http://purl.org/nidash/nidm#NIDM_0000116>
+        .\n@prefix nidm_pValueFWER: <http://purl.org/nidash/nidm#NIDM_0000115> .\n@prefix
+        nidm_qValueFDR: <http://purl.org/nidash/nidm#NIDM_0000119> .\n\n\nniiri:significant_cluster_0001
+        a prov:Entity , nidm_SignificantCluster: ;\n\trdfs:label \"Significant Cluster
+        0001\" ;\n\tnidm_clusterSizeInVoxels: \"530\"^^xsd:int ;\n\tnidm_clusterLabelId:
+        \"1\"^^xsd:int ;\n\tnidm_clusterSizeInResels: \"23.1209189500945\"^^xsd:float
+        ;\n\tnidm_pValueUncorrected: \"9.56276736481136e-52\"^^xsd:float ;\n\tnidm_pValueFWER:
+        \"0\"^^xsd:float ;\n\tnidm_qValueFDR: \"7.65021389184909e-51\"^^xsd:float
+        ;\n\tprov:wasDerivedFrom niiri:excursion_set_map_id ."}
+    headers:
+      accept-ranges: [bytes]
+      access-control-allow-origin: ['https://render.githubusercontent.com']
+      cache-control: [max-age=300]
+      connection: [close]
+      content-length: ['981']
+      content-security-policy: [default-src 'none']
+      content-type: [text/plain; charset=utf-8]
+      date: ['Wed, 06 May 2015 16:05:58 GMT']
+      etag: ['"c56b1ee17749acf1195212854636205fca8279b6"']
+      expires: ['Wed, 06 May 2015 16:10:58 GMT']
+      source-age: ['0']
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization,Accept-Encoding']
+      via: [1.1 varnish]
+      x-cache: [MISS]
+      x-cache-hits: ['0']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-served-by: [cache-mia1323-MIA]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
 version: 1


### PR DESCRIPTION
The pull request introduces a new script `nidm/nidm-results/scripts/release_nidm_results.py` which can be used to generate an owl file for release. The script perform the following steps:
 - Copy the current owl file (in `nidm-results/terms/`) to the `release` folder.
 - Remove the imports commands and copy the imported triples directly in the release file.
 - Update the examples addresses (i.e. replace `https://raw.githubusercontent.com/incf-nidash/nidm/master/` by `https://raw.githubusercontent.com/incf-nidash/nidm/NIDM-Results_x.x.x`
 - For a release version older (or equal to) 1.0.0, remove AFNI-related terms (not yet ready for release).

The script can be called as follows (replace "1.0.0" with the appropriate version number):
```
python nidm/nidm-results/scripts/release_nidm_results.py 1.0.0
```

After invoking `release_nidm_results.py`, a git tag named "NIDM-Results_x.x.x" must be created (to keep track of the current state of the examples).