### PR TITLE
fixed typo in homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@ Neuroimaging Data Model            </a>
         <h1 class="entry-title"></h1>
         
         <div class="entry-content">
-            <p>The Neuroimaging Data Model (NIDM) is a collection of specification documents that define extensions the the <a href="http://www.w3.org/TR/prov-primer/">W3C PROV</a> standard for the domain of human brain mapping. NIDM uses provenance information as means to link components from different stages of the scientific research process from dataset descriptors and computational workflow, to derived data and publication.
+            <p>The Neuroimaging Data Model (NIDM) is a collection of specification documents that define extensions to the <a href="http://www.w3.org/TR/prov-primer/">W3C PROV</a> standard for the domain of human brain mapping. NIDM uses provenance information as means to link components from different stages of the scientific research process from dataset descriptors and computational workflow, to derived data and publication.
 </br>
 </br>
 </br>


### PR DESCRIPTION
I fixed a typo in the nidash-homepage.

"that define extensions the the" to "that define extensions to the"