### PR TITLE
Explicitely use "nidm" prefix in nidm-experiment.owl

### DIFF
--- a/nidm/nidm-experiment/terms/nidm-experiment.owl
+++ b/nidm/nidm-experiment/terms/nidm-experiment.owl
@@ -1,4 +1,3 @@
-@prefix : <http://purl.org/nidash/nidm#> .
 @prefix ro: <http://www.obofoundry.org/ro/ro.owl#> .
 @prefix bfo: <http://www.ifomis.org/bfo/1.1#> .
 @prefix dct: <http://purl.org/dc/terms/> .
@@ -128,7 +127,7 @@ dct:hasPart rdf:type owl:ObjectProperty .
 
 ###  http://purl.org/nidash/nidm#NIDM_0000010
 
-:NIDM_0000010 rdf:type owl:ObjectProperty ;
+nidm:NIDM_0000010 rdf:type owl:ObjectProperty ;
               
               rdfs:label "has fMRI Design" ;
               
@@ -138,7 +137,7 @@ dct:hasPart rdf:type owl:ObjectProperty .
               
               obo:IAO_0000114 obo:IAO_0000122 ;
               
-              rdfs:range :NIDM_0000155 .
+              rdfs:range nidm:NIDM_0000155 .
 
 
 
@@ -182,14 +181,14 @@ dct:title rdf:type owl:DatatypeProperty .
 
 ###  http://purl.org/nidash/nidm#AcquisitionObject
 
-:AcquisitionObject rdf:type owl:Class ;
+nidm:AcquisitionObject rdf:type owl:Class ;
                    
                    rdfs:label "Acquisition Object"^^xsd:string ;
                    
                    rdfs:subClassOf prov:Entity ,
                                    [ rdf:type owl:Restriction ;
                                      owl:onProperty prov:specializationOf ;
-                                     owl:onClass :StudyObject ;
+                                     owl:onClass nidm:StudyObject ;
                                      owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger
                                    ] ;
                    
@@ -203,7 +202,7 @@ dct:title rdf:type owl:DatatypeProperty .
 
 ###  http://purl.org/nidash/nidm#AnatomicalScan
 
-:AnatomicalScan rdf:type owl:Class ;
+nidm:AnatomicalScan rdf:type owl:Class ;
                 
                 rdfs:subClassOf prov:Entity .
 
@@ -211,7 +210,7 @@ dct:title rdf:type owl:DatatypeProperty .
 
 ###  http://purl.org/nidash/nidm#AnatomyImagingAcquisition
 
-:AnatomyImagingAcquisition rdf:type owl:Class ;
+nidm:AnatomyImagingAcquisition rdf:type owl:Class ;
                            
                            rdfs:subClassOf prov:Activity .
 
@@ -219,7 +218,7 @@ dct:title rdf:type owl:DatatypeProperty .
 
 ###  http://purl.org/nidash/nidm#BaselineProtocol
 
-:BaselineProtocol rdf:type owl:Class ;
+nidm:BaselineProtocol rdf:type owl:Class ;
                   
                   rdfs:label "Baseline Protocol"^^xsd:string ;
                   
@@ -235,7 +234,7 @@ dct:title rdf:type owl:DatatypeProperty .
 
 ###  http://purl.org/nidash/nidm#BehaviorAndConsitionOnsets
 
-:BehaviorAndConsitionOnsets rdf:type owl:Class ;
+nidm:BehaviorAndConsitionOnsets rdf:type owl:Class ;
                             
                             rdfs:subClassOf prov:Entity .
 
@@ -243,7 +242,7 @@ dct:title rdf:type owl:DatatypeProperty .
 
 ###  http://purl.org/nidash/nidm#Condition
 
-:Condition rdf:type owl:Class ;
+nidm:Condition rdf:type owl:Class ;
            
            rdfs:subClassOf prov:Entity .
 
@@ -251,7 +250,7 @@ dct:title rdf:type owl:DatatypeProperty .
 
 ###  http://purl.org/nidash/nidm#Contrast
 
-:Contrast rdf:type owl:Class ;
+nidm:Contrast rdf:type owl:Class ;
           
           rdfs:subClassOf prov:Entity .
 
@@ -259,7 +258,7 @@ dct:title rdf:type owl:DatatypeProperty .
 
 ###  http://purl.org/nidash/nidm#DataCollection
 
-:DataCollection rdf:type owl:Class ;
+nidm:DataCollection rdf:type owl:Class ;
                 
                 rdfs:subClassOf prov:Collection .
 
@@ -267,11 +266,11 @@ dct:title rdf:type owl:DatatypeProperty .
 
 ###  http://purl.org/nidash/nidm#DemographicsAcquisitionObject
 
-:DemographicsAcquisitionObject rdf:type owl:Class ;
+nidm:DemographicsAcquisitionObject rdf:type owl:Class ;
                                
                                rdfs:label "Demographics Acquisition Object"^^xsd:string ;
                                
-                               rdfs:subClassOf :AcquisitionObject ;
+                               rdfs:subClassOf nidm:AcquisitionObject ;
                                
                                obo:IAO_0000115 "A demographics acquisition object is an entity that represents the demographics information acquired from a person in the participant role."^^xsd:string ;
                                
@@ -283,7 +282,7 @@ dct:title rdf:type owl:DatatypeProperty .
 
 ###  http://purl.org/nidash/nidm#FunctionalScan
 
-:FunctionalScan rdf:type owl:Class ;
+nidm:FunctionalScan rdf:type owl:Class ;
                 
                 rdfs:subClassOf prov:Entity .
 
@@ -291,7 +290,7 @@ dct:title rdf:type owl:DatatypeProperty .
 
 ###  http://purl.org/nidash/nidm#Group
 
-:Group rdf:type owl:Class ;
+nidm:Group rdf:type owl:Class ;
        
        rdfs:subClassOf prov:Collection .
 
@@ -299,7 +298,7 @@ dct:title rdf:type owl:DatatypeProperty .
 
 ###  http://purl.org/nidash/nidm#InvestigationCollection
 
-:InvestigationCollection rdf:type owl:Class ;
+nidm:InvestigationCollection rdf:type owl:Class ;
                          
                          rdfs:subClassOf prov:Collection .
 
@@ -307,7 +306,7 @@ dct:title rdf:type owl:DatatypeProperty .
 
 ###  http://purl.org/nidash/nidm#InvestigationProcess
 
-:InvestigationProcess rdf:type owl:Class ;
+nidm:InvestigationProcess rdf:type owl:Class ;
                       
                       rdfs:subClassOf prov:Activity .
 
@@ -315,11 +314,11 @@ dct:title rdf:type owl:DatatypeProperty .
 
 ###  http://purl.org/nidash/nidm#MRIAcquisitionObject
 
-:MRIAcquisitionObject rdf:type owl:Class ;
+nidm:MRIAcquisitionObject rdf:type owl:Class ;
                       
                       rdfs:label "MRI Acquisition Object"^^xsd:string ;
                       
-                      rdfs:subClassOf :AcquisitionObject ;
+                      rdfs:subClassOf nidm:AcquisitionObject ;
                       
                       obo:IAO_0000115 "An MRI acquisition object represents a specific series or scan during an MRI study."^^xsd:string ;
                       
@@ -331,7 +330,7 @@ dct:title rdf:type owl:DatatypeProperty .
 
 ###  http://purl.org/nidash/nidm#MRScanner
 
-:MRScanner rdf:type owl:Class ;
+nidm:MRScanner rdf:type owl:Class ;
            
            rdfs:subClassOf prov:Agent .
 
@@ -339,7 +338,7 @@ dct:title rdf:type owl:DatatypeProperty .
 
 ###  http://purl.org/nidash/nidm#Model
 
-:Model rdf:type owl:Class ;
+nidm:Model rdf:type owl:Class ;
        
        rdfs:subClassOf prov:Entity .
 
@@ -347,7 +346,7 @@ dct:title rdf:type owl:DatatypeProperty .
 
 ###  http://purl.org/nidash/nidm#ModelSpecification
 
-:ModelSpecification rdf:type owl:Class ;
+nidm:ModelSpecification rdf:type owl:Class ;
                     
                     rdfs:subClassOf prov:Activity .
 
@@ -355,7 +354,7 @@ dct:title rdf:type owl:DatatypeProperty .
 
 ###  http://purl.org/nidash/nidm#NIDM_0000155
 
-:NIDM_0000155 rdf:type owl:Class ;
+nidm:NIDM_0000155 rdf:type owl:Class ;
               
               rdfs:label "fMRI Design Type" ;
               
@@ -371,7 +370,7 @@ dct:title rdf:type owl:DatatypeProperty .
 
 ###  http://purl.org/nidash/nidm#PresentationSoftware
 
-:PresentationSoftware rdf:type owl:Class ;
+nidm:PresentationSoftware rdf:type owl:Class ;
                       
                       rdfs:subClassOf prov:SoftwareAgent .
 
@@ -379,7 +378,7 @@ dct:title rdf:type owl:DatatypeProperty .
 
 ###  http://purl.org/nidash/nidm#PrincipalInvestigator
 
-:PrincipalInvestigator rdf:type owl:Class ;
+nidm:PrincipalInvestigator rdf:type owl:Class ;
                        
                        rdfs:label "Principal Investigator"^^xsd:string ;
                        
@@ -395,14 +394,14 @@ dct:title rdf:type owl:DatatypeProperty .
 
 ###  http://purl.org/nidash/nidm#ProjectObject
 
-:ProjectObject rdf:type owl:Class ;
+nidm:ProjectObject rdf:type owl:Class ;
                
                rdfs:label "Project Object"^^xsd:string ;
                
                rdfs:subClassOf prov:Entity ,
                                [ rdf:type owl:Restriction ;
                                  owl:onProperty dct:hasPart ;
-                                 owl:someValuesFrom :StudyObject
+                                 owl:someValuesFrom nidm:StudyObject
                                ] ;
                
                obo:IAO_0000115 "A project object is an entity that represents administrative information about one or more studies."^^xsd:string ;
@@ -415,7 +414,7 @@ dct:title rdf:type owl:DatatypeProperty .
 
 ###  http://purl.org/nidash/nidm#ResearchAssistant
 
-:ResearchAssistant rdf:type owl:Class ;
+nidm:ResearchAssistant rdf:type owl:Class ;
                    
                    rdfs:label "Research Assistant"^^xsd:string ;
                    
@@ -431,7 +430,7 @@ dct:title rdf:type owl:DatatypeProperty .
 
 ###  http://purl.org/nidash/nidm#SessionAcquisition
 
-:SessionAcquisition rdf:type owl:Class ;
+nidm:SessionAcquisition rdf:type owl:Class ;
                     
                     rdfs:subClassOf prov:Activity .
 
@@ -439,18 +438,18 @@ dct:title rdf:type owl:DatatypeProperty .
 
 ###  http://purl.org/nidash/nidm#StudyObject
 
-:StudyObject rdf:type owl:Class ;
+nidm:StudyObject rdf:type owl:Class ;
              
              rdfs:label "Study Object"^^xsd:string ;
              
              rdfs:subClassOf prov:Entity ,
                              [ rdf:type owl:Restriction ;
                                owl:onProperty dct:hasPart ;
-                               owl:someValuesFrom :AcquisitionObject
+                               owl:someValuesFrom nidm:AcquisitionObject
                              ] ,
                              [ rdf:type owl:Restriction ;
                                owl:onProperty prov:specializationOf ;
-                               owl:onClass :ProjectObject ;
+                               owl:onClass nidm:ProjectObject ;
                                owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger
                              ] ;
              
@@ -464,7 +463,7 @@ dct:title rdf:type owl:DatatypeProperty .
 
 ###  http://purl.org/nidash/nidm#StudyParticipant
 
-:StudyParticipant rdf:type owl:Class ;
+nidm:StudyParticipant rdf:type owl:Class ;
                   
                   rdfs:label "Study Participant"^^xsd:string ;
                   
@@ -480,7 +479,7 @@ dct:title rdf:type owl:DatatypeProperty .
 
 ###  http://purl.org/nidash/nidm#Task
 
-:Task rdf:type owl:Class ;
+nidm:Task rdf:type owl:Class ;
       
       rdfs:subClassOf prov:Collection .
 
@@ -488,7 +487,7 @@ dct:title rdf:type owl:DatatypeProperty .
 
 ###  http://purl.org/nidash/nidm#TaskBasedImagingAcquisition
 
-:TaskBasedImagingAcquisition rdf:type owl:Class ;
+nidm:TaskBasedImagingAcquisition rdf:type owl:Class ;
                              
                              rdfs:subClassOf prov:Activity .
 
@@ -505,7 +504,7 @@ dct:title rdf:type owl:DatatypeProperty .
 
 ###  http://purl.org/nidash/nidm#NIDM_0000152
 
-:NIDM_0000152 rdf:type :NIDM_0000155 ,
+nidm:NIDM_0000152 rdf:type nidm:NIDM_0000155 ,
                        owl:NamedIndividual ;
               
               rdfs:label "Block-Based Design" ;
@@ -520,7 +519,7 @@ dct:title rdf:type owl:DatatypeProperty .
 
 ###  http://purl.org/nidash/nidm#NIDM_0000153
 
-:NIDM_0000153 rdf:type :NIDM_0000155 ,
+nidm:NIDM_0000153 rdf:type nidm:NIDM_0000155 ,
                        owl:NamedIndividual ;
               
               rdfs:label "Event-Related Design" ;
@@ -535,7 +534,7 @@ dct:title rdf:type owl:DatatypeProperty .
 
 ###  http://purl.org/nidash/nidm#NIDM_0000154
 
-:NIDM_0000154 rdf:type :NIDM_0000155 ,
+nidm:NIDM_0000154 rdf:type nidm:NIDM_0000155 ,
                        owl:NamedIndividual ;
               
               rdfs:label "Mixed Design" ;

--- a/vcr_cassettes/synopsis.yaml
+++ b/vcr_cassettes/synopsis.yaml
@@ -53235,4 +53235,855 @@ interactions:
       transfer-encoding: [chunked]
       x-ua-compatible: [IE=Edge]
     status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [provenance.ecs.soton.ac.uk]
+      User-Agent: [Python-urllib/2.7]
+    method: GET
+    uri: https://provenance.ecs.soton.ac.uk/store/documents/113215.ttl
+  response:
+    body: {string: !!python/unicode "@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix
+        nidm_ExtentThreshold: <http://purl.org/nidash/nidm#NIDM_0000026> .\n@prefix
+        obo: <http://purl.obolibrary.org/obo/> .\n@prefix pre_1: <http://www.w3.org/2001/XMLSchema#>
+        .\n@prefix pre_0: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n@prefix
+        nidm_effectDegreesOfFreedom: <http://purl.org/nidash/nidm#NIDM_0000091> .\n@prefix
+        nidm_dependenceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000089>
+        .\n@prefix nidm_grandMeanScaling: <http://purl.org/nidash/nidm#NIDM_0000096>
+        .\n@prefix nidm_PeakDefinitionCriteria: <http://purl.org/nidash/nidm#NIDM_0000063>
+        .\n@prefix obo_tstatistic: <http://purl.obolibrary.org/obo/STATO_0000176>
+        .\n@prefix nidm_spm_results_nidm: <http://purl.org/nidash/nidm#NIDM_0000168>
+        .\n@prefix nidm_equivalentZStatistic: <http://purl.org/nidash/nidm#NIDM_0000092>
+        .\n@prefix nidm_ConjunctionInference: <http://purl.org/nidash/nidm#NIDM_0000011>
+        .\n@prefix nidm_SearchSpaceMaskMap: <http://purl.org/nidash/nidm#NIDM_0000068>
+        .\n@prefix nidm_heightCriticalThresholdFWE05: <http://purl.org/nidash/nidm#NIDM_0000147>
+        .\n@prefix nidm_dimensionsInVoxels: <http://purl.org/nidash/nidm#NIDM_0000090>
+        .\n@prefix nidm_numberOfDimensions: <http://purl.org/nidash/nidm#NIDM_0000112>
+        .\n@prefix nlx_SPM: <http://neurolex.org/wiki/nif-0000-00343> .\n@prefix nidm_statisticType:
+        <http://purl.org/nidash/nidm#NIDM_0000123> .\n@prefix bnode: <http://openprovenance.org/provtoolbox/bnode/>
+        .\n@prefix nidm_errorDegreesOfFreedom: <http://purl.org/nidash/nidm#NIDM_0000093>
+        .\n@prefix dct: <http://purl.org/dc/terms/> .\n@prefix nidm_contrastName:
+        <http://purl.org/nidash/nidm#NIDM_0000085> .\n@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#>
+        .\n@prefix nidm_softwareVersion: <http://purl.org/nidash/nidm#NIDM_0000122>
+        .\n@prefix nidm_heightCriticalThresholdFDR05: <http://purl.org/nidash/nidm#NIDM_0000146>
+        .\n@prefix nidm_ParameterEstimateMap: <http://purl.org/nidash/nidm#NIDM_0000061>
+        .\n@prefix obo_statistic: <http://purl.obolibrary.org/obo/STATO_0000039> .\n@prefix
+        nidm_noiseFWHMInVoxels: <http://purl.org/nidash/nidm#NIDM_0000159> .\n@prefix
+        nidm_hasClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000098> .\n@prefix
+        nidm_isUserDefined: <http://purl.org/nidash/nidm#NIDM_0000106> .\n@prefix
+        dc: <http://purl.org/dc/elements/1.1/> .\n@prefix nidm_coordinateVector: <http://purl.org/nidash/nidm#NIDM_0000086>
+        .\n@prefix nidm_numberOfSignificantClusters: <http://purl.org/nidash/nidm#NIDM_0000111>
+        .\n@prefix nidm_pValueUncorrected: <http://purl.org/nidash/nidm#NIDM_0000116>
+        .\n@prefix nidm_voxelToWorldMapping: <http://purl.org/nidash/nidm#NIDM_0000132>
+        .\n@prefix nidm_NIDMResults: <http://purl.org/nidash/nidm#NIDM_0000027> .\n@prefix
+        nidm_ContrastStandardErrorMap: <http://purl.org/nidash/nidm#NIDM_0000013>
+        .\n@prefix nidm_DisplayMaskMap: <http://purl.org/nidash/nidm#NIDM_0000020>
+        .\n@prefix obo_FWERadjustedpvalue: <http://purl.obolibrary.org/obo/OBI_0001265>
+        .\n@prefix nidm_version: <http://purl.org/nidash/nidm#NIDM_0000127> .\n@prefix
+        nidm_withEstimationMethod: <http://purl.org/nidash/nidm#NIDM_0000134> .\n@prefix
+        nidm_StatisticMap: <http://purl.org/nidash/nidm#NIDM_0000076> .\n@prefix nidm_PValueUncorrected:
+        <http://purl.org/nidash/nidm#NIDM_0000160> .\n@prefix nlx: <http://neurolex.org/wiki/>
+        .\n@prefix nidm_minDistanceBetweenPeaks: <http://purl.org/nidash/nidm#NIDM_0000109>
+        .\n@prefix nidm_ModelParametersEstimation: <http://purl.org/nidash/nidm#NIDM_0000056>
+        .\n@prefix nidm_searchVolumeInUnits: <http://purl.org/nidash/nidm#NIDM_0000136>
+        .\n@prefix nidm_inCoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000104>
+        .\n@prefix nidm_expectedNumberOfVoxelsPerCluster: <http://purl.org/nidash/nidm#NIDM_0000143>
+        .\n@prefix nidm_hasConnectivityCriterion: <http://purl.org/nidash/nidm#NIDM_0000099>
+        .\n@prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
+        .\n@prefix nidm_Peak: <http://purl.org/nidash/nidm#NIDM_0000062> .\n@prefix
+        spm_smallestSignificantClusterSizeInVoxelsFWE05: <http://purl.org/nidash/spm#SPM_0000014>
+        .\n@prefix nidm_clusterSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000084>
+        .\n@prefix nidm_equivalentThreshold: <http://purl.org/nidash/nidm#NIDM_0000161>
+        .\n@prefix nidm_inWorldCoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000105>
+        .\n@prefix nidm_hasMaximumIntensityProjection: <http://purl.org/nidash/nidm#NIDM_0000138>
+        .\n@prefix nidm_ResidualMeanSquaresMap: <http://purl.org/nidash/nidm#NIDM_0000066>
+        .\n@prefix dctype: <http://purl.org/dc/dcmitype/> .\n@prefix nidm_hasAlternativeHypothesis:
+        <http://purl.org/nidash/nidm#NIDM_0000097> .\n@prefix nidm_HeightThreshold:
+        <http://purl.org/nidash/nidm#NIDM_0000034> .\n@prefix nidm_targetIntensity:
+        <http://purl.org/nidash/nidm#NIDM_0000124> .\n@prefix nidm_CoordinateSpace:
+        <http://purl.org/nidash/nidm#NIDM_0000016> .\n@prefix spm_smallestSignificantClusterSizeInVoxelsFDR05:
+        <http://purl.org/nidash/spm#SPM_0000013> .\n@prefix fsl: <http://purl.org/nidash/fsl#>
+        .\n@prefix nidm_DesignMatrix: <http://purl.org/nidash/nidm#NIDM_0000019> .\n@prefix
+        nidm_clusterSizeInResels: <http://purl.org/nidash/nidm#NIDM_0000156> .\n@prefix
+        nidm_errorVarianceHomogeneous: <http://purl.org/nidash/nidm#NIDM_0000094>
+        .\n@prefix xsd_1: <http://www.w3.org/2001/XMLSchema##> .\n@prefix nidm_NIDMResultsExport:
+        <http://purl.org/nidash/nidm#NIDM_0000166> .\n@prefix nidm_maxNumberOfPeaksPerCluster:
+        <http://purl.org/nidash/nidm#NIDM_0000108> .\n@prefix nidm_pValue: <http://purl.org/nidash/nidm#NIDM_0000114>
+        .\n@prefix nidm_ExcursionSetMap: <http://purl.org/nidash/nidm#NIDM_0000025>
+        .\n@prefix spm: <http://purl.org/nidash/spm#> .\n@prefix nidm_expectedNumberOfClusters:
+        <http://purl.org/nidash/nidm#NIDM_0000141> .\n@prefix nidm_searchVolumeInVoxels:
+        <http://purl.org/nidash/nidm#NIDM_0000121> .\n@prefix nidm_qValueFDR: <http://purl.org/nidash/nidm#NIDM_0000119>
+        .\n@prefix niiri: <http://iri.nidash.org/> .\n@prefix nidm_ContrastEstimation:
+        <http://purl.org/nidash/nidm#NIDM_0000001> .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+        .\n@prefix nidm_reselSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000148>
+        .\n@prefix nidm_ContrastMap: <http://purl.org/nidash/nidm#NIDM_0000002> .\n@prefix
+        nidm_pValueFWER: <http://purl.org/nidash/nidm#NIDM_0000115> .\n@prefix nidm_noiseFWHMInUnits:
+        <http://purl.org/nidash/nidm#NIDM_0000157> .\n@prefix nidm_DataScaling: <http://purl.org/nidash/nidm#NIDM_0000018>
+        .\n@prefix nidm_SupraThresholdCluster: <http://purl.org/nidash/nidm#NIDM_0000070>
+        .\n@prefix nidm_hasErrorDependence: <http://purl.org/nidash/nidm#NIDM_0000100>
+        .\n@prefix obo_contrastweightmatrix: <http://purl.obolibrary.org/obo/STATO_0000323>
+        .\n@prefix nidm_clusterLabelId: <http://purl.org/nidash/nidm#NIDM_0000082>
+        .\n@prefix nidm_ReselsPerVoxelMap: <http://purl.org/nidash/nidm#NIDM_0000144>
+        .\n@prefix nidm_voxel18connected: <http://purl.org/nidash/nidm#NIDM_0000128>
+        .\n@prefix nidm: <http://purl.org/nidash/nidm#> .\n@prefix nidm_Coordinate:
+        <http://purl.org/nidash/nidm#NIDM_0000015> .\n@prefix nidm_searchVolumeInResels:
+        <http://purl.org/nidash/nidm#NIDM_0000149> .\n@prefix nidm_OneTailedTest:
+        <http://purl.org/nidash/nidm#NIDM_0000060> .\n@prefix nidm_voxelSize: <http://purl.org/nidash/nidm#NIDM_0000131>
+        .\n@prefix nidm_MaskMap: <http://purl.org/nidash/nidm#NIDM_0000054> .\n@prefix
+        obo_ordinaryleastsquaresestimation: <http://purl.obolibrary.org/obo/STATO_0000370>
+        .\n@prefix nidm_GrandMeanMap: <http://purl.org/nidash/nidm#NIDM_0000033> .\n@prefix
+        nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .\n@prefix
+        nidm_IndependentParameter: <http://purl.org/nidash/nidm#NIDM_0000073> .\n@prefix
+        nidm_IndependentError: <http://purl.org/nidash/nidm#NIDM_0000048> .\n@prefix
+        nidm_randomFieldStationarity: <http://purl.org/nidash/nidm#NIDM_0000120> .\n@prefix
+        obo_normaldistribution: <http://purl.obolibrary.org/obo/STATO_0000227> .\n@prefix
+        nidm_voxelUnits: <http://purl.org/nidash/nidm#NIDM_0000133> .\n@prefix nidm_varianceMapWiseDependence:
+        <http://purl.org/nidash/nidm#NIDM_0000126> .\n@prefix nidm_ErrorModel: <http://purl.org/nidash/nidm#NIDM_0000023>
+        .\n@prefix nidm_maskedMedian: <http://purl.org/nidash/nidm#NIDM_0000107> .\n@prefix
+        nidm_hasErrorDistribution: <http://purl.org/nidash/nidm#NIDM_0000101> .\n@prefix
+        nidm_ClusterDefinitionCriteria: <http://purl.org/nidash/nidm#NIDM_0000007>
+        .\n@prefix spm_searchVolumeReselsGeometry: <http://purl.org/nidash/spm#SPM_0000010>
+        .\n\n\nniiri:contrast_estimation_id prov:wasAssociatedWith niiri:software_id
+        .\n\nniiri:model_pe_id prov:wasAssociatedWith niiri:software_id .\n\nniiri:inference_id
+        prov:wasAssociatedWith niiri:software_id .\n\nniiri:contrast_estimation_id_2
+        prov:wasAssociatedWith niiri:software_id .\n\nniiri:export_id prov:wasAssociatedWith
+        niiri:exporter_id .\n\nniiri:peak_0003 prov:wasDerivedFrom niiri:supra_threshold_cluster_0001
+        .\n\nniiri:supra_threshold_cluster_0005 prov:wasDerivedFrom niiri:excursion_set_map_id
+        .\n\nniiri:beta_map_id_3 prov:wasDerivedFrom niiri:beta_map_id_3_der .\n\nniiri:peak_0002
+        prov:wasDerivedFrom niiri:supra_threshold_cluster_0001 .\n\nniiri:contrast_map_id_2
+        prov:wasDerivedFrom niiri:contrast_map_id_2_der .\n\nniiri:peak_0001 prov:wasDerivedFrom
+        niiri:supra_threshold_cluster_0001 .\n\nniiri:beta_map_id_1 prov:wasDerivedFrom
+        niiri:beta_map_id_1_der .\n\nniiri:statistic_map_id_2 prov:wasDerivedFrom
+        niiri:statistic_map_id_2_der .\n\nniiri:resels_per_voxel_map_id prov:wasDerivedFrom
+        niiri:resels_per_voxel_map_id_der .\n\nniiri:supra_threshold_cluster_0003
+        prov:wasDerivedFrom niiri:excursion_set_map_id .\n\nniiri:statistic_map_id
+        prov:wasDerivedFrom niiri:statistic_map_id_der .\n\nniiri:peak_0004 prov:wasDerivedFrom
+        niiri:supra_threshold_cluster_0002 .\n\nniiri:contrast_map_id prov:wasDerivedFrom
+        niiri:contrast_map_id_der .\n\nniiri:supra_threshold_cluster_0004 prov:wasDerivedFrom
+        niiri:excursion_set_map_id .\n\nniiri:supra_threshold_cluster_0002 prov:wasDerivedFrom
+        niiri:excursion_set_map_id .\n\nniiri:beta_map_id_2 prov:wasDerivedFrom niiri:beta_map_id_2_der
+        .\n\nniiri:supra_threshold_cluster_0001 prov:wasDerivedFrom niiri:excursion_set_map_id
+        .\n\nniiri:contrast_estimation_id_2 prov:used niiri:contrast_id_2 .\n\nniiri:model_pe_id
+        prov:used niiri:error_model_id , niiri:design_matrix_id , niiri:data_id .\n\nniiri:inference_id
+        prov:used niiri:statistic_map_id , niiri:statistic_map_id_2 , niiri:height_threshold_id
+        , niiri:extent_threshold_id , niiri:display_map_id , niiri:peak_definition_criteria_id
+        , niiri:cluster_definition_criteria_id .\n\nniiri:contrast_estimation_id_2
+        prov:used niiri:beta_map_id_3 , niiri:mask_id_1 .\n\nniiri:contrast_estimation_id
+        prov:used niiri:contrast_id , niiri:beta_map_id_1 , niiri:residual_mean_squares_map_id
+        , niiri:design_matrix_id , niiri:beta_map_id_2 , niiri:mask_id_1 .\n\nniiri:inference_id
+        prov:used niiri:mask_id_1 , niiri:resels_per_voxel_map_id .\n\nniiri:contrast_estimation_id_2
+        prov:used niiri:design_matrix_id , niiri:residual_mean_squares_map_id .\n\nniiri:exporter_id
+        a prov:Agent , nidm:NIDM_0000168 , prov:SoftwareAgent ;\n\trdfs:label \"spm_results_nidm\"
+        ;\n\tnidm:NIDM_0000122 \"12b.5858\"^^pre_1:string .\n\nniiri:software_id a
+        prov:Agent , nlx:nif-0000-00343 , prov:SoftwareAgent ;\n\trdfs:label \"SPM\"
+        ;\n\tnidm:NIDM_0000122 \"12b.5853\"^^pre_1:string .\n\nniiri:peak_0002 a prov:Entity
+        , nidm:NIDM_0000062 ;\n\trdfs:label \"Peak: 0002\" ;\n\tprov:atLocation niiri:coordinate_0002
+        ;\n\tprov:value \"13.0321407318\"^^pre_1:float ;\n\tnidm:NIDM_0000119 \"1.19156591714e-11\"^^pre_1:float
+        ;\n\tnidm:NIDM_0000092 \"INF\"^^pre_1:float ;\n\tnidm:NIDM_0000115 \"0\"^^pre_1:float
+        ;\n\tnidm:NIDM_0000116 \"4.44089209850063e-16\"^^pre_1:float .\n\nniiri:peak_0003
+        a prov:Entity , nidm:NIDM_0000062 ;\n\trdfs:label \"Peak: 0003\" ;\n\tprov:atLocation
+        niiri:coordinate_0003 ;\n\tprov:value \"10.2856016159058\"^^pre_1:float ;\n\tnidm:NIDM_0000119
+        \"6.84121260274992e-10\"^^pre_1:float ;\n\tnidm:NIDM_0000092 \"INF\"^^pre_1:float
+        ;\n\tnidm:NIDM_0000115 \"7.69451169446711e-12\"^^pre_1:float ;\n\tnidm:NIDM_0000116
+        \"4.44089209850063e-16\"^^pre_1:float .\n\nniiri:contrast_id a prov:Entity
+        , obo:STATO_0000323 ;\n\trdfs:label \"Contrast: listening > reading\" ;\n\tprov:value
+        \"[1, -1, 0, 0]\"^^pre_1:string ;\n\tnidm:NIDM_0000123 obo:STATO_0000176 ;\n\tnidm:NIDM_0000085
+        \"listening > reading\"^^pre_1:string .\n\nniiri:peak_0001 a prov:Entity ,
+        nidm:NIDM_0000062 ;\n\trdfs:label \"Peak: 0001\" ;\n\tprov:atLocation niiri:coordinate_0001
+        ;\n\tprov:value \"17.5207633972168\"^^pre_1:float ;\n\tnidm:NIDM_0000119 \"1.19156591713838e-11\"^^pre_1:float
+        ;\n\tnidm:NIDM_0000092 \"INF\"^^pre_1:float ;\n\tnidm:NIDM_0000115 \"0\"^^pre_1:float
+        ;\n\tnidm:NIDM_0000116 \"4.44089209850063e-16\"^^pre_1:float .\n\nniiri:peak_0004
+        a prov:Entity , nidm:NIDM_0000062 ;\n\trdfs:label \"Peak: 0004\" ;\n\tprov:atLocation
+        niiri:coordinate_0004 ;\n\tprov:value \"13.5425577163696\"^^pre_1:float ;\n\tnidm:NIDM_0000119
+        \"1.19156591713838e-11\"^^pre_1:float ;\n\tnidm:NIDM_0000092 \"INF\"^^pre_1:float
+        ;\n\tnidm:NIDM_0000115 \"0\"^^pre_1:float ;\n\tnidm:NIDM_0000116 \"4.44089209850063e-16\"^^pre_1:float
+        .\n\nniiri:residual_mean_squares_map_id a prov:Entity , nidm:NIDM_0000066
+        ;\n\trdfs:label \"Residual Mean Squares Map\" ;\n\tprov:atLocation \"ResidualMeanSquares.nii.gz\"^^pre_1:anyURI
+        ;\n\tnfo:fileName \"ResidualMeanSquares.nii.gz\"^^pre_1:string ;\n\tnidm:NIDM_0000104
+        niiri:coordinate_space_id_1 ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string
+        ;\n\tdct:format \"image/nifti\"^^pre_1:string .\n\nniiri:data_id a prov:Entity
+        , prov:Collection , nidm:NIDM_0000018 ;\n\trdfs:label \"Data\" ;\n\tnidm:NIDM_0000124
+        \"100\"^^pre_1:float ;\n\tnidm:NIDM_0000096 \"true\"^^pre_1:boolean .\n\nniiri:contrast_standard_error_map_id
+        a prov:Entity , nidm:NIDM_0000013 ;\n\trdfs:label \"Contrast 1 Standard Error
+        Map\" ;\n\tprov:atLocation \"ContrastStandardError_0001.nii.gz\"^^pre_1:anyURI
+        ;\n\tnfo:fileName \"ContrastStandardError_0001.nii.gz\"^^pre_1:string ;\n\tnidm:NIDM_0000104
+        niiri:coordinate_space_id_1 ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string
+        ;\n\tdct:format \"image/nifti\"^^pre_1:string .\n\nniiri:contrast_map_id_der
+        a prov:Entity , nidm:NIDM_0000002 ;\n\tnfo:fileName \"con_0001.nii\"^^pre_1:string
+        ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string ;\n\tdct:format
+        \"image/nifti\"^^pre_1:string .\n\nniiri:design_matrix_png_id a prov:Entity
+        , dctype:Image ;\n\tprov:atLocation \"DesignMatrix.png\"^^pre_1:anyURI ;\n\tnfo:fileName
+        \"DesignMatrix.png\"^^pre_1:string ;\n\tdct:format \"image/png\"^^pre_1:string
+        .\n\nniiri:coordinate_0002 a prov:Entity , nidm:NIDM_0000015 ;\n\trdfs:label
+        \"Coordinate: 0002\" ;\n\tnidm:NIDM_0000086 \"[ -42, -31, 11 ]\"^^pre_1:string
+        .\n\nniiri:cluster_definition_criteria_id a prov:Entity , nidm:NIDM_0000007
+        ;\n\trdfs:label \"Cluster Connectivity Criterion: 18\" ;\n\tnidm:NIDM_0000099
+        nidm:NIDM_0000128 .\n\nniiri:coordinate_space_id_1 a prov:Entity , nidm:NIDM_0000016
+        ;\n\trdfs:label \"Coordinate space 1\" ;\n\tnidm:NIDM_0000132 \"[[-3, 0, 0,
+        78],[0, 3, 0, -112],[0, 0, 3, -50],[0, 0, 0, 1]]\"^^pre_1:string ;\n\tnidm:NIDM_0000133
+        \"[ \\\"mm\\\", \\\"mm\\\", \\\"mm\\\" ]\"^^pre_1:string ;\n\tnidm:NIDM_0000105
+        nidm:NIDM_0000051 ;\n\tnidm:NIDM_0000131 \"[ 3, 3, 3 ]\"^^pre_1:string ;\n\tnidm:NIDM_0000090
+        \"[ 53, 63, 46 ]\"^^pre_1:string ;\n\tnidm:NIDM_0000112 \"3\"^^pre_1:int .\n\nniiri:beta_map_id_2
+        a prov:Entity , nidm:NIDM_0000061 ;\n\trdfs:label \"Beta Map 2\" ;\n\tprov:atLocation
+        \"ParameterEstimate_0002.nii.gz\"^^pre_1:anyURI ;\n\tnfo:fileName \"ParameterEstimate_0002.nii.gz\"^^pre_1:string
+        ;\n\tnidm:NIDM_0000104 niiri:coordinate_space_id_1 ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string
+        ;\n\tdct:format \"image/nifti\"^^pre_1:string .\n\nniiri:supra_threshold_cluster_0001
+        a prov:Entity , nidm:NIDM_0000070 ;\n\trdfs:label \"Supra-Threshold Cluster:
+        0001\" ;\n\tnidm:NIDM_0000119 \"1.77948412240239e-18\"^^pre_1:float ;\n\tnidm:NIDM_0000156
+        \"6.31265696809113\"^^pre_1:float ;\n\tnidm:NIDM_0000084 \"839\"^^pre_1:int
+        ;\n\tnidm:NIDM_0000082 \"1\"^^pre_1:int ;\n\tnidm:NIDM_0000115 \"0\"^^pre_1:float
+        ;\n\tnidm:NIDM_0000116 \"3.55896824480477e-19\"^^pre_1:float .\n\nniiri:height_threshold_id
+        a prov:Entity , nidm:NIDM_0000034 , nidm:NIDM_0000160 ;\n\trdfs:label \"Height
+        Threshold: p<7.62276079258051e-07 (unc)\" ;\n\tprov:value \"7.62276079258051e-07\"^^pre_1:float
+        ;\n\tnidm:NIDM_0000161 niiri:height_threshold_id_3 , niiri:height_threshold_id_2
+        .\n\nniiri:resels_per_voxel_map_id_der a prov:Entity , nidm:NIDM_0000144 ;\n\tnfo:fileName
+        \"RPV.nii\"^^pre_1:string ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string
+        ;\n\tdct:format \"image/nifti\"^^pre_1:string .\n\nniiri:search_space_mask_id
+        a prov:Entity , nidm:NIDM_0000068 ;\n\trdfs:label \"Search Space Mask Map\"
+        ;\n\tprov:atLocation \"SearchSpaceMask.nii.gz\"^^pre_1:anyURI ;\n\tnidm:NIDM_0000121
+        \"69306\"^^pre_1:int ;\n\tnidm:NIDM_0000141 \"0.0512932943875478\"^^pre_1:float
+        ;\n\tnidm:NIDM_0000157 \"[ 16.2383695773208, 16.3091687172086, 13.5499997663244
+        ]\"^^pre_1:string ;\n\tnidm:NIDM_0000147 \"4.85241745689539\"^^pre_1:float
+        ;\n\tspm:SPM_0000013 \"29\"^^pre_1:int ;\n\tnidm:NIDM_0000143 \"4.02834655908613\"^^pre_1:float
+        ;\n\tnidm:NIDM_0000149 \"467.07642343881\"^^pre_1:float ;\n\tnidm:NIDM_0000148
+        \"132.907586178202\"^^pre_1:float ;\n\tnidm:NIDM_0000159 \"[ 5.41278985910694,
+        5.43638957240286, 4.51666658877481 ]\"^^pre_1:string ;\n\tnfo:fileName \"SearchSpaceMask.nii.gz\"^^pre_1:string
+        ;\n\tnidm:NIDM_0000136 \"1871262\"^^pre_1:float ;\n\tspm:SPM_0000014 \"12\"^^pre_1:int
+        ;\n\tdct:format \"image/nifti\"^^pre_1:string ;\n\tnidm:NIDM_0000104 niiri:coordinate_space_id_1
+        ;\n\tnidm:NIDM_0000146 \"5.7639536857605\"^^pre_1:float ;\n\tcrypto:sha512
+        \"932fd9f0d55e9822748f4a9b35a0a7f0fe442f3e061e2eda48c2617a2938df50ea84deca8de0725641a0105b712a80a0c8931df9bdf3bef788b1041379d00875\"^^pre_1:string
+        ;\n\tspm:SPM_0000010 \"[7, 42.96312274763, 269.40914815306, 467.07642343881]\"^^pre_1:string
+        ;\n\tnidm:NIDM_0000120 \"true\"^^pre_1:boolean .\n\nniiri:resels_per_voxel_map_id
+        a prov:Entity , nidm:NIDM_0000144 ;\n\trdfs:label \"Resels per Voxel Map\"
+        ;\n\tprov:atLocation \"ReselsPerVoxel.nii.gz\"^^pre_1:anyURI ;\n\tnfo:fileName
+        \"ReselsPerVoxel.nii.gz\"^^pre_1:string ;\n\tnidm:NIDM_0000104 niiri:coordinate_space_id_1
+        ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string ;\n\tdct:format
+        \"image/nifti\"^^pre_1:string .\n\nniiri:beta_map_id_3_der a prov:Entity ,
+        nidm:NIDM_0000061 ;\n\tnfo:fileName \"beta_0003.nii\"^^pre_1:string ;\n\tcrypto:sha512
+        \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string ;\n\tdct:format \"image/nifti\"^^pre_1:string
+        .\n\nniiri:beta_map_id_1 a prov:Entity , nidm:NIDM_0000061 ;\n\trdfs:label
+        \"Beta Map 1\" ;\n\tprov:atLocation \"ParameterEstimate_0001.nii.gz\"^^pre_1:anyURI
+        ;\n\tnfo:fileName \"ParameterEstimate_0001.nii.gz\"^^pre_1:string ;\n\tnidm:NIDM_0000104
+        niiri:coordinate_space_id_1 ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string
+        ;\n\tdct:format \"image/nifti\"^^pre_1:string .\n\nniiri:contrast_map_id_2_der
+        a prov:Entity , nidm:NIDM_0000002 ;\n\tnfo:fileName \"con_0002.nii\"^^pre_1:string
+        ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string ;\n\tdct:format
+        \"image/nifti\"^^pre_1:string .\n\nniiri:contrast_map_id a prov:Entity , nidm:NIDM_0000002
+        ;\n\trdfs:label \"Contrast Map: listening > reading\" ;\n\tprov:atLocation
+        \"Contrast_0001.nii.gz\"^^pre_1:anyURI ;\n\tnfo:fileName \"Contrast_0001.nii.gz\"^^pre_1:string
+        ;\n\tnidm:NIDM_0000104 niiri:coordinate_space_id_1 ;\n\tnidm:NIDM_0000085
+        \"listening > reading\"^^pre_1:string ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string
+        ;\n\tdct:format \"image/nifti\"^^pre_1:string .\n\nniiri:display_map_id a
+        prov:Entity , nidm:NIDM_0000020 ;\n\trdfs:label \"Display Mask Map\" ;\n\tprov:atLocation
+        \"DisplayMask.nii.gz\"^^pre_1:anyURI ;\n\tnfo:fileName \"DisplayMask.nii.gz\"^^pre_1:string
+        ;\n\tnidm:NIDM_0000104 niiri:coordinate_space_id_1 ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string
+        ;\n\tdct:format \"image/nifti\"^^pre_1:string .\n\nniiri:statistic_map_id_der
+        a prov:Entity , nidm:NIDM_0000076 ;\n\tnfo:fileName \"spmT_0001.nii\"^^pre_1:string
+        ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string ;\n\tdct:format
+        \"image/nifti\"^^pre_1:string .\n\nniiri:contrast_standard_error_map_id_2
+        a prov:Entity , nidm:NIDM_0000013 ;\n\trdfs:label \"Contrast 2 Standard Error
+        Map\" ;\n\tprov:atLocation \"ContrastStandardError_0002.nii.gz\"^^pre_1:anyURI
+        ;\n\tnfo:fileName \"ContrastStandardError_0002.nii.gz\"^^pre_1:string ;\n\tnidm:NIDM_0000104
+        niiri:coordinate_space_id_1 ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string
+        ;\n\tdct:format \"image/nifti\"^^pre_1:string .\n\nniiri:supra_threshold_cluster_0005
+        a prov:Entity , nidm:NIDM_0000070 ;\n\trdfs:label \"Supra-Threshold Cluster:
+        0005\" ;\n\tnidm:NIDM_0000119 \"0.0818393184514307\"^^pre_1:float ;\n\tnidm:NIDM_0000156
+        \"0.0902882999011843\"^^pre_1:float ;\n\tnidm:NIDM_0000084 \"12\"^^pre_1:int
+        ;\n\tnidm:NIDM_0000082 \"5\"^^pre_1:int ;\n\tnidm:NIDM_0000115 \"0.00418900977248904\"^^pre_1:float
+        ;\n\tnidm:NIDM_0000116 \"0.0818393184514307\"^^pre_1:float .\n\nniiri:spm_results_id
+        a prov:Entity , nidm:NIDM_0000027 , prov:Bundle ;\n\trdfs:label \"NIDM-Results\"
+        ;\n\tnidm:NIDM_0000127 \"1.1.0\"^^pre_1:string .\n\nniiri:mask_id_1 a prov:Entity
+        , nidm:NIDM_0000054 ;\n\trdfs:label \"Mask\" ;\n\tprov:atLocation \"Mask.nii.gz\"^^pre_1:anyURI
+        ;\n\tnfo:fileName \"Mask.nii.gz\"^^pre_1:string ;\n\tnidm:NIDM_0000106 \"false\"^^pre_1:boolean
+        ;\n\tnidm:NIDM_0000104 niiri:coordinate_space_id_1 ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string
+        ;\n\tdct:format \"image/nifti\"^^pre_1:string .\n\nniiri:extent_threshold_id_3
+        a prov:Entity , nidm:NIDM_0000026 , nidm:NIDM_0000160 ;\n\trdfs:label \"Extent
+        Threshold\" ;\n\tprov:value \"1\"^^pre_1:float .\n\nniiri:extent_threshold_id_2
+        a prov:Entity , nidm:NIDM_0000026 , obo:OBI_0001265 ;\n\trdfs:label \"Extent
+        Threshold\" ;\n\tprov:value \"1\"^^pre_1:float .\n\nniiri:height_threshold_id_2
+        a prov:Entity , nidm:NIDM_0000034 , obo:STATO_0000039 ;\n\trdfs:label \"Height
+        Threshold\" ;\n\tprov:value \"5.23529984739211\"^^pre_1:float .\n\nniiri:height_threshold_id_3
+        a prov:Entity , obo:OBI_0001265 , nidm:NIDM_0000034 ;\n\trdfs:label \"Height
+        Threshold\" ;\n\tprov:value \"0.05\"^^pre_1:float .\n\nniiri:grand_mean_map_id
+        a prov:Entity , nidm:NIDM_0000033 ;\n\trdfs:label \"Grand Mean Map\" ;\n\tprov:atLocation
+        \"GrandMean.nii.gz\"^^pre_1:anyURI ;\n\tnfo:fileName \"GrandMean.nii.gz\"^^pre_1:string
+        ;\n\tnidm:NIDM_0000107 \"115\"^^pre_1:float ;\n\tnidm:NIDM_0000104 niiri:coordinate_space_id_1
+        ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string ;\n\tdct:format
+        \"image/nifti\"^^pre_1:string .\n\nniiri:statistic_map_id_2_der a prov:Entity
+        , nidm:NIDM_0000076 ;\n\tnfo:fileName \"spmT_0002.nii\"^^pre_1:string ;\n\tcrypto:sha512
+        \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string ;\n\tdct:format \"image/nifti\"^^pre_1:string
+        .\n\nniiri:coordinate_0001 a prov:Entity , nidm:NIDM_0000015 ;\n\trdfs:label
+        \"Coordinate: 0001\" ;\n\tnidm:NIDM_0000086 \"[ -60, -25, 11 ]\"^^pre_1:string
+        .\n\nniiri:coordinate_0003 a prov:Entity , nidm:NIDM_0000015 ;\n\trdfs:label
+        \"Coordinate: 0003\" ;\n\tnidm:NIDM_0000086 \"[ -66, -31, -1 ]\"^^pre_1:string
+        .\n\nniiri:error_model_id a prov:Entity , nidm:NIDM_0000023 ;\n\tnidm:NIDM_0000089
+        nidm:NIDM_0000073 ;\n\tnidm:NIDM_0000126 nidm:NIDM_0000073 ;\n\tnidm:NIDM_0000100
+        nidm:NIDM_0000048 ;\n\tnidm:NIDM_0000094 \"true\"^^pre_1:boolean ;\n\tnidm:NIDM_0000101
+        obo:STATO_0000227 .\n\nniiri:coordinate_0004 a prov:Entity , nidm:NIDM_0000015
+        ;\n\trdfs:label \"Coordinate: 0004\" ;\n\tnidm:NIDM_0000086 \"[ 63, -13, -4
+        ]\"^^pre_1:string .\n\nniiri:beta_map_id_3 a prov:Entity , nidm:NIDM_0000061
+        ;\n\trdfs:label \"Beta Map 3\" ;\n\tprov:atLocation \"ParameterEstimate_0003.nii.gz\"^^pre_1:anyURI
+        ;\n\tnfo:fileName \"ParameterEstimate_0003.nii.gz\"^^pre_1:string ;\n\tnidm:NIDM_0000104
+        niiri:coordinate_space_id_1 ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string
+        ;\n\tdct:format \"image/nifti\"^^pre_1:string .\n\nniiri:supra_threshold_cluster_0002
+        a prov:Entity , nidm:NIDM_0000070 ;\n\trdfs:label \"Supra-Threshold Cluster:
+        0002\" ;\n\tnidm:NIDM_0000119 \"1.33570070658018e-16\"^^pre_1:float ;\n\tnidm:NIDM_0000156
+        \"5.22919736927692\"^^pre_1:float ;\n\tnidm:NIDM_0000084 \"695\"^^pre_1:int
+        ;\n\tnidm:NIDM_0000082 \"2\"^^pre_1:int ;\n\tnidm:NIDM_0000115 \"0\"^^pre_1:float
+        ;\n\tnidm:NIDM_0000116 \"5.34280282632073e-17\"^^pre_1:float .\n\nniiri:supra_threshold_cluster_0003
+        a prov:Entity , nidm:NIDM_0000070 ;\n\trdfs:label \"Supra-Threshold Cluster:
+        0003\" ;\n\tnidm:NIDM_0000119 \"0.00829922079256674\"^^pre_1:float ;\n\tnidm:NIDM_0000156
+        \"0.278388924695318\"^^pre_1:float ;\n\tnidm:NIDM_0000084 \"37\"^^pre_1:int
+        ;\n\tnidm:NIDM_0000082 \"3\"^^pre_1:int ;\n\tnidm:NIDM_0000115 \"0.000255384009130943\"^^pre_1:float
+        ;\n\tnidm:NIDM_0000116 \"0.00497953247554004\"^^pre_1:float .\n\nniiri:beta_map_id_2_der
+        a prov:Entity , nidm:NIDM_0000061 ;\n\tnfo:fileName \"beta_0002.nii\"^^pre_1:string
+        ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string ;\n\tdct:format
+        \"image/nifti\"^^pre_1:string .\n\nniiri:excursion_set_map_id a prov:Entity
+        , nidm:NIDM_0000025 ;\n\trdfs:label \"Excursion Set Map\" ;\n\tprov:atLocation
+        \"ExcursionSet.nii.gz\"^^pre_1:anyURI ;\n\tnfo:fileName \"ExcursionSet.nii.gz\"^^pre_1:string
+        ;\n\tnidm:NIDM_0000114 \"2.83510681598e-09\"^^pre_1:float ;\n\tnidm:NIDM_0000104
+        niiri:coordinate_space_id_1 ;\n\tcrypto:sha512 \"d96b82761c299a66978893cab6034f3f8aed25d0a135636b0ffe79f4cf11becce86ba261f7aeb43717f5d0e47ad0b14cfb0402786251e3f2c507890c83b27652\"^^pre_1:string
+        ;\n\tnidm:NIDM_0000111 \"5\"^^pre_1:int ;\n\tnidm:NIDM_0000138 niiri:maximum_intensity_projection_id
+        ;\n\tnidm:NIDM_0000098 niiri:cluster_label_map_id ;\n\tdct:format \"image/nifti\"^^pre_1:string
+        .\n\nniiri:supra_threshold_cluster_0004 a prov:Entity , nidm:NIDM_0000070
+        ;\n\trdfs:label \"Supra-Threshold Cluster: 0004\" ;\n\tnidm:NIDM_0000119 \"0.0137821290130967\"^^pre_1:float
+        ;\n\tnidm:NIDM_0000156 \"0.218196724761195\"^^pre_1:float ;\n\tnidm:NIDM_0000084
+        \"29\"^^pre_1:int ;\n\tnidm:NIDM_0000082 \"4\"^^pre_1:int ;\n\tnidm:NIDM_0000115
+        \"0.000565384750377596\"^^pre_1:float ;\n\tnidm:NIDM_0000116 \"0.0110257032104773\"^^pre_1:float
+        .\n\nniiri:statistic_map_id_2 a prov:Entity , nidm:NIDM_0000076 ;\n\trdfs:label
+        \"Statistic Map: motor\" ;\n\tprov:atLocation \"TStatistic_0002.nii.gz\"^^pre_1:anyURI
+        ;\n\tnidm:NIDM_0000093 \"72.9999999990787\"^^pre_1:float ;\n\tnfo:fileName
+        \"TStatistic_0002.nii.gz\"^^pre_1:string ;\n\tnidm:NIDM_0000123 obo:STATO_0000176
+        ;\n\tnidm:NIDM_0000104 niiri:coordinate_space_id_1 ;\n\tnidm:NIDM_0000091
+        \"1\"^^pre_1:float ;\n\tnidm:NIDM_0000085 \"motor\"^^pre_1:string ;\n\tcrypto:sha512
+        \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string ;\n\tdct:format \"image/nifti\"^^pre_1:string
+        .\n\nniiri:contrast_map_id_2 a prov:Entity , nidm:NIDM_0000002 ;\n\trdfs:label
+        \"Contrast Map: motor\" ;\n\tprov:atLocation \"Contrast_0002.nii.gz\"^^pre_1:anyURI
+        ;\n\tnfo:fileName \"Contrast_0002.nii.gz\"^^pre_1:string ;\n\tnidm:NIDM_0000104
+        niiri:coordinate_space_id_1 ;\n\tnidm:NIDM_0000085 \"motor\"^^pre_1:string
+        ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string ;\n\tdct:format
+        \"image/nifti\"^^pre_1:string .\n\nniiri:peak_definition_criteria_id a prov:Entity
+        , nidm:NIDM_0000063 ;\n\trdfs:label \"Peak Definition Criteria\" ;\n\tnidm:NIDM_0000109
+        \"8.0\"^^pre_1:float ;\n\tnidm:NIDM_0000108 \"3\"^^pre_1:int .\n\nniiri:extent_threshold_id
+        a prov:Entity , nidm:NIDM_0000026 , obo:STATO_0000039 ;\n\trdfs:label \"Extent
+        Threshold: k>=10\" ;\n\tnidm:NIDM_0000084 \"10\"^^pre_1:int ;\n\tnidm:NIDM_0000156
+        \"3.3\"^^pre_1:float ;\n\tnidm:NIDM_0000161 niiri:height_threshold_id_3 ,
+        niiri:height_threshold_id_2 .\n\nniiri:design_matrix_id a prov:Entity , nidm:NIDM_0000019
+        ;\n\trdfs:label \"Design Matrix\" ;\n\tprov:atLocation \"DesignMatrix.csv\"^^pre_1:anyURI
+        ;\n\tnfo:fileName \"DesignMatrix.csv\"^^pre_1:string ;\n\tdc:description niiri:design_matrix_png_id
+        ;\n\tdct:format \"text/csv\"^^pre_1:string .\n\nniiri:contrast_id_2 a prov:Entity
+        , obo:STATO_0000323 ;\n\trdfs:label \"Contrast: motor\" ;\n\tprov:value \"[
+        0, 0, 1 ]\"^^pre_1:string ;\n\tnidm:NIDM_0000123 obo:STATO_0000176 ;\n\tnidm:NIDM_0000085
+        \"motor\"^^pre_1:string .\n\nniiri:beta_map_id_1_der a prov:Entity , nidm:NIDM_0000061
+        ;\n\tnfo:fileName \"beta_0001.nii\"^^pre_1:string ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string
+        ;\n\tdct:format \"image/nifti\"^^pre_1:string .\n\nniiri:statistic_map_id
+        a prov:Entity , nidm:NIDM_0000076 ;\n\trdfs:label \"Statistic Map: listening
+        > reading\" ;\n\tprov:atLocation \"TStatistic_0001.nii.gz\"^^pre_1:anyURI
+        ;\n\tnidm:NIDM_0000093 \"72.9999999990787\"^^pre_1:float ;\n\tnfo:fileName
+        \"TStatistic_0001.nii.gz\"^^pre_1:string ;\n\tnidm:NIDM_0000123 obo:STATO_0000176
+        ;\n\tnidm:NIDM_0000104 niiri:coordinate_space_id_1 ;\n\tnidm:NIDM_0000091
+        \"1\"^^pre_1:float ;\n\tnidm:NIDM_0000085 \"listening > reading\"^^pre_1:string
+        ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string ;\n\tdct:format
+        \"image/nifti\"^^pre_1:string .\n\nniiri:model_pe_id a prov:Activity , nidm:NIDM_0000056
+        ;\n\trdfs:label \"Model parameters estimation\" ;\n\tnidm:NIDM_0000134 obo:STATO_0000370
+        .\n\nniiri:contrast_estimation_id_2 a prov:Activity , nidm:NIDM_0000001 ;\n\trdfs:label
+        \"Contrast estimation 2\" .\n\nniiri:contrast_estimation_id a prov:Activity
+        , nidm:NIDM_0000001 ;\n\trdfs:label \"Contrast estimation 1\" .\n\nniiri:export_id
+        a prov:Activity , nidm:NIDM_0000166 ;\n\trdfs:label \"NIDM-Results export\"
+        .\n\nniiri:inference_id a prov:Activity , nidm:NIDM_0000011 ;\n\trdfs:label
+        \"Conjunction Inference\" ;\n\tnidm:NIDM_0000097 nidm:NIDM_0000060 .\n\nniiri:statistic_map_id_2
+        prov:wasGeneratedBy niiri:contrast_estimation_id_2 .\n\nniiri:excursion_set_map_id
+        prov:wasGeneratedBy niiri:inference_id .\n\nniiri:contrast_standard_error_map_id_2
+        prov:wasGeneratedBy niiri:contrast_estimation_id_2 .\n\nniiri:mask_id_1 prov:wasGeneratedBy
+        niiri:model_pe_id .\n\n_:blank1 a prov:Generation ;\n\tprov:activity niiri:export_id
+        .\n\nniiri:spm_results_id prov:qualifiedGeneration _:blank1 .\n\n_:blank1
+        prov:atTime \"2014-05-19T10:30:00.000+01:00\"^^pre_1:dateTime .\n\nniiri:grand_mean_map_id
+        prov:wasGeneratedBy niiri:model_pe_id .\n\nniiri:resels_per_voxel_map_id prov:wasGeneratedBy
+        niiri:model_pe_id .\n\nniiri:contrast_map_id prov:wasGeneratedBy niiri:contrast_estimation_id
+        .\n\nniiri:contrast_standard_error_map_id prov:wasGeneratedBy niiri:contrast_estimation_id
+        .\n\nniiri:beta_map_id_1 prov:wasGeneratedBy niiri:model_pe_id .\n\nniiri:residual_mean_squares_map_id
+        prov:wasGeneratedBy niiri:model_pe_id .\n\nniiri:beta_map_id_3 prov:wasGeneratedBy
+        niiri:model_pe_id .\n\nniiri:search_space_mask_id prov:wasGeneratedBy niiri:inference_id
+        .\n\nniiri:statistic_map_id prov:wasGeneratedBy niiri:contrast_estimation_id
+        .\n\nniiri:contrast_map_id_2 prov:wasGeneratedBy niiri:contrast_estimation_id_2
+        .\n\nniiri:beta_map_id_2 prov:wasGeneratedBy niiri:model_pe_id .\n"}
+    headers:
+      connection: [close]
+      content-length: ['29822']
+      content-type: [text/html; charset=utf-8]
+      date: ['Wed, 20 Jan 2016 17:46:12 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000;]
+      vary: [Accept-Encoding]
+      x-ua-compatible: [IE=Edge]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [provenance.ecs.soton.ac.uk]
+      User-Agent: [Python-urllib/2.7]
+    method: GET
+    uri: https://provenance.ecs.soton.ac.uk/store/documents/113216.ttl
+  response:
+    body: {string: !!python/unicode "@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix
+        nidm_ExtentThreshold: <http://purl.org/nidash/nidm#NIDM_0000026> .\n@prefix
+        obo: <http://purl.obolibrary.org/obo/> .\n@prefix pre_1: <http://www.w3.org/2001/XMLSchema#>
+        .\n@prefix pre_0: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n@prefix
+        nidm_effectDegreesOfFreedom: <http://purl.org/nidash/nidm#NIDM_0000091> .\n@prefix
+        nidm_dependenceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000089>
+        .\n@prefix nidm_grandMeanScaling: <http://purl.org/nidash/nidm#NIDM_0000096>
+        .\n@prefix nidm_PeakDefinitionCriteria: <http://purl.org/nidash/nidm#NIDM_0000063>
+        .\n@prefix obo_tstatistic: <http://purl.obolibrary.org/obo/STATO_0000176>
+        .\n@prefix nidm_spm_results_nidm: <http://purl.org/nidash/nidm#NIDM_0000168>
+        .\n@prefix nidm_equivalentZStatistic: <http://purl.org/nidash/nidm#NIDM_0000092>
+        .\n@prefix nidm_ConjunctionInference: <http://purl.org/nidash/nidm#NIDM_0000011>
+        .\n@prefix nidm_SearchSpaceMaskMap: <http://purl.org/nidash/nidm#NIDM_0000068>
+        .\n@prefix nidm_heightCriticalThresholdFWE05: <http://purl.org/nidash/nidm#NIDM_0000147>
+        .\n@prefix nidm_dimensionsInVoxels: <http://purl.org/nidash/nidm#NIDM_0000090>
+        .\n@prefix nidm_numberOfDimensions: <http://purl.org/nidash/nidm#NIDM_0000112>
+        .\n@prefix nlx_SPM: <http://neurolex.org/wiki/nif-0000-00343> .\n@prefix nidm_statisticType:
+        <http://purl.org/nidash/nidm#NIDM_0000123> .\n@prefix bnode: <http://openprovenance.org/provtoolbox/bnode/>
+        .\n@prefix nidm_errorDegreesOfFreedom: <http://purl.org/nidash/nidm#NIDM_0000093>
+        .\n@prefix dct: <http://purl.org/dc/terms/> .\n@prefix nidm_contrastName:
+        <http://purl.org/nidash/nidm#NIDM_0000085> .\n@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#>
+        .\n@prefix nidm_softwareVersion: <http://purl.org/nidash/nidm#NIDM_0000122>
+        .\n@prefix nidm_heightCriticalThresholdFDR05: <http://purl.org/nidash/nidm#NIDM_0000146>
+        .\n@prefix nidm_ParameterEstimateMap: <http://purl.org/nidash/nidm#NIDM_0000061>
+        .\n@prefix obo_statistic: <http://purl.obolibrary.org/obo/STATO_0000039> .\n@prefix
+        nidm_noiseFWHMInVoxels: <http://purl.org/nidash/nidm#NIDM_0000159> .\n@prefix
+        nidm_hasClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000098> .\n@prefix
+        nidm_isUserDefined: <http://purl.org/nidash/nidm#NIDM_0000106> .\n@prefix
+        dc: <http://purl.org/dc/elements/1.1/> .\n@prefix nidm_coordinateVector: <http://purl.org/nidash/nidm#NIDM_0000086>
+        .\n@prefix nidm_numberOfSignificantClusters: <http://purl.org/nidash/nidm#NIDM_0000111>
+        .\n@prefix nidm_pValueUncorrected: <http://purl.org/nidash/nidm#NIDM_0000116>
+        .\n@prefix nidm_voxelToWorldMapping: <http://purl.org/nidash/nidm#NIDM_0000132>
+        .\n@prefix nidm_NIDMResults: <http://purl.org/nidash/nidm#NIDM_0000027> .\n@prefix
+        nidm_ContrastStandardErrorMap: <http://purl.org/nidash/nidm#NIDM_0000013>
+        .\n@prefix nidm_DisplayMaskMap: <http://purl.org/nidash/nidm#NIDM_0000020>
+        .\n@prefix nidm_Inference: <http://purl.org/nidash/nidm#NIDM_0000049> .\n@prefix
+        obo_FWERadjustedpvalue: <http://purl.obolibrary.org/obo/OBI_0001265> .\n@prefix
+        nidm_version: <http://purl.org/nidash/nidm#NIDM_0000127> .\n@prefix nidm_withEstimationMethod:
+        <http://purl.org/nidash/nidm#NIDM_0000134> .\n@prefix nidm_StatisticMap: <http://purl.org/nidash/nidm#NIDM_0000076>
+        .\n@prefix nidm_PValueUncorrected: <http://purl.org/nidash/nidm#NIDM_0000160>
+        .\n@prefix nlx: <http://neurolex.org/wiki/> .\n@prefix nidm_minDistanceBetweenPeaks:
+        <http://purl.org/nidash/nidm#NIDM_0000109> .\n@prefix nidm_ModelParametersEstimation:
+        <http://purl.org/nidash/nidm#NIDM_0000056> .\n@prefix nidm_searchVolumeInUnits:
+        <http://purl.org/nidash/nidm#NIDM_0000136> .\n@prefix nidm_inCoordinateSpace:
+        <http://purl.org/nidash/nidm#NIDM_0000104> .\n@prefix nidm_expectedNumberOfVoxelsPerCluster:
+        <http://purl.org/nidash/nidm#NIDM_0000143> .\n@prefix nidm_hasConnectivityCriterion:
+        <http://purl.org/nidash/nidm#NIDM_0000099> .\n@prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
+        .\n@prefix nidm_Peak: <http://purl.org/nidash/nidm#NIDM_0000062> .\n@prefix
+        spm_smallestSignificantClusterSizeInVoxelsFWE05: <http://purl.org/nidash/spm#SPM_0000014>
+        .\n@prefix nidm_clusterSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000084>
+        .\n@prefix nidm_equivalentThreshold: <http://purl.org/nidash/nidm#NIDM_0000161>
+        .\n@prefix nidm_inWorldCoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000105>
+        .\n@prefix nidm_hasMaximumIntensityProjection: <http://purl.org/nidash/nidm#NIDM_0000138>
+        .\n@prefix nidm_ResidualMeanSquaresMap: <http://purl.org/nidash/nidm#NIDM_0000066>
+        .\n@prefix dctype: <http://purl.org/dc/dcmitype/> .\n@prefix nidm_hasAlternativeHypothesis:
+        <http://purl.org/nidash/nidm#NIDM_0000097> .\n@prefix nidm_HeightThreshold:
+        <http://purl.org/nidash/nidm#NIDM_0000034> .\n@prefix nidm_targetIntensity:
+        <http://purl.org/nidash/nidm#NIDM_0000124> .\n@prefix nidm_CoordinateSpace:
+        <http://purl.org/nidash/nidm#NIDM_0000016> .\n@prefix spm_smallestSignificantClusterSizeInVoxelsFDR05:
+        <http://purl.org/nidash/spm#SPM_0000013> .\n@prefix fsl: <http://purl.org/nidash/fsl#>
+        .\n@prefix nidm_DesignMatrix: <http://purl.org/nidash/nidm#NIDM_0000019> .\n@prefix
+        nidm_clusterSizeInResels: <http://purl.org/nidash/nidm#NIDM_0000156> .\n@prefix
+        nidm_errorVarianceHomogeneous: <http://purl.org/nidash/nidm#NIDM_0000094>
+        .\n@prefix xsd_1: <http://www.w3.org/2001/XMLSchema##> .\n@prefix nidm_NIDMResultsExport:
+        <http://purl.org/nidash/nidm#NIDM_0000166> .\n@prefix nidm_maxNumberOfPeaksPerCluster:
+        <http://purl.org/nidash/nidm#NIDM_0000108> .\n@prefix nidm_pValue: <http://purl.org/nidash/nidm#NIDM_0000114>
+        .\n@prefix nidm_ExcursionSetMap: <http://purl.org/nidash/nidm#NIDM_0000025>
+        .\n@prefix spm: <http://purl.org/nidash/spm#> .\n@prefix nidm_expectedNumberOfClusters:
+        <http://purl.org/nidash/nidm#NIDM_0000141> .\n@prefix nidm_searchVolumeInVoxels:
+        <http://purl.org/nidash/nidm#NIDM_0000121> .\n@prefix nidm_qValueFDR: <http://purl.org/nidash/nidm#NIDM_0000119>
+        .\n@prefix niiri: <http://iri.nidash.org/> .\n@prefix nidm_ContrastEstimation:
+        <http://purl.org/nidash/nidm#NIDM_0000001> .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+        .\n@prefix nidm_reselSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000148>
+        .\n@prefix nidm_ContrastMap: <http://purl.org/nidash/nidm#NIDM_0000002> .\n@prefix
+        nidm_pValueFWER: <http://purl.org/nidash/nidm#NIDM_0000115> .\n@prefix nidm_noiseFWHMInUnits:
+        <http://purl.org/nidash/nidm#NIDM_0000157> .\n@prefix nidm_DataScaling: <http://purl.org/nidash/nidm#NIDM_0000018>
+        .\n@prefix nidm_SupraThresholdCluster: <http://purl.org/nidash/nidm#NIDM_0000070>
+        .\n@prefix nidm_hasErrorDependence: <http://purl.org/nidash/nidm#NIDM_0000100>
+        .\n@prefix obo_contrastweightmatrix: <http://purl.obolibrary.org/obo/STATO_0000323>
+        .\n@prefix nidm_clusterLabelId: <http://purl.org/nidash/nidm#NIDM_0000082>
+        .\n@prefix nidm_ReselsPerVoxelMap: <http://purl.org/nidash/nidm#NIDM_0000144>
+        .\n@prefix nidm_voxel18connected: <http://purl.org/nidash/nidm#NIDM_0000128>
+        .\n@prefix nidm: <http://purl.org/nidash/nidm#> .\n@prefix nidm_Coordinate:
+        <http://purl.org/nidash/nidm#NIDM_0000015> .\n@prefix nidm_searchVolumeInResels:
+        <http://purl.org/nidash/nidm#NIDM_0000149> .\n@prefix nidm_OneTailedTest:
+        <http://purl.org/nidash/nidm#NIDM_0000060> .\n@prefix nidm_voxelSize: <http://purl.org/nidash/nidm#NIDM_0000131>
+        .\n@prefix nidm_MaskMap: <http://purl.org/nidash/nidm#NIDM_0000054> .\n@prefix
+        obo_ordinaryleastsquaresestimation: <http://purl.obolibrary.org/obo/STATO_0000370>
+        .\n@prefix nidm_GrandMeanMap: <http://purl.org/nidash/nidm#NIDM_0000033> .\n@prefix
+        nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .\n@prefix
+        nidm_IndependentParameter: <http://purl.org/nidash/nidm#NIDM_0000073> .\n@prefix
+        nidm_IndependentError: <http://purl.org/nidash/nidm#NIDM_0000048> .\n@prefix
+        nidm_randomFieldStationarity: <http://purl.org/nidash/nidm#NIDM_0000120> .\n@prefix
+        obo_normaldistribution: <http://purl.obolibrary.org/obo/STATO_0000227> .\n@prefix
+        nidm_voxelUnits: <http://purl.org/nidash/nidm#NIDM_0000133> .\n@prefix nidm_varianceMapWiseDependence:
+        <http://purl.org/nidash/nidm#NIDM_0000126> .\n@prefix nidm_ErrorModel: <http://purl.org/nidash/nidm#NIDM_0000023>
+        .\n@prefix nidm_maskedMedian: <http://purl.org/nidash/nidm#NIDM_0000107> .\n@prefix
+        nidm_hasErrorDistribution: <http://purl.org/nidash/nidm#NIDM_0000101> .\n@prefix
+        nidm_ClusterDefinitionCriteria: <http://purl.org/nidash/nidm#NIDM_0000007>
+        .\n@prefix spm_searchVolumeReselsGeometry: <http://purl.org/nidash/spm#SPM_0000010>
+        .\n\n\nniiri:supra_threshold_cluster_0004 prov:wasDerivedFrom niiri:excursion_set_map_id
+        .\n\nniiri:supra_threshold_cluster_0003 prov:wasDerivedFrom niiri:excursion_set_map_id
+        .\n\nniiri:supra_threshold_cluster_0005 prov:wasDerivedFrom niiri:excursion_set_map_id
+        .\n\nniiri:supra_threshold_cluster_0002 prov:wasDerivedFrom niiri:excursion_set_map_id
+        .\n\nniiri:supra_threshold_cluster_0001 prov:wasDerivedFrom niiri:excursion_set_map_id
+        .\n\nniiri:statistic_map_id prov:wasDerivedFrom niiri:statistic_map_id_der
+        .\n\nniiri:beta_map_id_2 prov:wasDerivedFrom niiri:beta_map_id_2_der .\n\nniiri:contrast_map_id_2
+        prov:wasDerivedFrom niiri:contrast_map_id_2_der .\n\nniiri:statistic_map_id_2
+        prov:wasDerivedFrom niiri:statistic_map_id_2_der .\n\nniiri:peak_0003 prov:wasDerivedFrom
+        niiri:supra_threshold_cluster_0001 .\n\nniiri:peak_0004 prov:wasDerivedFrom
+        niiri:supra_threshold_cluster_0002 .\n\nniiri:contrast_map_id prov:wasDerivedFrom
+        niiri:contrast_map_id_der .\n\nniiri:peak_0002 prov:wasDerivedFrom niiri:supra_threshold_cluster_0001
+        .\n\nniiri:beta_map_id_1 prov:wasDerivedFrom niiri:beta_map_id_1_der .\n\nniiri:peak_0001
+        prov:wasDerivedFrom niiri:supra_threshold_cluster_0001 .\n\nniiri:beta_map_id_3
+        prov:wasDerivedFrom niiri:beta_map_id_3_der .\n\nniiri:resels_per_voxel_map_id
+        prov:wasDerivedFrom niiri:resels_per_voxel_map_id_der .\n\nniiri:inference_id_2
+        prov:wasAssociatedWith niiri:software_id .\n\nniiri:inference_id_3 prov:wasAssociatedWith
+        niiri:software_id .\n\nniiri:inference_id prov:wasAssociatedWith niiri:software_id
+        .\n\nniiri:export_id prov:wasAssociatedWith niiri:exporter_id .\n\nniiri:contrast_estimation_id
+        prov:wasAssociatedWith niiri:software_id .\n\nniiri:contrast_estimation_id_2
+        prov:wasAssociatedWith niiri:software_id .\n\nniiri:model_pe_id prov:wasAssociatedWith
+        niiri:software_id .\n\nniiri:inference_id_3 prov:used niiri:statistic_map_id_2
+        .\n\nniiri:model_pe_id prov:used niiri:error_model_id .\n\nniiri:inference_id_2
+        prov:used niiri:height_threshold_id_1_2 , niiri:statistic_map_id_2 .\n\nniiri:inference_id_3
+        prov:used niiri:statistic_map_id .\n\nniiri:inference_id_2 prov:used niiri:resels_per_voxel_map_id
+        , niiri:mask_id_1 , niiri:cluster_definition_criteria_id_2 .\n\nniiri:contrast_estimation_id
+        prov:used niiri:residual_mean_squares_map_id , niiri:mask_id_1 , niiri:contrast_id
+        , niiri:design_matrix_id .\n\nniiri:inference_id prov:used niiri:height_threshold_id_1_1
+        .\n\nniiri:contrast_estimation_id_2 prov:used niiri:residual_mean_squares_map_id
+        , niiri:mask_id_1 .\n\nniiri:inference_id_3 prov:used niiri:resels_per_voxel_map_id
+        , niiri:mask_id_1 , niiri:height_threshold_id_3 .\n\nniiri:inference_id prov:used
+        niiri:statistic_map_id .\n\nniiri:contrast_estimation_id_2 prov:used niiri:design_matrix_id
+        .\n\nniiri:model_pe_id prov:used niiri:design_matrix_id , niiri:data_id .\n\nniiri:contrast_estimation_id_2
+        prov:used niiri:contrast_id_2 .\n\nniiri:contrast_estimation_id prov:used
+        niiri:beta_map_id_1 .\n\nniiri:contrast_estimation_id_2 prov:used niiri:beta_map_id_3
+        .\n\nniiri:inference_id prov:used niiri:resels_per_voxel_map_id .\n\nniiri:contrast_estimation_id
+        prov:used niiri:beta_map_id_2 .\n\nniiri:inference_id prov:used niiri:cluster_definition_criteria_id
+        , niiri:mask_id_1 .\n\nniiri:inference_id_2 prov:used niiri:extent_threshold_id_1_2
+        , niiri:peak_definition_criteria_id_2 .\n\nniiri:inference_id_3 prov:used
+        niiri:display_map_id_3 , niiri:extent_threshold_id_3 .\n\nniiri:inference_id
+        prov:used niiri:peak_definition_criteria_id , niiri:extent_threshold_id_1_1
+        .\n\nniiri:inference_id_3 prov:used niiri:cluster_definition_criteria_id_3
+        , niiri:peak_definition_criteria_id_3 .\n\nniiri:exporter_id a prov:Agent
+        , nidm:NIDM_0000168 , prov:SoftwareAgent ;\n\trdfs:label \"spm_results_nidm\"
+        ;\n\tnidm:NIDM_0000122 \"12b.5858\"^^pre_1:string .\n\nniiri:software_id a
+        prov:Agent , nlx:nif-0000-00343 , prov:SoftwareAgent ;\n\trdfs:label \"SPM\"
+        ;\n\tnidm:NIDM_0000122 \"12b.5853\"^^pre_1:string .\n\nniiri:peak_0002 a prov:Entity
+        , nidm:NIDM_0000062 ;\n\trdfs:label \"Peak: 0002\" ;\n\tprov:atLocation niiri:coordinate_0002
+        ;\n\tprov:value \"13.0321407318\"^^pre_1:float ;\n\tnidm:NIDM_0000119 \"1.19156591714e-11\"^^pre_1:float
+        ;\n\tnidm:NIDM_0000092 \"INF\"^^pre_1:float ;\n\tnidm:NIDM_0000115 \"0\"^^pre_1:float
+        ;\n\tnidm:NIDM_0000116 \"4.44089209850063e-16\"^^pre_1:float .\n\nniiri:peak_0003
+        a prov:Entity , nidm:NIDM_0000062 ;\n\trdfs:label \"Peak: 0003\" ;\n\tprov:atLocation
+        niiri:coordinate_0003 ;\n\tprov:value \"10.2856016159058\"^^pre_1:float ;\n\tnidm:NIDM_0000119
+        \"6.84121260274992e-10\"^^pre_1:float ;\n\tnidm:NIDM_0000092 \"INF\"^^pre_1:float
+        ;\n\tnidm:NIDM_0000115 \"7.69451169446711e-12\"^^pre_1:float ;\n\tnidm:NIDM_0000116
+        \"4.44089209850063e-16\"^^pre_1:float .\n\nniiri:contrast_id a prov:Entity
+        , obo:STATO_0000323 ;\n\trdfs:label \"Contrast: listening > reading\" ;\n\tprov:value
+        \"[1, -1, 0, 0]\"^^pre_1:string ;\n\tnidm:NIDM_0000123 obo:STATO_0000176 ;\n\tnidm:NIDM_0000085
+        \"listening > reading\"^^pre_1:string .\n\nniiri:peak_0001 a prov:Entity ,
+        nidm:NIDM_0000062 ;\n\trdfs:label \"Peak: 0001\" ;\n\tprov:atLocation niiri:coordinate_0001
+        ;\n\tprov:value \"17.5207633972168\"^^pre_1:float ;\n\tnidm:NIDM_0000119 \"1.19156591713838e-11\"^^pre_1:float
+        ;\n\tnidm:NIDM_0000092 \"INF\"^^pre_1:float ;\n\tnidm:NIDM_0000115 \"0\"^^pre_1:float
+        ;\n\tnidm:NIDM_0000116 \"4.44089209850063e-16\"^^pre_1:float .\n\nniiri:peak_0004
+        a prov:Entity , nidm:NIDM_0000062 ;\n\trdfs:label \"Peak: 0004\" ;\n\tprov:atLocation
+        niiri:coordinate_0004 ;\n\tprov:value \"13.5425577163696\"^^pre_1:float ;\n\tnidm:NIDM_0000119
+        \"1.19156591713838e-11\"^^pre_1:float ;\n\tnidm:NIDM_0000092 \"INF\"^^pre_1:float
+        ;\n\tnidm:NIDM_0000115 \"0\"^^pre_1:float ;\n\tnidm:NIDM_0000116 \"4.44089209850063e-16\"^^pre_1:float
+        .\n\nniiri:cluster_definition_criteria_id_2 a prov:Entity , nidm:NIDM_0000007
+        ;\n\trdfs:label \"Cluster Connectivity Criterion: 18\" ;\n\tnidm:NIDM_0000099
+        nidm:NIDM_0000128 .\n\nniiri:cluster_definition_criteria_id_3 a prov:Entity
+        , nidm:NIDM_0000007 ;\n\trdfs:label \"Cluster Connectivity Criterion: 18\"
+        ;\n\tnidm:NIDM_0000099 nidm:NIDM_0000128 .\n\nniiri:error_model_id a prov:Entity
+        , nidm:NIDM_0000023 ;\n\tnidm:NIDM_0000089 nidm:NIDM_0000073 ;\n\tnidm:NIDM_0000126
+        nidm:NIDM_0000073 ;\n\tnidm:NIDM_0000100 nidm:NIDM_0000048 ;\n\tnidm:NIDM_0000094
+        \"true\"^^pre_1:boolean ;\n\tnidm:NIDM_0000101 obo:STATO_0000227 .\n\nniiri:data_id
+        a prov:Entity , prov:Collection , nidm:NIDM_0000018 ;\n\trdfs:label \"Data\"
+        ;\n\tnidm:NIDM_0000124 \"100\"^^pre_1:float ;\n\tnidm:NIDM_0000096 \"true\"^^pre_1:boolean
+        .\n\nniiri:contrast_standard_error_map_id a prov:Entity , nidm:NIDM_0000013
+        ;\n\trdfs:label \"Contrast 1 Standard Error Map\" ;\n\tprov:atLocation \"ContrastStandardError_0001.nii.gz\"^^pre_1:anyURI
+        ;\n\tnfo:fileName \"ContrastStandardError_0001.nii.gz\"^^pre_1:string ;\n\tnidm:NIDM_0000104
+        niiri:coordinate_space_id_1 ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string
+        ;\n\tdct:format \"image/nifti\"^^pre_1:string .\n\nniiri:height_threshold_id_3_2
+        a prov:Entity , nidm:NIDM_0000034 , nidm:NIDM_0000160 ;\n\trdfs:label \"Height
+        Threshold\" ;\n\tprov:value \"2.7772578456986e-06\"^^pre_1:float .\n\nniiri:contrast_map_id_der
+        a prov:Entity , nidm:NIDM_0000002 ;\n\tnfo:fileName \"con_0001.nii\"^^pre_1:string
+        ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string ;\n\tdct:format
+        \"image/nifti\"^^pre_1:string .\n\nniiri:display_map_id_3 a prov:Entity ,
+        nidm:NIDM_0000020 ;\n\trdfs:label \"Display Mask Map\" ;\n\tprov:atLocation
+        \"DisplayMask.nii.gz\"^^pre_1:anyURI ;\n\tnfo:fileName \"DisplayMask.nii.gz\"^^pre_1:string
+        ;\n\tnidm:NIDM_0000104 niiri:coordinate_space_id_1 ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string
+        ;\n\tdct:format \"image/nifti\"^^pre_1:string .\n\nniiri:statistic_map_id_2
+        a prov:Entity , nidm:NIDM_0000076 ;\n\trdfs:label \"Statistic Map: motor\"
+        ;\n\tprov:atLocation \"TStatistic_0002.nii.gz\"^^pre_1:anyURI ;\n\tnidm:NIDM_0000093
+        \"72.9999999990787\"^^pre_1:float ;\n\tnfo:fileName \"TStatistic_0002.nii.gz\"^^pre_1:string
+        ;\n\tnidm:NIDM_0000123 obo:STATO_0000176 ;\n\tnidm:NIDM_0000104 niiri:coordinate_space_id_1
+        ;\n\tnidm:NIDM_0000091 \"1\"^^pre_1:float ;\n\tnidm:NIDM_0000085 \"motor\"^^pre_1:string
+        ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string ;\n\tdct:format
+        \"image/nifti\"^^pre_1:string .\n\nniiri:extent_threshold_id_1_1 a prov:Entity
+        , nidm:NIDM_0000026 , obo:STATO_0000039 ;\n\trdfs:label \"Extent Threshold:
+        k>=0\" ;\n\tnidm:NIDM_0000084 \"0\"^^pre_1:int ;\n\tnidm:NIDM_0000156 \"0\"^^pre_1:float
+        ;\n\tnidm:NIDM_0000161 niiri:extent_threshold_id_2 , niiri:extent_threshold_id_3
+        .\n\nniiri:display_map_id_2 a prov:Entity , nidm:NIDM_0000020 ;\n\trdfs:label
+        \"Display Mask Map\" ;\n\tprov:atLocation \"DisplayMask.nii.gz\"^^pre_1:anyURI
+        ;\n\tnfo:fileName \"DisplayMask.nii.gz\"^^pre_1:string ;\n\tnidm:NIDM_0000104
+        niiri:coordinate_space_id_1 ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string
+        ;\n\tdct:format \"image/nifti\"^^pre_1:string .\n\nniiri:coordinate_0002 a
+        prov:Entity , nidm:NIDM_0000015 ;\n\trdfs:label \"Coordinate: 0002\" ;\n\tnidm:NIDM_0000086
+        \"[ -42, -31, 11 ]\"^^pre_1:string .\n\nniiri:height_threshold_id_12 a prov:Entity
+        , nidm:NIDM_0000034 , obo:STATO_0000039 ;\n\trdfs:label \"Height Threshold\"
+        ;\n\tprov:value \"5.23529984739211\"^^pre_1:float .\n\nniiri:cluster_definition_criteria_id
+        a prov:Entity , nidm:NIDM_0000007 ;\n\trdfs:label \"Cluster Connectivity Criterion:
+        18\" ;\n\tnidm:NIDM_0000099 nidm:NIDM_0000128 .\n\nniiri:supra_threshold_cluster_0004
+        a prov:Entity , nidm:NIDM_0000070 ;\n\trdfs:label \"Supra-Threshold Cluster:
+        0004\" ;\n\tnidm:NIDM_0000119 \"0.0137821290130967\"^^pre_1:float ;\n\tnidm:NIDM_0000156
+        \"0.218196724761195\"^^pre_1:float ;\n\tnidm:NIDM_0000084 \"29\"^^pre_1:int
+        ;\n\tnidm:NIDM_0000082 \"4\"^^pre_1:int ;\n\tnidm:NIDM_0000115 \"0.000565384750377596\"^^pre_1:float
+        ;\n\tnidm:NIDM_0000116 \"0.0110257032104773\"^^pre_1:float .\n\nniiri:height_threshold_id_1_2
+        a prov:Entity , obo:OBI_0001265 , nidm:NIDM_0000034 ;\n\trdfs:label \"Height
+        Threshold: p<0.05 (FWE)\" ;\n\tprov:value \"0.0499999999999976\"^^pre_1:float
+        ;\n\tnidm:NIDM_0000161 niiri:height_threshold_id_3 , niiri:height_threshold_id_2
+        .\n\nniiri:extent_threshold_id_2_1 a prov:Entity , nidm:NIDM_0000026 , obo:OBI_0001265
+        ;\n\trdfs:label \"Extent Threshold\" ;\n\tprov:value \"1\"^^pre_1:float .\n\nniiri:beta_map_id_2
+        a prov:Entity , nidm:NIDM_0000061 ;\n\trdfs:label \"Beta Map 2\" ;\n\tprov:atLocation
+        \"ParameterEstimate_0002.nii.gz\"^^pre_1:anyURI ;\n\tnfo:fileName \"ParameterEstimate_0002.nii.gz\"^^pre_1:string
+        ;\n\tnidm:NIDM_0000104 niiri:coordinate_space_id_1 ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string
+        ;\n\tdct:format \"image/nifti\"^^pre_1:string .\n\nniiri:height_threshold_id_1_1
+        a prov:Entity , obo:OBI_0001265 , nidm:NIDM_0000034 ;\n\trdfs:label \"Height
+        Threshold: p<0.05 (FWE)\" ;\n\tprov:value \"0.0499999999999976\"^^pre_1:float
+        ;\n\tnidm:NIDM_0000161 niiri:height_threshold_id_3 , niiri:height_threshold_id_2
+        .\n\nniiri:design_matrix_png_id a prov:Entity , dctype:Image ;\n\tprov:atLocation
+        \"DesignMatrix.png\"^^pre_1:anyURI ;\n\tnfo:fileName \"DesignMatrix.png\"^^pre_1:string
+        ;\n\tdct:format \"image/png\"^^pre_1:string .\n\nniiri:height_threshold_id
+        a prov:Entity , obo:OBI_0001265 , nidm:NIDM_0000034 ;\n\trdfs:label \"Height
+        Threshold: p<0.05 (FWE)\" ;\n\tprov:value \"0.05\"^^pre_1:float ;\n\tnidm:NIDM_0000161
+        niiri:height_threshold_id_13 , niiri:height_threshold_id_12 .\n\nniiri:extent_threshold_id_3_2
+        a prov:Entity , nidm:NIDM_0000026 , nidm:NIDM_0000160 ;\n\trdfs:label \"Extent
+        Threshold\" ;\n\tprov:value \"1\"^^pre_1:float .\n\nniiri:extent_threshold_id_3_1
+        a prov:Entity , nidm:NIDM_0000026 , nidm:NIDM_0000160 ;\n\trdfs:label \"Extent
+        Threshold\" ;\n\tprov:value \"1\"^^pre_1:float .\n\nniiri:search_space_mask_id
+        a prov:Entity , nidm:NIDM_0000068 ;\n\trdfs:label \"Search Space Mask Map\"
+        ;\n\tprov:atLocation \"SearchSpaceMask.nii.gz\"^^pre_1:anyURI ;\n\tnidm:NIDM_0000121
+        \"69306\"^^pre_1:int ;\n\tnidm:NIDM_0000141 \"0.0512932943875478\"^^pre_1:float
+        ;\n\tnidm:NIDM_0000157 \"[ 16.2383695773208, 16.3091687172086, 13.5499997663244
+        ]\"^^pre_1:string ;\n\tnidm:NIDM_0000147 \"4.85241745689539\"^^pre_1:float
+        ;\n\tspm:SPM_0000013 \"29\"^^pre_1:int ;\n\tnidm:NIDM_0000143 \"4.02834655908613\"^^pre_1:float
+        ;\n\tnidm:NIDM_0000149 \"467.07642343881\"^^pre_1:float ;\n\tnidm:NIDM_0000148
+        \"132.907586178202\"^^pre_1:float ;\n\tnidm:NIDM_0000159 \"[ 5.41278985910694,
+        5.43638957240286, 4.51666658877481 ]\"^^pre_1:string ;\n\tnfo:fileName \"SearchSpaceMask.nii.gz\"^^pre_1:string
+        ;\n\tnidm:NIDM_0000136 \"1871262\"^^pre_1:float ;\n\tspm:SPM_0000014 \"12\"^^pre_1:int
+        ;\n\tdct:format \"image/nifti\"^^pre_1:string ;\n\tnidm:NIDM_0000104 niiri:coordinate_space_id_1
+        ;\n\tnidm:NIDM_0000146 \"5.7639536857605\"^^pre_1:float ;\n\tcrypto:sha512
+        \"932fd9f0d55e9822748f4a9b35a0a7f0fe442f3e061e2eda48c2617a2938df50ea84deca8de0725641a0105b712a80a0c8931df9bdf3bef788b1041379d00875\"^^pre_1:string
+        ;\n\tspm:SPM_0000010 \"[7, 42.96312274763, 269.40914815306, 467.07642343881]\"^^pre_1:string
+        ;\n\tnidm:NIDM_0000120 \"true\"^^pre_1:boolean .\n\nniiri:resels_per_voxel_map_id
+        a prov:Entity , nidm:NIDM_0000144 ;\n\trdfs:label \"Resels per Voxel Map\"
+        ;\n\tprov:atLocation \"ReselsPerVoxel.nii.gz\"^^pre_1:anyURI ;\n\tnfo:fileName
+        \"ReselsPerVoxel.nii.gz\"^^pre_1:string ;\n\tnidm:NIDM_0000104 niiri:coordinate_space_id_1
+        ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string ;\n\tdct:format
+        \"image/nifti\"^^pre_1:string .\n\nniiri:beta_map_id_3_der a prov:Entity ,
+        nidm:NIDM_0000061 ;\n\tnfo:fileName \"beta_0003.nii\"^^pre_1:string ;\n\tcrypto:sha512
+        \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string ;\n\tdct:format \"image/nifti\"^^pre_1:string
+        .\n\nniiri:beta_map_id_1 a prov:Entity , nidm:NIDM_0000061 ;\n\trdfs:label
+        \"Beta Map 1\" ;\n\tprov:atLocation \"ParameterEstimate_0001.nii.gz\"^^pre_1:anyURI
+        ;\n\tnfo:fileName \"ParameterEstimate_0001.nii.gz\"^^pre_1:string ;\n\tnidm:NIDM_0000104
+        niiri:coordinate_space_id_1 ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string
+        ;\n\tdct:format \"image/nifti\"^^pre_1:string .\n\nniiri:contrast_map_id_2_der
+        a prov:Entity , nidm:NIDM_0000002 ;\n\tnfo:fileName \"con_0002.nii\"^^pre_1:string
+        ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string ;\n\tdct:format
+        \"image/nifti\"^^pre_1:string .\n\nniiri:contrast_map_id a prov:Entity , nidm:NIDM_0000002
+        ;\n\trdfs:label \"Contrast Map: listening > reading\" ;\n\tprov:atLocation
+        \"Contrast_0001.nii.gz\"^^pre_1:anyURI ;\n\tnfo:fileName \"Contrast_0001.nii.gz\"^^pre_1:string
+        ;\n\tnidm:NIDM_0000104 niiri:coordinate_space_id_1 ;\n\tnidm:NIDM_0000085
+        \"listening > reading\"^^pre_1:string ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string
+        ;\n\tdct:format \"image/nifti\"^^pre_1:string .\n\nniiri:display_map_id a
+        prov:Entity , nidm:NIDM_0000020 ;\n\trdfs:label \"Display Mask Map\" ;\n\tprov:atLocation
+        \"DisplayMask.nii.gz\"^^pre_1:anyURI ;\n\tnfo:fileName \"DisplayMask.nii.gz\"^^pre_1:string
+        ;\n\tnidm:NIDM_0000104 niiri:coordinate_space_id_1 ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string
+        ;\n\tdct:format \"image/nifti\"^^pre_1:string .\n\nniiri:extent_threshold_id_23
+        a prov:Entity , nidm:NIDM_0000026 , nidm:NIDM_0000160 ;\n\trdfs:label \"Extent
+        Threshold\" ;\n\tprov:value \"1\"^^pre_1:float .\n\nniiri:height_threshold_id_2_2
+        a prov:Entity , nidm:NIDM_0000034 , obo:STATO_0000039 ;\n\trdfs:label \"Height
+        Threshold\" ;\n\tprov:value \"4.85241745689539\"^^pre_1:float .\n\nniiri:contrast_standard_error_map_id_2
+        a prov:Entity , nidm:NIDM_0000013 ;\n\trdfs:label \"Contrast 2 Standard Error
+        Map\" ;\n\tprov:atLocation \"ContrastStandardError_0002.nii.gz\"^^pre_1:anyURI
+        ;\n\tnfo:fileName \"ContrastStandardError_0002.nii.gz\"^^pre_1:string ;\n\tnidm:NIDM_0000104
+        niiri:coordinate_space_id_1 ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string
+        ;\n\tdct:format \"image/nifti\"^^pre_1:string .\n\nniiri:extent_threshold_id_22
+        a prov:Entity , nidm:NIDM_0000026 , obo:OBI_0001265 ;\n\trdfs:label \"Extent
+        Threshold\" ;\n\tprov:value \"1\"^^pre_1:float .\n\nniiri:height_threshold_id_32
+        a prov:Entity , nidm:NIDM_0000034 , obo:STATO_0000039 ;\n\trdfs:label \"Height
+        Threshold\" ;\n\tprov:value \"5.23529984739211\"^^pre_1:float .\n\nniiri:height_threshold_id_33
+        a prov:Entity , obo:OBI_0001265 , nidm:NIDM_0000034 ;\n\trdfs:label \"Height
+        Threshold\" ;\n\tprov:value \"0.05\"^^pre_1:float .\n\nniiri:spm_results_id
+        a prov:Entity , nidm:NIDM_0000027 , prov:Bundle ;\n\trdfs:label \"NIDM-Results\"
+        ;\n\tnidm:NIDM_0000127 \"1.1.0\"^^pre_1:string .\n\nniiri:mask_id_1 a prov:Entity
+        , nidm:NIDM_0000054 ;\n\trdfs:label \"Mask\" ;\n\tprov:atLocation \"Mask.nii.gz\"^^pre_1:anyURI
+        ;\n\tnfo:fileName \"Mask.nii.gz\"^^pre_1:string ;\n\tnidm:NIDM_0000106 \"false\"^^pre_1:boolean
+        ;\n\tnidm:NIDM_0000104 niiri:coordinate_space_id_1 ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string
+        ;\n\tdct:format \"image/nifti\"^^pre_1:string .\n\nniiri:height_threshold_id_13
+        a prov:Entity , nidm:NIDM_0000034 , nidm:NIDM_0000160 ;\n\trdfs:label \"Height
+        Threshold\" ;\n\tprov:value \"7.62276079258051e-07\"^^pre_1:float .\n\nniiri:extent_threshold_id_2_2
+        a prov:Entity , nidm:NIDM_0000026 , obo:OBI_0001265 ;\n\trdfs:label \"Extent
+        Threshold\" ;\n\tprov:value \"1\"^^pre_1:float .\n\nniiri:statistic_map_id_2_der
+        a prov:Entity , nidm:NIDM_0000076 ;\n\tnfo:fileName \"spmT_0002.nii\"^^pre_1:string
+        ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string ;\n\tdct:format
+        \"image/nifti\"^^pre_1:string .\n\nniiri:extent_threshold_id_32 a prov:Entity
+        , nidm:NIDM_0000026 , obo:OBI_0001265 ;\n\trdfs:label \"Extent Threshold\"
+        ;\n\tprov:value \"1\"^^pre_1:float .\n\nniiri:extent_threshold_id_3 a prov:Entity
+        , nidm:NIDM_0000026 , obo:STATO_0000039 ;\n\trdfs:label \"Extent Threshold:
+        k>=10\" ;\n\tnidm:NIDM_0000084 \"10\"^^pre_1:int ;\n\tnidm:NIDM_0000156 \"3.3\"^^pre_1:float
+        ;\n\tnidm:NIDM_0000161 niiri:height_threshold_id_13 , niiri:height_threshold_id_12
+        .\n\nniiri:coordinate_space_id_1 a prov:Entity , nidm:NIDM_0000016 ;\n\trdfs:label
+        \"Coordinate space 1\" ;\n\tnidm:NIDM_0000132 \"[[-3, 0, 0, 78],[0, 3, 0,
+        -112],[0, 0, 3, -50],[0, 0, 0, 1]]\"^^pre_1:string ;\n\tnidm:NIDM_0000133
+        \"[ \\\"mm\\\", \\\"mm\\\", \\\"mm\\\" ]\"^^pre_1:string ;\n\tnidm:NIDM_0000105
+        nidm:NIDM_0000051 ;\n\tnidm:NIDM_0000131 \"[ 3, 3, 3 ]\"^^pre_1:string ;\n\tnidm:NIDM_0000090
+        \"[ 53, 63, 46 ]\"^^pre_1:string ;\n\tnidm:NIDM_0000112 \"3\"^^pre_1:int .\n\nniiri:height_threshold_id_3
+        a prov:Entity , nidm:NIDM_0000034 , nidm:NIDM_0000160 ;\n\trdfs:label \"Height
+        Threshold: p<0.001 (unc)\" ;\n\tprov:value \"7.62276079258051e-07\"^^pre_1:float
+        ;\n\tnidm:NIDM_0000161 niiri:height_threshold_id_33 , niiri:height_threshold_id_32
+        .\n\nniiri:grand_mean_map_id a prov:Entity , nidm:NIDM_0000033 ;\n\trdfs:label
+        \"Grand Mean Map\" ;\n\tprov:atLocation \"GrandMean.nii.gz\"^^pre_1:anyURI
+        ;\n\tnfo:fileName \"GrandMean.nii.gz\"^^pre_1:string ;\n\tnidm:NIDM_0000107
+        \"115\"^^pre_1:float ;\n\tnidm:NIDM_0000104 niiri:coordinate_space_id_1 ;\n\tcrypto:sha512
+        \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string ;\n\tdct:format \"image/nifti\"^^pre_1:string
+        .\n\nniiri:extent_threshold_id_1_2 a prov:Entity , nidm:NIDM_0000026 , obo:STATO_0000039
+        ;\n\trdfs:label \"Extent Threshold: k>=0\" ;\n\tnidm:NIDM_0000084 \"0\"^^pre_1:int
+        ;\n\tnidm:NIDM_0000156 \"0\"^^pre_1:float ;\n\tnidm:NIDM_0000161 niiri:extent_threshold_id_2
+        , niiri:extent_threshold_id_3 .\n\nniiri:peak_definition_criteria_id_2 a prov:Entity
+        , nidm:NIDM_0000063 ;\n\trdfs:label \"Peak Definition Criteria\" ;\n\tnidm:NIDM_0000109
+        \"8.0\"^^pre_1:float ;\n\tnidm:NIDM_0000108 \"3\"^^pre_1:int .\n\nniiri:excursion_set_map_id
+        a prov:Entity , nidm:NIDM_0000025 ;\n\trdfs:label \"Excursion Set Map\" ;\n\tprov:atLocation
+        \"ExcursionSet.nii.gz\"^^pre_1:anyURI ;\n\tnfo:fileName \"ExcursionSet.nii.gz\"^^pre_1:string
+        ;\n\tnidm:NIDM_0000114 \"2.83510681598e-09\"^^pre_1:float ;\n\tnidm:NIDM_0000104
+        niiri:coordinate_space_id_1 ;\n\tcrypto:sha512 \"d96b82761c299a66978893cab6034f3f8aed25d0a135636b0ffe79f4cf11becce86ba261f7aeb43717f5d0e47ad0b14cfb0402786251e3f2c507890c83b27652\"^^pre_1:string
+        ;\n\tnidm:NIDM_0000111 \"5\"^^pre_1:int ;\n\tnidm:NIDM_0000138 niiri:maximum_intensity_projection_id
+        ;\n\tnidm:NIDM_0000098 niiri:cluster_label_map_id ;\n\tdct:format \"image/nifti\"^^pre_1:string
+        .\n\nniiri:coordinate_0001 a prov:Entity , nidm:NIDM_0000015 ;\n\trdfs:label
+        \"Coordinate: 0001\" ;\n\tnidm:NIDM_0000086 \"[ -60, -25, 11 ]\"^^pre_1:string
+        .\n\nniiri:extent_threshold_id_13 a prov:Entity , nidm:NIDM_0000026 , nidm:NIDM_0000160
+        ;\n\trdfs:label \"Extent Threshold\" ;\n\tprov:value \"1\"^^pre_1:float .\n\nniiri:coordinate_0003
+        a prov:Entity , nidm:NIDM_0000015 ;\n\trdfs:label \"Coordinate: 0003\" ;\n\tnidm:NIDM_0000086
+        \"[ -66, -31, -1 ]\"^^pre_1:string .\n\nniiri:contrast_id_2 a prov:Entity
+        , obo:STATO_0000323 ;\n\trdfs:label \"Contrast: motor\" ;\n\tprov:value \"[
+        0, 0, 1 ]\"^^pre_1:string ;\n\tnidm:NIDM_0000123 obo:STATO_0000176 ;\n\tnidm:NIDM_0000085
+        \"motor\"^^pre_1:string .\n\nniiri:coordinate_0004 a prov:Entity , nidm:NIDM_0000015
+        ;\n\trdfs:label \"Coordinate: 0004\" ;\n\tnidm:NIDM_0000086 \"[ 63, -13, -4
+        ]\"^^pre_1:string .\n\nniiri:beta_map_id_3 a prov:Entity , nidm:NIDM_0000061
+        ;\n\trdfs:label \"Beta Map 3\" ;\n\tprov:atLocation \"ParameterEstimate_0003.nii.gz\"^^pre_1:anyURI
+        ;\n\tnfo:fileName \"ParameterEstimate_0003.nii.gz\"^^pre_1:string ;\n\tnidm:NIDM_0000104
+        niiri:coordinate_space_id_1 ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string
+        ;\n\tdct:format \"image/nifti\"^^pre_1:string .\n\nniiri:height_threshold_id_22
+        a prov:Entity , nidm:NIDM_0000034 , obo:STATO_0000039 ;\n\trdfs:label \"Height
+        Threshold\" ;\n\tprov:value \"5.23529984739211\"^^pre_1:float .\n\nniiri:supra_threshold_cluster_0002
+        a prov:Entity , nidm:NIDM_0000070 ;\n\trdfs:label \"Supra-Threshold Cluster:
+        0002\" ;\n\tnidm:NIDM_0000119 \"1.33570070658018e-16\"^^pre_1:float ;\n\tnidm:NIDM_0000156
+        \"5.22919736927692\"^^pre_1:float ;\n\tnidm:NIDM_0000084 \"695\"^^pre_1:int
+        ;\n\tnidm:NIDM_0000082 \"2\"^^pre_1:int ;\n\tnidm:NIDM_0000115 \"0\"^^pre_1:float
+        ;\n\tnidm:NIDM_0000116 \"5.34280282632073e-17\"^^pre_1:float .\n\nniiri:supra_threshold_cluster_0003
+        a prov:Entity , nidm:NIDM_0000070 ;\n\trdfs:label \"Supra-Threshold Cluster:
+        0003\" ;\n\tnidm:NIDM_0000119 \"0.00829922079256674\"^^pre_1:float ;\n\tnidm:NIDM_0000156
+        \"0.278388924695318\"^^pre_1:float ;\n\tnidm:NIDM_0000084 \"37\"^^pre_1:int
+        ;\n\tnidm:NIDM_0000082 \"3\"^^pre_1:int ;\n\tnidm:NIDM_0000115 \"0.000255384009130943\"^^pre_1:float
+        ;\n\tnidm:NIDM_0000116 \"0.00497953247554004\"^^pre_1:float .\n\nniiri:beta_map_id_2_der
+        a prov:Entity , nidm:NIDM_0000061 ;\n\tnfo:fileName \"beta_0002.nii\"^^pre_1:string
+        ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string ;\n\tdct:format
+        \"image/nifti\"^^pre_1:string .\n\nniiri:peak_definition_criteria_id_3 a prov:Entity
+        , nidm:NIDM_0000063 ;\n\trdfs:label \"Peak Definition Criteria\" ;\n\tnidm:NIDM_0000109
+        \"8.0\"^^pre_1:float ;\n\tnidm:NIDM_0000108 \"3\"^^pre_1:int .\n\nniiri:supra_threshold_cluster_0001
+        a prov:Entity , nidm:NIDM_0000070 ;\n\trdfs:label \"Supra-Threshold Cluster:
+        0001\" ;\n\tnidm:NIDM_0000119 \"1.77948412240239e-18\"^^pre_1:float ;\n\tnidm:NIDM_0000156
+        \"6.31265696809113\"^^pre_1:float ;\n\tnidm:NIDM_0000084 \"839\"^^pre_1:int
+        ;\n\tnidm:NIDM_0000082 \"1\"^^pre_1:int ;\n\tnidm:NIDM_0000115 \"0\"^^pre_1:float
+        ;\n\tnidm:NIDM_0000116 \"3.55896824480477e-19\"^^pre_1:float .\n\nniiri:supra_threshold_cluster_0005
+        a prov:Entity , nidm:NIDM_0000070 ;\n\trdfs:label \"Supra-Threshold Cluster:
+        0005\" ;\n\tnidm:NIDM_0000119 \"0.0818393184514307\"^^pre_1:float ;\n\tnidm:NIDM_0000156
+        \"0.0902882999011843\"^^pre_1:float ;\n\tnidm:NIDM_0000084 \"12\"^^pre_1:int
+        ;\n\tnidm:NIDM_0000082 \"5\"^^pre_1:int ;\n\tnidm:NIDM_0000115 \"0.00418900977248904\"^^pre_1:float
+        ;\n\tnidm:NIDM_0000116 \"0.0818393184514307\"^^pre_1:float .\n\nniiri:height_threshold_id_3_1
+        a prov:Entity , nidm:NIDM_0000034 , nidm:NIDM_0000160 ;\n\trdfs:label \"Height
+        Threshold\" ;\n\tprov:value \"2.7772578456986e-06\"^^pre_1:float .\n\nniiri:contrast_map_id_2
+        a prov:Entity , nidm:NIDM_0000002 ;\n\trdfs:label \"Contrast Map: motor\"
+        ;\n\tprov:atLocation \"Contrast_0002.nii.gz\"^^pre_1:anyURI ;\n\tnfo:fileName
+        \"Contrast_0002.nii.gz\"^^pre_1:string ;\n\tnidm:NIDM_0000104 niiri:coordinate_space_id_1
+        ;\n\tnidm:NIDM_0000085 \"motor\"^^pre_1:string ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string
+        ;\n\tdct:format \"image/nifti\"^^pre_1:string .\n\nniiri:height_threshold_id_2_1
+        a prov:Entity , nidm:NIDM_0000034 , obo:STATO_0000039 ;\n\trdfs:label \"Height
+        Threshold\" ;\n\tprov:value \"4.85241745689539\"^^pre_1:float .\n\nniiri:statistic_map_id_der
+        a prov:Entity , nidm:NIDM_0000076 ;\n\tnfo:fileName \"spmT_0001.nii\"^^pre_1:string
+        ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string ;\n\tdct:format
+        \"image/nifti\"^^pre_1:string .\n\nniiri:residual_mean_squares_map_id a prov:Entity
+        , nidm:NIDM_0000066 ;\n\trdfs:label \"Residual Mean Squares Map\" ;\n\tprov:atLocation
+        \"ResidualMeanSquares.nii.gz\"^^pre_1:anyURI ;\n\tnfo:fileName \"ResidualMeanSquares.nii.gz\"^^pre_1:string
+        ;\n\tnidm:NIDM_0000104 niiri:coordinate_space_id_1 ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string
+        ;\n\tdct:format \"image/nifti\"^^pre_1:string .\n\nniiri:peak_definition_criteria_id
+        a prov:Entity , nidm:NIDM_0000063 ;\n\trdfs:label \"Peak Definition Criteria\"
+        ;\n\tnidm:NIDM_0000109 \"8.0\"^^pre_1:float ;\n\tnidm:NIDM_0000108 \"3\"^^pre_1:int
+        .\n\nniiri:extent_threshold_id a prov:Entity , nidm:NIDM_0000026 , obo:STATO_0000039
+        ;\n\trdfs:label \"Extent Threshold: k>=0\" ;\n\tnidm:NIDM_0000084 \"0\"^^pre_1:int
+        ;\n\tnidm:NIDM_0000156 \"0\"^^pre_1:float ;\n\tnidm:NIDM_0000161 niiri:height_threshold_id_13
+        , niiri:height_threshold_id_12 .\n\nniiri:extent_threshold_id_33 a prov:Entity
+        , nidm:NIDM_0000026 , nidm:NIDM_0000160 ;\n\trdfs:label \"Extent Threshold\"
+        ;\n\tprov:value \"1\"^^pre_1:float .\n\nniiri:design_matrix_id a prov:Entity
+        , nidm:NIDM_0000019 ;\n\trdfs:label \"Design Matrix\" ;\n\tprov:atLocation
+        \"DesignMatrix.csv\"^^pre_1:anyURI ;\n\tnfo:fileName \"DesignMatrix.csv\"^^pre_1:string
+        ;\n\tdc:description niiri:design_matrix_png_id ;\n\tdct:format \"text/csv\"^^pre_1:string
+        .\n\nniiri:height_threshold_id_23 a prov:Entity , obo:OBI_0001265 , nidm:NIDM_0000034
+        ;\n\trdfs:label \"Height Threshold\" ;\n\tprov:value \"0.05\"^^pre_1:float
+        .\n\nniiri:extent_threshold_id_12 a prov:Entity , nidm:NIDM_0000026 , obo:OBI_0001265
+        ;\n\trdfs:label \"Extent Threshold\" ;\n\tprov:value \"1\"^^pre_1:float .\n\nniiri:resels_per_voxel_map_id_der
+        a prov:Entity , nidm:NIDM_0000144 ;\n\tnfo:fileName \"RPV.nii\"^^pre_1:string
+        ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string ;\n\tdct:format
+        \"image/nifti\"^^pre_1:string .\n\nniiri:beta_map_id_1_der a prov:Entity ,
+        nidm:NIDM_0000061 ;\n\tnfo:fileName \"beta_0001.nii\"^^pre_1:string ;\n\tcrypto:sha512
+        \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string ;\n\tdct:format \"image/nifti\"^^pre_1:string
+        .\n\nniiri:statistic_map_id a prov:Entity , nidm:NIDM_0000076 ;\n\trdfs:label
+        \"Statistic Map: listening > reading\" ;\n\tprov:atLocation \"TStatistic_0001.nii.gz\"^^pre_1:anyURI
+        ;\n\tnidm:NIDM_0000093 \"72.9999999990787\"^^pre_1:float ;\n\tnfo:fileName
+        \"TStatistic_0001.nii.gz\"^^pre_1:string ;\n\tnidm:NIDM_0000123 obo:STATO_0000176
+        ;\n\tnidm:NIDM_0000104 niiri:coordinate_space_id_1 ;\n\tnidm:NIDM_0000091
+        \"1\"^^pre_1:float ;\n\tnidm:NIDM_0000085 \"listening > reading\"^^pre_1:string
+        ;\n\tcrypto:sha512 \"e43b6e01b0463fe7d40782137867a\"^^pre_1:string ;\n\tdct:format
+        \"image/nifti\"^^pre_1:string .\n\nniiri:model_pe_id a prov:Activity , nidm:NIDM_0000056
+        ;\n\trdfs:label \"Model parameters estimation\" ;\n\tnidm:NIDM_0000134 obo:STATO_0000370
+        .\n\nniiri:inference_id_3 a prov:Activity , nidm:NIDM_0000011 ;\n\trdfs:label
+        \"Conjunction Inference 3\" ;\n\tnidm:NIDM_0000097 nidm:NIDM_0000060 .\n\nniiri:inference_id_2
+        a prov:Activity , nidm:NIDM_0000049 ;\n\trdfs:label \"Inference 2\" ;\n\tnidm:NIDM_0000097
+        nidm:NIDM_0000060 .\n\nniiri:export_id a prov:Activity , nidm:NIDM_0000166
+        ;\n\trdfs:label \"NIDM-Results export\" .\n\nniiri:inference_id a prov:Activity
+        , nidm:NIDM_0000049 ;\n\trdfs:label \"Inference 1\" ;\n\tnidm:NIDM_0000097
+        nidm:NIDM_0000060 .\n\nniiri:contrast_estimation_id_2 a prov:Activity , nidm:NIDM_0000001
+        ;\n\trdfs:label \"Contrast estimation 2\" .\n\nniiri:contrast_estimation_id
+        a prov:Activity , nidm:NIDM_0000001 ;\n\trdfs:label \"Contrast estimation
+        1\" .\n\nniiri:contrast_standard_error_map_id prov:wasGeneratedBy niiri:contrast_estimation_id
+        .\n\nniiri:contrast_standard_error_map_id_2 prov:wasGeneratedBy niiri:contrast_estimation_id_2
+        .\n\n_:blank1 a prov:Generation ;\n\tprov:activity niiri:export_id .\n\nniiri:spm_results_id
+        prov:qualifiedGeneration _:blank1 .\n\n_:blank1 prov:atTime \"2014-05-19T10:30:00.000+01:00\"^^pre_1:dateTime
+        .\n\nniiri:excursion_set_map_id prov:wasGeneratedBy niiri:inference_id .\n\nniiri:search_space_mask_id
+        prov:wasGeneratedBy niiri:inference_id .\n\nniiri:statistic_map_id prov:wasGeneratedBy
+        niiri:contrast_estimation_id .\n\nniiri:grand_mean_map_id prov:wasGeneratedBy
+        niiri:model_pe_id .\n\nniiri:beta_map_id_2 prov:wasGeneratedBy niiri:model_pe_id
+        .\n\nniiri:contrast_map_id_2 prov:wasGeneratedBy niiri:contrast_estimation_id_2
+        .\n\nniiri:mask_id_1 prov:wasGeneratedBy niiri:model_pe_id .\n\nniiri:contrast_map_id
+        prov:wasGeneratedBy niiri:contrast_estimation_id .\n\nniiri:beta_map_id_1
+        prov:wasGeneratedBy niiri:model_pe_id .\n\nniiri:beta_map_id_3 prov:wasGeneratedBy
+        niiri:model_pe_id .\n\nniiri:residual_mean_squares_map_id prov:wasGeneratedBy
+        niiri:model_pe_id .\n\nniiri:resels_per_voxel_map_id prov:wasGeneratedBy niiri:model_pe_id
+        .\n\nniiri:statistic_map_id_2 prov:wasGeneratedBy niiri:contrast_estimation_id_2
+        .\n"}
+    headers:
+      connection: [close]
+      content-length: ['36743']
+      content-type: [text/html; charset=utf-8]
+      date: ['Wed, 20 Jan 2016 17:46:15 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000;]
+      vary: [Accept-Encoding]
+      x-ua-compatible: [IE=Edge]
+    status: {code: 200, message: OK}
 version: 1


### PR DESCRIPTION
Use explicitely the "nidm" prefix (rather than a default namespace on ":") for the experiment model.