### PR TITLE
WIP: Example freesurfer data cube

### DIFF
--- a/nidm/nidm-experiment/ncanda/check_cube_for_duplicate_obs.rq
+++ b/nidm/nidm-experiment/ncanda/check_cube_for_duplicate_obs.rq
@@ -1,0 +1,32 @@
+prefix rdfs:     <http://www.w3.org/2000/01/rdf-schema#>
+prefix owl:      <http://www.w3.org/2002/07/owl#>
+prefix xsd:      <http://www.w3.org/2001/XMLSchema#>
+prefix skos:     <http://www.w3.org/2004/02/skos/core#>
+prefix void:     <http://rdfs.org/ns/void#>
+prefix dct:      <http://purl.org/dc/terms/>
+prefix foaf:     <http://xmlns.com/foaf/0.1/>
+
+prefix qb:       <http://purl.org/linked-data/cube#>
+
+prefix ncanda:   <http://ncanda.sri.com/terms.ttl#>
+prefix fma:      <http://purl.org/sig/fma#>
+prefix prov:     <http://w3c.org/ns/prov#>
+prefix nidm:     <http://purl.org/nidash/nidm#>
+prefix fs:       <http://www.incf.org/ns/nidash/fs#>
+
+ASK {
+  FILTER( ?allEqual )
+  {
+    # For each pair of observations test if all the dimension values are the same
+    SELECT (MIN(?equal) AS ?allEqual) WHERE {
+        ?obs1 qb:dataSet ?dataset .
+        ?obs2 qb:dataSet ?dataset .
+        FILTER (?obs1 != ?obs2)
+        ?dataset qb:structure/qb:component/qb:componentProperty ?dim .
+        ?dim a qb:DimensionProperty .
+        ?obs1 ?dim ?value1 .
+        ?obs2 ?dim ?value2 .
+        BIND( ?value1 = ?value2 AS ?equal)
+    } GROUP BY ?obs1 ?obs2
+  }
+}

--- a/nidm/nidm-experiment/ncanda/fs-cube.ttl
+++ b/nidm/nidm-experiment/ncanda/fs-cube.ttl
@@ -1,0 +1,267 @@
+@prefix rdf:      <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:     <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl:      <http://www.w3.org/2002/07/owl#> .
+@prefix xsd:      <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos:     <http://www.w3.org/2004/02/skos/core#> .
+@prefix void:     <http://rdfs.org/ns/void#> .
+@prefix dct:      <http://purl.org/dc/terms/> .
+@prefix foaf:     <http://xmlns.com/foaf/0.1/> .
+@prefix org:      <http://www.w3.org/ns/org#> .
+@prefix admingeo: <http://data.ordnancesurvey.co.uk/ontology/admingeo/> .
+@prefix interval: <http://reference.data.gov.uk/def/intervals/> .
+
+@prefix qb:       <http://purl.org/linked-data/cube#> .
+
+@prefix sdmx-concept:    <http://purl.org/linked-data/sdmx/2009/concept#> .
+@prefix sdmx-dimension:  <http://purl.org/linked-data/sdmx/2009/dimension#> .
+@prefix sdmx-attribute:  <http://purl.org/linked-data/sdmx/2009/attribute#> .
+@prefix sdmx-measure:    <http://purl.org/linked-data/sdmx/2009/measure#> .
+@prefix sdmx-metadata:   <http://purl.org/linked-data/sdmx/2009/metadata#> .
+@prefix sdmx-code:       <http://purl.org/linked-data/sdmx/2009/code#> .
+@prefix sdmx-subject:    <http://purl.org/linked-data/sdmx/2009/subject#> .
+
+@prefix ncanda:   <http://ncanda.sri.com/terms.ttl#> .
+@prefix fma:      <http://purl.org/sig/fma#> .
+@prefix prov:     <http://w3c.org/ns/prov#> .
+@prefix nidm:     <http://purl.org/nidash/nidm#> .
+@prefix fs:       <http://www.incf.org/ns/nidash/fs#> .
+
+# -- Data Set --------------------------------------------
+
+ncanda:ncanda_release_001 a qb:DataSet, prov:Entity, prov:Collection, prov:Bundle ;
+    dct:title              "NCANDA Release 001"@en ;
+    rdfs:label             "NCANDA Release 001"@en ;
+    rdfs:comment           "Average cortical thickness across NCANDA participants."@en ;
+    dct:description        "Average cortical thickness across NCANDA participants."@en ;
+    dct:publisher          ncanda:sri_international ;
+    prov:wasAttributedTo   ncanda:sri_international ;
+    dct:issued             "2015-11-05"^^xsd:date ;
+    dct:subject            nidm:freesurfer ;
+    qb:structure           ncanda:freesurfer-dsd ;
+    nidm:unitMeasure       nidm:milimeters ;
+    qb:slice               ncanda:slice1, ncanda:slice2, ncanda:slice3, ncanda:slice4, ncanda:slice5, ncanda:slice6 ;
+    prov:hadMember         ncanda:slice1, ncanda:slice2, ncanda:slice3, ncanda:slice4, ncanda:slice5, ncanda:slice6 ;
+    .
+
+ncanda:sri_international a org:Organization, foaf:Agent, prov:Agent, prov:Organization ;
+    rdfs:label "SRI International"@en .
+
+# -- Data structure definition ----------------------------
+
+ncanda:freesurfer-dsd a qb:DataStructureDefinition ;
+    qb:component
+    # The dimensions
+        [ qb:dimension ncanda:participant ; qb:order 1 ],
+        [ qb:dimension ncanda:studyEvent ;  qb:order 2 ; qb:componentAttachment qb:Slice ],
+        [ qb:dimension ncanda:hemisphere ;  qb:order 3 ; qb:componentAttachment qb:Slice ],
+        [ qb:dimension ncanda:brainRegion ;  qb:order 4 ; qb:componentAttachment qb:Slice ] ;
+
+    # The measure(s)
+    qb:component [ qb:measure fs:meanThickness],
+                 [ qb:measure fs:thickSTD] ;
+
+    # The attributes
+    qb:component [ qb:attribute nidm:unitMeasure ;
+                   qb:componentRequired "true"^^xsd:boolean ;
+                   qb:componentAttachment qb:DataSet; ] ;
+
+    # slices
+    qb:sliceKey ncanda:sliceByParticipant ;
+    .
+
+# Slice Key
+ncanda:sliceByParticipant a qb:SliceKey;
+    rdfs:label "slice by participant"@en;
+    rdfs:comment "Slice by grouping particpants together, fixing studyEvent, hemisphere, and brain region values"@en;
+    qb:componentProperty nidm:studyEvent, fs:hemisphere, fs:brainRegion ;
+    .
+
+# -- Dimensions  ----------------------------------------
+
+ncanda:participant a rdf:Property, qb:DimensionProperty ;
+    rdfs:label "study participant"@en ;
+    rdfs:subPropertyOf nidm:participant ;
+    rdfs:range xsd:string ;
+    qb:concept nidm:Participant ;
+    .
+
+ncanda:studyEvent  a rdf:Property, qb:DimensionProperty ;
+    rdfs:label "study event"@en ;
+    rdfs:subPropertyOf nidm:studyEvent ;
+    rdfs:range xsd:string ;
+    qb:concept nidm:StudyEvent ;
+    .
+
+ncanda:hemisphere  a rdf:Property, qb:DimensionProperty ;
+    rdfs:label "hemisphere"@en ;
+    rdfs:subPropertyOf fs:hemisphere ;
+    rdfs:range xsd:string ;
+    qb:concept fma:Hemisphere ;
+    .
+
+ncanda:brainRegion  a rdf:Property, qb:DimensionProperty ;
+    rdfs:label "brain region"@en ;
+    rdfs:subPropertyOf fs:brainRegion ;
+    rdfs:range xsd:string ;
+    qb:concept fma:BrainRegion ;
+    .
+
+# -- Measure(s) -------------------------------------------
+
+fs:meanThickness  a rdf:Property, qb:MeasureProperty ;
+    rdfs:label "mean thickness"@en ;
+    rdfs:subPropertyOf prov:value ;
+    rdfs:range xsd:float ;
+    .
+
+fs:thickSTD  a rdf:Property, qb:MeasureProperty ;
+    rdfs:label "thickness standard deviation"@en ;
+    rdfs:subPropertyOf prov:value ;
+    rdfs:range xsd:float ;
+    .
+
+# -- Observations -----------------------------------------
+
+# Column 1
+
+ncanda:slice1 a qb:Slice, prov:Entity, prov:Collection ;
+    qb:sliceStructure  ncanda:sliceByParticipant ;
+    ncanda:studyEvent  "baseline" ;
+    ncanda:hemisphere  fma:RightHemisphere ;
+    ncanda:brainRegion fma:Precuneus ;
+    qb:observation ncanda:obs1 ;
+    prov:hadMember ncanda:obs1 ;
+    .
+
+ncanda:obs1 a qb:Observation, prov:Entity ;
+    qb:dataSet            ncanda:ncanda_release_001 ;
+    ncanda:participant    "NCANDA_S00033"   ;
+    fs:meanThickness      2.583 ;
+    fs:thickSTD           0.698 ;
+    .
+
+# Column 2
+
+ncanda:slice2 a qb:Slice, prov:Entity, prov:Collection ;
+    qb:sliceStructure  ncanda:sliceByParticipant ;
+    ncanda:studyEvent  "baseline" ;
+    ncanda:hemisphere  fma:RightHemisphere ;
+    ncanda:brainRegion fma:Precentral ;
+    qb:observation ncanda:obs2 ;
+    prov:hadMember ncanda:obs2 ;
+    .
+
+ncanda:obs2 a qb:Observation, prov:Entity ;
+    qb:dataSet            ncanda:ncanda_release_001 ;
+    ncanda:participant    "NCANDA_S00033"   ;
+    fs:meanThickness      2.583 ;
+    fs:thickSTD           0.698 ;
+    .
+
+# Column 3
+
+ncanda:slice3 a qb:Slice, prov:Entity, prov:Collection ;
+    qb:sliceStructure  ncanda:sliceByParticipant ;
+    ncanda:studyEvent  "baseline" ;
+    ncanda:hemisphere  fma:LeftHemisphere ;
+    ncanda:brainRegion fma:Precuneus ;
+    qb:observation ncanda:obs3 ;
+    prov:hadMember ncanda:obs3 ;
+    .
+
+ncanda:obs3 a qb:Observation, prov:Entity ;
+    qb:dataSet            ncanda:ncanda_release_001 ;
+    ncanda:participant    "NCANDA_S00033"   ;
+    fs:meanThickness      2.583 ;
+    fs:thickSTD           0.698 ;
+    .
+
+# Column 4
+
+ncanda:slice4 a qb:Slice, prov:Entity, prov:Collection ;
+    qb:sliceStructure  ncanda:sliceByParticipant ;
+    ncanda:studyEvent  "baseline" ;
+    ncanda:hemisphere  fma:LeftHemisphere ;
+    ncanda:brainRegion fma:Precentral ;
+    qb:observation ncanda:obs4 ;
+    prov:hadMember ncanda:obs4 ;
+    .
+
+ncanda:obs4 a qb:Observation, prov:Entity ;
+    qb:dataSet            ncanda:ncanda_release_001 ;
+    ncanda:participant    "NCANDA_S00033"   ;
+    fs:meanThickness      2.583 ;
+    fs:thickSTD           0.698 ;
+    .
+
+# Column 5
+
+ncanda:slice5 a qb:Slice, prov:Entity, prov:Collection ;
+    qb:sliceStructure  ncanda:sliceByParticipant ;
+    ncanda:studyEvent  "followup_1yr" ;
+    ncanda:hemisphere  fma:RightHemisphere ;
+    ncanda:brainRegion fma:Precuneus ;
+    qb:observation ncanda:obs5 ;
+    prov:hadMember ncanda:obs5 ;
+    .
+
+ncanda:obs5 a qb:Observation, prov:Entity ;
+    qb:dataSet            ncanda:ncanda_release_001 ;
+    ncanda:participant    "NCANDA_S00033"   ;
+    fs:meanThickness      2.583 ;
+    fs:thickSTD           0.698 ;
+    .
+
+# Column 6
+
+ncanda:slice6 a qb:Slice, prov:Entity, prov:Collection ;
+    qb:sliceStructure  ncanda:sliceByParticipant ;
+    ncanda:studyEvent  "followup_1yr" ;
+    ncanda:hemisphere  fma:RightHemisphere ;
+    ncanda:brainRegion fma:Precentral ;
+    qb:observation ncanda:obs6 ;
+    prov:hadMember ncanda:obs6 ;
+    .
+
+ncanda:obs6 a qb:Observation, prov:Entity ;
+    qb:dataSet            ncanda:ncanda_release_001 ;
+    ncanda:participant    "NCANDA_S00033"   ;
+    fs:meanThickness      2.583 ;
+    fs:thickSTD           0.698 ;
+    .
+
+# Column 7
+
+ncanda:slice7 a qb:Slice, prov:Entity, prov:Collection ;
+    qb:sliceStructure  ncanda:sliceByParticipant ;
+    ncanda:studyEvent  "followup_1yr" ;
+    ncanda:hemisphere  fma:LeftHemisphere ;
+    ncanda:brainRegion fma:Precuneus ;
+    qb:observation ncanda:obs7 ;
+    prov:hadMember ncanda:obs7 ;
+    .
+
+ncanda:obs7 a qb:Observation, prov:Entity ;
+    qb:dataSet            ncanda:ncanda_release_001 ;
+    ncanda:participant    "NCANDA_S00033"   ;
+    fs:meanThickness      2.583 ;
+    fs:thickSTD           0.698 ;
+    .
+
+# Column 8
+
+ncanda:slice8 a qb:Slice, prov:Entity, prov:Collection ;
+    qb:sliceStructure  ncanda:sliceByParticipant ;
+    ncanda:studyEvent  "followup_1yr" ;
+    ncanda:hemisphere  fma:LeftHemisphere ;
+    ncanda:brainRegion fma:Precentral ;
+    qb:observation ncanda:obs8 ;
+    prov:hadMember ncanda:obs8 ;
+    .
+
+ncanda:obs8 a qb:Observation, prov:Entity ;
+    qb:dataSet            ncanda:ncanda_release_001 ;
+    ncanda:participant    "NCANDA_S00033"   ;
+    fs:meanThickness      2.583 ;
+    fs:thickSTD           0.698 ;
+    .

--- a/nidm/nidm-experiment/ncanda/fs-cube.ttl
+++ b/nidm/nidm-experiment/ncanda/fs-cube.ttl
@@ -154,8 +154,8 @@ ncanda:slice2 a qb:Slice, prov:Entity, prov:Collection ;
 ncanda:obs2 a qb:Observation, prov:Entity ;
     qb:dataSet            ncanda:ncanda_release_001 ;
     ncanda:participant    "NCANDA_S00033"   ;
-    fs:meanThickness      2.583 ;
-    fs:thickSTD           0.698 ;
+    fs:meanThickness      2.552 ;
+    fs:thickSTD           0.578 ;
     .
 
 # Column 3
@@ -172,8 +172,8 @@ ncanda:slice3 a qb:Slice, prov:Entity, prov:Collection ;
 ncanda:obs3 a qb:Observation, prov:Entity ;
     qb:dataSet            ncanda:ncanda_release_001 ;
     ncanda:participant    "NCANDA_S00033"   ;
-    fs:meanThickness      2.583 ;
-    fs:thickSTD           0.698 ;
+    fs:meanThickness      2.481 ;
+    fs:thickSTD           0.498 ;
     .
 
 # Column 4
@@ -190,8 +190,8 @@ ncanda:slice4 a qb:Slice, prov:Entity, prov:Collection ;
 ncanda:obs4 a qb:Observation, prov:Entity ;
     qb:dataSet            ncanda:ncanda_release_001 ;
     ncanda:participant    "NCANDA_S00033"   ;
-    fs:meanThickness      2.583 ;
-    fs:thickSTD           0.698 ;
+    fs:meanThickness      2.473 ;
+    fs:thickSTD           0.670 ;
     .
 
 # Column 5
@@ -208,8 +208,8 @@ ncanda:slice5 a qb:Slice, prov:Entity, prov:Collection ;
 ncanda:obs5 a qb:Observation, prov:Entity ;
     qb:dataSet            ncanda:ncanda_release_001 ;
     ncanda:participant    "NCANDA_S00033"   ;
-    fs:meanThickness      2.583 ;
-    fs:thickSTD           0.698 ;
+    fs:meanThickness      2.451 ;
+    fs:thickSTD           0.701 ;
     .
 
 # Column 6
@@ -226,8 +226,8 @@ ncanda:slice6 a qb:Slice, prov:Entity, prov:Collection ;
 ncanda:obs6 a qb:Observation, prov:Entity ;
     qb:dataSet            ncanda:ncanda_release_001 ;
     ncanda:participant    "NCANDA_S00033"   ;
-    fs:meanThickness      2.583 ;
-    fs:thickSTD           0.698 ;
+    fs:meanThickness      2.567 ;
+    fs:thickSTD           0.456 ;
     .
 
 # Column 7
@@ -244,8 +244,8 @@ ncanda:slice7 a qb:Slice, prov:Entity, prov:Collection ;
 ncanda:obs7 a qb:Observation, prov:Entity ;
     qb:dataSet            ncanda:ncanda_release_001 ;
     ncanda:participant    "NCANDA_S00033"   ;
-    fs:meanThickness      2.583 ;
-    fs:thickSTD           0.698 ;
+    fs:meanThickness      2.356 ;
+    fs:thickSTD           0.765 ;
     .
 
 # Column 8
@@ -262,6 +262,6 @@ ncanda:slice8 a qb:Slice, prov:Entity, prov:Collection ;
 ncanda:obs8 a qb:Observation, prov:Entity ;
     qb:dataSet            ncanda:ncanda_release_001 ;
     ncanda:participant    "NCANDA_S00033"   ;
-    fs:meanThickness      2.583 ;
-    fs:thickSTD           0.698 ;
+    fs:meanThickness      2.456 ;
+    fs:thickSTD           0.432 ;
     .

--- a/nidm/nidm-experiment/ncanda/ncanda-event-hemi-region-thick.rq
+++ b/nidm/nidm-experiment/ncanda/ncanda-event-hemi-region-thick.rq
@@ -1,0 +1,30 @@
+# Get a table of thickness measures
+
+prefix rdfs:     <http://www.w3.org/2000/01/rdf-schema#>
+prefix owl:      <http://www.w3.org/2002/07/owl#>
+prefix xsd:      <http://www.w3.org/2001/XMLSchema#>
+prefix skos:     <http://www.w3.org/2004/02/skos/core#>
+prefix void:     <http://rdfs.org/ns/void#>
+prefix dct:      <http://purl.org/dc/terms/>
+prefix foaf:     <http://xmlns.com/foaf/0.1/>
+
+prefix qb:       <http://purl.org/linked-data/cube#>
+
+prefix ncanda:   <http://ncanda.sri.com/terms.ttl#>
+prefix fma:      <http://purl.org/sig/fma#>
+prefix prov:     <http://w3c.org/ns/prov#>
+prefix nidm:     <http://purl.org/nidash/nidm#>
+prefix fs:       <http://www.incf.org/ns/nidash/fs#>
+
+SELECT DISTINCT ?participant ?study_event ?hemipshere ?brain_region ?mean_thickness ?thickness_std
+WHERE {?obs a qb:Observation ;
+            # Observations have the measures and row index
+            ncanda:participant ?participant ;
+            fs:meanThickness ?mean_thickness ;
+            fs:thickSTD ?thickness_std .
+      ?slice a qb:Slice ;
+             # Slices have the dimension information for grouping
+             qb:observation ?obs ;
+             ncanda:hemisphere ?hemipshere ;
+             ncanda:brainRegion ?brain_region ;
+             ncanda:studyEvent ?study_event .}

--- a/nidm/nidm-experiment/ncanda/ncanda-measures-name-datatype.rq
+++ b/nidm/nidm-experiment/ncanda/ncanda-measures-name-datatype.rq
@@ -1,0 +1,27 @@
+# Get a table of the available measures, their name, and datatype
+prefix rdfs:     <http://www.w3.org/2000/01/rdf-schema#>
+prefix owl:      <http://www.w3.org/2002/07/owl#>
+prefix xsd:      <http://www.w3.org/2001/XMLSchema#>
+prefix skos:     <http://www.w3.org/2004/02/skos/core#>
+prefix void:     <http://rdfs.org/ns/void#>
+prefix dct:      <http://purl.org/dc/terms/>
+prefix foaf:     <http://xmlns.com/foaf/0.1/>
+
+prefix qb:       <http://purl.org/linked-data/cube#>
+
+prefix ncanda:   <http://ncanda.sri.com/terms.ttl#>
+prefix fma:      <http://purl.org/sig/fma#>
+prefix prov:     <http://w3c.org/ns/prov#>
+prefix nidm:     <http://purl.org/nidash/nidm#>
+prefix fs:       <http://www.incf.org/ns/nidash/fs#>
+
+SELECT DISTINCT ?measure ?name ?datatype
+WHERE {ncanda:freesurfer-dsd a qb:DataStructureDefinition ;
+               # measures are attached to a data structure definition as a
+               # blank node to illustrate this only holds true in this document
+							 qb:component [ qb:measure ?measure ] .
+       ?measure rdfs:label ?name ;
+                # measures are also given datatype information directly in The
+                # document
+                rdfs:range ?datatype .
+            }


### PR DESCRIPTION
This PR adds an example [RDF Data Cube][1] to nidm experiment for discussion on the monday call. This model is based off of the freesurfer example and includes additional information that would be appropriate for a data dictionary/common data element model. I've also included some preliminary mappings to PROV.

A complete example includes the following corresponding information:
- [X] Data Set
- [X] Data Structure Definition
- [X] Slice Key Mappings
  - [X] Dimensions
  - [X] Measures
  - [X] Observations
- [ ] Vocabularies (links are examples with sdmx)
  - [ ] Concept Vocabulary - http://purl.org/linked-data/sdmx/2009/concept#
  - [ ] Dimension Vocabulary http://purl.org/linked-data/sdmx/2009/dimension#
  - [ ] Attribute Vocabulary - http://purl.org/linked-data/sdmx/2009/attribute#
  - [ ] Measure Vocabulary - http://purl.org/linked-data/sdmx/2009/measure#
  - [ ] Code Vocabulary - http://purl.org/linked-data/sdmx/2009/code#

[1]:  http://www.w3.org/TR/vocab-data-cube/