### PR TITLE
nidm-results.html redirects to 1.1.0 spec

### DIFF
--- a/doc/content/specs/nidm-results.html
+++ b/doc/content/specs/nidm-results.html
@@ -5,7 +5,7 @@
 		<meta charset='utf-8'>
 		<script src='http://www.w3.org/Tools/respec/respec-w3c-common'
 		async class='remove'></script>
-		<meta http-equiv="refresh" content="0; url=./nidm-results_100.html" />
+		<meta http-equiv="refresh" content="0; url=./nidm-results_110.html" />
 	</head>
 	<body>
 	</body>


### PR DESCRIPTION
This is a small fix that should have been implemented as part of https://github.com/incf-nidash/nidm/pull/334.