### PR TITLE
Link to public mailing list for comments

### DIFF
--- a/doc/content/specs/include/nidm-experiment_head.html
+++ b/doc/content/specs/include/nidm-experiment_head.html
@@ -61,7 +61,7 @@
             previousPublishDate: "2013-12-10",
             wg: "NIDASH Working Group",
 			wgURI:        "http://nidm.nidash.org",
-			wgPublicList: "incf-nidash-nidm@googlegroups.com",
+			wgPublicList: "nidm-users@googlegroups.com",
 			wgPatentURI:  "http://nidm.nidash.org",
             afterEnd: function () {
 

--- a/doc/content/specs/include/nidm-results_dev_head.html
+++ b/doc/content/specs/include/nidm-results_dev_head.html
@@ -95,7 +95,7 @@
 						previousPublishDate:  "2013-12-10",
 						wg:           "NIDASH Working Group",
 						wgURI:        "http://nidm.nidash.org",
-						wgPublicList: "incf-nidash-nidm@googlegroups.com",
+						wgPublicList: "nidm-users@googlegroups.com",
 						wgPatentURI:  "http://nidm.nidash.org",
 						afterEnd: function () {
 
@@ -166,7 +166,7 @@
 						<section>
 							<h4 id="please-send-comments">Please Send Comments</h4>
 							<!-- FIXME: Is this the right e-mail address to receive comments? -->
-							This document was published by the NIDASH NIDM Working Group. If you wish to make comments regarding this document, please report using the <a href="https://github.com/incf-nidash/nidm/issues/">NIDM issue tracker</a> or send them to <a href="mailto:incf-nidash-nidm@googlegroups.com">incf-nidash-nidm@googlegroups.com</a>. All comments are welcome.
+							This document was published by the NIDASH NIDM Working Group. If you wish to make comments regarding this document, please report using the <a href="https://github.com/incf-nidash/nidm/issues/">NIDM issue tracker</a> or send them to <a href="mailto:nidm-users@googlegroups.com">nidm-users@googlegroups.com</a>. All comments are welcome.
 						</section>			
 						</section>	
 						

--- a/doc/content/specs/include/nidm-results_head.html
+++ b/doc/content/specs/include/nidm-results_head.html
@@ -95,7 +95,7 @@
 						previousPublishDate:  "2013-12-10",
 						wg:           "NIDASH Working Group",
 						wgURI:        "http://nidm.nidash.org",
-						wgPublicList: "incf-nidash-nidm@googlegroups.com",
+						wgPublicList: "nidm-users@googlegroups.com",
 						wgPatentURI:  "http://nidm.nidash.org",
 						afterEnd: function () {
 
@@ -166,7 +166,7 @@
 						<section>
 							<h4 id="please-send-comments">Please Send Comments</h4>
 							<!-- FIXME: Is this the right e-mail address to receive comments? -->
-							This document was published by the NIDASH NIDM Working Group as a Candidate Release. If you wish to make comments regarding this document, please report using the <a href="https://github.com/incf-nidash/nidm/issues/">NIDM issue tracker</a> or send them to <a href="mailto:incf-nidash-nidm@googlegroups.com">incf-nidash-nidm@googlegroups.com</a>. All comments are welcome.
+							This document was published by the NIDASH NIDM Working Group as a Candidate Release. If you wish to make comments regarding this document, please report using the <a href="https://github.com/incf-nidash/nidm/issues/">NIDM issue tracker</a> or send them to <a href="mailto:nidm-users@googlegroups.com">nidm-users@googlegroups.com</a>. All comments are welcome.
 						</section>			
 						</section>	
 						

--- a/doc/content/specs/nidm-descriptor.html
+++ b/doc/content/specs/nidm-descriptor.html
@@ -29,7 +29,7 @@
             previousPublishDate: "2013-12-10",
             wg: "NIDASH Working Group",
 			wgURI:        "http://nidm.nidash.org",
-			wgPublicList: "incf-nidash-nidm@googlegroups.com",
+			wgPublicList: "nidm-users@googlegroups.com",
 			wgPatentURI:  "http://nidm.nidash.org",
             afterEnd: function () {
 

--- a/doc/content/specs/nidm-experiment_dev.html
+++ b/doc/content/specs/nidm-experiment_dev.html
@@ -61,7 +61,7 @@
             previousPublishDate: "2013-12-10",
             wg: "NIDASH Working Group",
 			wgURI:        "http://nidm.nidash.org",
-			wgPublicList: "incf-nidash-nidm@googlegroups.com",
+			wgPublicList: "nidm-users@googlegroups.com",
 			wgPatentURI:  "http://nidm.nidash.org",
             afterEnd: function () {
 

--- a/doc/content/specs/nidm-overview.html
+++ b/doc/content/specs/nidm-overview.html
@@ -63,7 +63,7 @@
             previousPublishDate: "2013-12-10",
             wg: "NIDASH Working Group",
 			wgURI:        "http://nidm.nidash.org",
-			wgPublicList: "incf-nidash-nidm@googlegroups.com",
+			wgPublicList: "nidm-users@googlegroups.com",
 			wgPatentURI:  "http://nidm.nidash.org",
             afterEnd: function () {
 
@@ -190,7 +190,7 @@
             <p>
                 This document was published by the NIDM Working Group as a Working Draft. If you wish to make comments
                 regarding this document, please report using the <a href="https://github.com/incf-nidash/nidm/issues/">NIDM issue
-                tracker</a>. You can also ask questions at  <a href="mailto:incf-nidash-nidm@googlegroups.com">incf-nidash-nidm@googlegroups.com</a>. All comments
+                tracker</a>. You can also ask questions at  <a href="mailto:nidm-users@googlegroups.com">nidm-users@googlegroups.com</a>. All comments
                 are welcome.
             </p>
         </section>
@@ -414,7 +414,7 @@
             <tr>
                 <td>All</td>
                 <td align="center">
-                    <a href="mailto:incf-nidash-nidm@googlegroups.com">incf-nidash-nidm@googlegroups.com</a>
+                    <a href="mailto:nidm-users@googlegroups.com">nidm-users@googlegroups.com</a>
                 </td>
                 <td>NIDM mailing list
                 </td>

--- a/doc/content/specs/nidm-primer.html
+++ b/doc/content/specs/nidm-primer.html
@@ -65,7 +65,7 @@
             previousPublishDate: "2013-12-10",
             wg: "NIDM Working Group",
 			wgURI:        "http://nidm.nidash.org",
-			wgPublicList: "incf-nidash-nidm@googlegroups.com",
+			wgPublicList: "nidm-users@googlegroups.com",
 			wgPatentURI:  "http://nidm.nidash.org",
             afterEnd: function () {
 
@@ -348,7 +348,7 @@
         <section>
         <h4>Workflow Component</h4>
             <p>
-			The NIDM Workflow Component focus group is just beginning to work on an object model for capturing workflow 			provenance.  We encourage those interested in participating to contact the <a 			href="mailto:incf-nidash-nidm@googlegroups.com">NIDM google group</a> for further information. There has been work
+			The NIDM Workflow Component focus group is just beginning to work on an object model for capturing workflow 			provenance.  We encourage those interested in participating to contact the <a 			href="mailto:nidm-users@googlegroups.com">NIDM google group</a> for further information. There has been work
 			on two preliminary implementations of provenance using NIDM, one using the <a href="http://nipy.sourceforge.net/nipype/">Nypipe </a> workflow system and the other the <a href="http://www.fil.ion.ucl.ac.uk/spm/">SPM </a> batch processing system.
             </p>
 			<p>
@@ -501,7 +501,7 @@
             <tr>
                 <td>All</td>
                 <td align="center">
-                    <a href="mailto:incf-nidash-nidm@googlegroups.com">incf-nidash-nidm@googlegroups.com</a>
+                    <a href="mailto:nidm-users@googlegroups.com">nidm-users@googlegroups.com</a>
                 </td>
                 <td>NIDM mailing list
                 </td>

--- a/doc/content/specs/nidm-results_010.html
+++ b/doc/content/specs/nidm-results_010.html
@@ -86,7 +86,7 @@
             previousPublishDate:  "2013-12-10",
             wg:           "NIDASH Working Group",
             wgURI:        "http://nidm.nidash.org",
-            wgPublicList: "incf-nidash-nidm@googlegroups.com",
+            wgPublicList: "nidm-users@googlegroups.com",
             wgPatentURI:  "http://nidm.nidash.org",
             afterEnd: function () {
 
@@ -157,7 +157,7 @@
             <section>
               <h4 id="please-send-comments">Please Send Comments</h4>
               <!-- FIXME: Is this the right e-mail address to receive comments? -->
-              This document was published by the NIDASH NIDM Working Group as a Candidate Release. If you wish to               make comments regarding this document, please report using the <a               href="https://github.com/incf-nidash/nidm/issues/">NIDM issue tracker</a>. please send them to <a               href="mailto:incf-nidash-nidm@googlegroups.com">incf-nidash-nidm@googlegroups.com</a>. All comments               are welcome.
+              This document was published by the NIDASH NIDM Working Group as a Candidate Release. If you wish to               make comments regarding this document, please report using the <a               href="https://github.com/incf-nidash/nidm/issues/">NIDM issue tracker</a>. please send them to <a               href="mailto:nidm-users@googlegroups.com">nidm-users@googlegroups.com</a>. All comments               are welcome.
             </section>      
             </section>  
             

--- a/doc/content/specs/nidm-results_020.html
+++ b/doc/content/specs/nidm-results_020.html
@@ -93,7 +93,7 @@
 						previousPublishDate:  "2013-12-10",
 						wg:           "NIDASH Working Group",
 						wgURI:        "http://nidm.nidash.org",
-						wgPublicList: "incf-nidash-nidm@googlegroups.com",
+						wgPublicList: "nidm-users@googlegroups.com",
 						wgPatentURI:  "http://nidm.nidash.org",
 						afterEnd: function () {
 
@@ -164,7 +164,7 @@
 						<section>
 							<h4 id="please-send-comments">Please Send Comments</h4>
 							<!-- FIXME: Is this the right e-mail address to receive comments? -->
-							This document was published by the NIDASH NIDM Working Group as a Candidate Release. If you wish to make comments regarding this document, please report using the <a href="https://github.com/incf-nidash/nidm/issues/">NIDM issue tracker</a> or send them to <a href="mailto:incf-nidash-nidm@googlegroups.com">incf-nidash-nidm@googlegroups.com</a>. All comments are welcome.
+							This document was published by the NIDASH NIDM Working Group as a Candidate Release. If you wish to make comments regarding this document, please report using the <a href="https://github.com/incf-nidash/nidm/issues/">NIDM issue tracker</a> or send them to <a href="mailto:nidm-users@googlegroups.com">nidm-users@googlegroups.com</a>. All comments are welcome.
 						</section>			
 						</section>	
 						

--- a/doc/content/specs/nidm-results_100.html
+++ b/doc/content/specs/nidm-results_100.html
@@ -93,7 +93,7 @@
 						previousPublishDate:  "2013-12-10",
 						wg:           "NIDASH Working Group",
 						wgURI:        "http://nidm.nidash.org",
-						wgPublicList: "incf-nidash-nidm@googlegroups.com",
+						wgPublicList: "nidm-users@googlegroups.com",
 						wgPatentURI:  "http://nidm.nidash.org",
 						afterEnd: function () {
 
@@ -164,7 +164,7 @@
 						<section>
 							<h4 id="please-send-comments">Please Send Comments</h4>
 							<!-- FIXME: Is this the right e-mail address to receive comments? -->
-							This document was published by the NIDASH NIDM Working Group as a Candidate Release. If you wish to make comments regarding this document, please report using the <a href="https://github.com/incf-nidash/nidm/issues/">NIDM issue tracker</a> or send them to <a href="mailto:incf-nidash-nidm@googlegroups.com">incf-nidash-nidm@googlegroups.com</a>. All comments are welcome.
+							This document was published by the NIDASH NIDM Working Group as a Candidate Release. If you wish to make comments regarding this document, please report using the <a href="https://github.com/incf-nidash/nidm/issues/">NIDM issue tracker</a> or send them to <a href="mailto:nidm-users@googlegroups.com">nidm-users@googlegroups.com</a>. All comments are welcome.
 						</section>			
 						</section>	
 						

--- a/doc/content/specs/nidm-results_110.html
+++ b/doc/content/specs/nidm-results_110.html
@@ -93,7 +93,7 @@
 						previousPublishDate:  "2013-12-10",
 						wg:           "NIDASH Working Group",
 						wgURI:        "http://nidm.nidash.org",
-						wgPublicList: "incf-nidash-nidm@googlegroups.com",
+						wgPublicList: "nidm-users@googlegroups.com",
 						wgPatentURI:  "http://nidm.nidash.org",
 						afterEnd: function () {
 
@@ -164,7 +164,7 @@
 						<section>
 							<h4 id="please-send-comments">Please Send Comments</h4>
 							<!-- FIXME: Is this the right e-mail address to receive comments? -->
-							This document was published by the NIDASH NIDM Working Group as a Candidate Release. If you wish to make comments regarding this document, please report using the <a href="https://github.com/incf-nidash/nidm/issues/">NIDM issue tracker</a> or send them to <a href="mailto:incf-nidash-nidm@googlegroups.com">incf-nidash-nidm@googlegroups.com</a>. All comments are welcome.
+							This document was published by the NIDASH NIDM Working Group as a Candidate Release. If you wish to make comments regarding this document, please report using the <a href="https://github.com/incf-nidash/nidm/issues/">NIDM issue tracker</a> or send them to <a href="mailto:nidm-users@googlegroups.com">nidm-users@googlegroups.com</a>. All comments are welcome.
 						</section>			
 						</section>	
 						

--- a/doc/content/specs/nidm-results_120.html
+++ b/doc/content/specs/nidm-results_120.html
@@ -95,7 +95,7 @@
 						previousPublishDate:  "2013-12-10",
 						wg:           "NIDASH Working Group",
 						wgURI:        "http://nidm.nidash.org",
-						wgPublicList: "incf-nidash-nidm@googlegroups.com",
+						wgPublicList: "nidm-users@googlegroups.com",
 						wgPatentURI:  "http://nidm.nidash.org",
 						afterEnd: function () {
 
@@ -166,7 +166,7 @@
 						<section>
 							<h4 id="please-send-comments">Please Send Comments</h4>
 							<!-- FIXME: Is this the right e-mail address to receive comments? -->
-							This document was published by the NIDASH NIDM Working Group as a Candidate Release. If you wish to make comments regarding this document, please report using the <a href="https://github.com/incf-nidash/nidm/issues/">NIDM issue tracker</a> or send them to <a href="mailto:incf-nidash-nidm@googlegroups.com">incf-nidash-nidm@googlegroups.com</a>. All comments are welcome.
+							This document was published by the NIDASH NIDM Working Group as a Candidate Release. If you wish to make comments regarding this document, please report using the <a href="https://github.com/incf-nidash/nidm/issues/">NIDM issue tracker</a> or send them to <a href="mailto:nidm-users@googlegroups.com">nidm-users@googlegroups.com</a>. All comments are welcome.
 						</section>			
 						</section>	
 						

--- a/doc/content/specs/nidm-results_130-rc1.html
+++ b/doc/content/specs/nidm-results_130-rc1.html
@@ -95,7 +95,7 @@
 						previousPublishDate:  "2013-12-10",
 						wg:           "NIDASH Working Group",
 						wgURI:        "http://nidm.nidash.org",
-						wgPublicList: "incf-nidash-nidm@googlegroups.com",
+						wgPublicList: "nidm-users@googlegroups.com",
 						wgPatentURI:  "http://nidm.nidash.org",
 						afterEnd: function () {
 
@@ -166,7 +166,7 @@
 						<section>
 							<h4 id="please-send-comments">Please Send Comments</h4>
 							<!-- FIXME: Is this the right e-mail address to receive comments? -->
-							This document was published by the NIDASH NIDM Working Group as a Candidate Release. If you wish to make comments regarding this document, please report using the <a href="https://github.com/incf-nidash/nidm/issues/">NIDM issue tracker</a> or send them to <a href="mailto:incf-nidash-nidm@googlegroups.com">incf-nidash-nidm@googlegroups.com</a>. All comments are welcome.
+							This document was published by the NIDASH NIDM Working Group as a Candidate Release. If you wish to make comments regarding this document, please report using the <a href="https://github.com/incf-nidash/nidm/issues/">NIDM issue tracker</a> or send them to <a href="mailto:nidm-users@googlegroups.com">nidm-users@googlegroups.com</a>. All comments are welcome.
 						</section>			
 						</section>	
 						

--- a/doc/content/specs/nidm-results_130-rc2.html
+++ b/doc/content/specs/nidm-results_130-rc2.html
@@ -95,7 +95,7 @@
 						previousPublishDate:  "2013-12-10",
 						wg:           "NIDASH Working Group",
 						wgURI:        "http://nidm.nidash.org",
-						wgPublicList: "incf-nidash-nidm@googlegroups.com",
+						wgPublicList: "nidm-users@googlegroups.com",
 						wgPatentURI:  "http://nidm.nidash.org",
 						afterEnd: function () {
 
@@ -166,7 +166,7 @@
 						<section>
 							<h4 id="please-send-comments">Please Send Comments</h4>
 							<!-- FIXME: Is this the right e-mail address to receive comments? -->
-							This document was published by the NIDASH NIDM Working Group as a Candidate Release. If you wish to make comments regarding this document, please report using the <a href="https://github.com/incf-nidash/nidm/issues/">NIDM issue tracker</a> or send them to <a href="mailto:incf-nidash-nidm@googlegroups.com">incf-nidash-nidm@googlegroups.com</a>. All comments are welcome.
+							This document was published by the NIDASH NIDM Working Group as a Candidate Release. If you wish to make comments regarding this document, please report using the <a href="https://github.com/incf-nidash/nidm/issues/">NIDM issue tracker</a> or send them to <a href="mailto:nidm-users@googlegroups.com">nidm-users@googlegroups.com</a>. All comments are welcome.
 						</section>			
 						</section>	
 						

--- a/doc/content/specs/nidm-results_130-rc3.html
+++ b/doc/content/specs/nidm-results_130-rc3.html
@@ -95,7 +95,7 @@
 						previousPublishDate:  "2013-12-10",
 						wg:           "NIDASH Working Group",
 						wgURI:        "http://nidm.nidash.org",
-						wgPublicList: "incf-nidash-nidm@googlegroups.com",
+						wgPublicList: "nidm-users@googlegroups.com",
 						wgPatentURI:  "http://nidm.nidash.org",
 						afterEnd: function () {
 
@@ -166,7 +166,7 @@
 						<section>
 							<h4 id="please-send-comments">Please Send Comments</h4>
 							<!-- FIXME: Is this the right e-mail address to receive comments? -->
-							This document was published by the NIDASH NIDM Working Group as a Candidate Release. If you wish to make comments regarding this document, please report using the <a href="https://github.com/incf-nidash/nidm/issues/">NIDM issue tracker</a> or send them to <a href="mailto:incf-nidash-nidm@googlegroups.com">incf-nidash-nidm@googlegroups.com</a>. All comments are welcome.
+							This document was published by the NIDASH NIDM Working Group as a Candidate Release. If you wish to make comments regarding this document, please report using the <a href="https://github.com/incf-nidash/nidm/issues/">NIDM issue tracker</a> or send them to <a href="mailto:nidm-users@googlegroups.com">nidm-users@googlegroups.com</a>. All comments are welcome.
 						</section>			
 						</section>	
 						

--- a/doc/content/specs/nidm-results_130.html
+++ b/doc/content/specs/nidm-results_130.html
@@ -95,7 +95,7 @@
 						previousPublishDate:  "2013-12-10",
 						wg:           "NIDASH Working Group",
 						wgURI:        "http://nidm.nidash.org",
-						wgPublicList: "incf-nidash-nidm@googlegroups.com",
+						wgPublicList: "nidm-users@googlegroups.com",
 						wgPatentURI:  "http://nidm.nidash.org",
 						afterEnd: function () {
 
@@ -166,7 +166,7 @@
 						<section>
 							<h4 id="please-send-comments">Please Send Comments</h4>
 							<!-- FIXME: Is this the right e-mail address to receive comments? -->
-							This document was published by the NIDASH NIDM Working Group as a Candidate Release. If you wish to make comments regarding this document, please report using the <a href="https://github.com/incf-nidash/nidm/issues/">NIDM issue tracker</a> or send them to <a href="mailto:incf-nidash-nidm@googlegroups.com">incf-nidash-nidm@googlegroups.com</a>. All comments are welcome.
+							This document was published by the NIDASH NIDM Working Group as a Candidate Release. If you wish to make comments regarding this document, please report using the <a href="https://github.com/incf-nidash/nidm/issues/">NIDM issue tracker</a> or send them to <a href="mailto:nidm-users@googlegroups.com">nidm-users@googlegroups.com</a>. All comments are welcome.
 						</section>			
 						</section>	
 						

--- a/doc/content/specs/nidm-results_dev.html
+++ b/doc/content/specs/nidm-results_dev.html
@@ -95,7 +95,7 @@
 						previousPublishDate:  "2013-12-10",
 						wg:           "NIDASH Working Group",
 						wgURI:        "http://nidm.nidash.org",
-						wgPublicList: "incf-nidash-nidm@googlegroups.com",
+						wgPublicList: "nidm-users@googlegroups.com",
 						wgPatentURI:  "http://nidm.nidash.org",
 						afterEnd: function () {
 
@@ -166,7 +166,7 @@
 						<section>
 							<h4 id="please-send-comments">Please Send Comments</h4>
 							<!-- FIXME: Is this the right e-mail address to receive comments? -->
-							This document was published by the NIDASH NIDM Working Group. If you wish to make comments regarding this document, please report using the <a href="https://github.com/incf-nidash/nidm/issues/">NIDM issue tracker</a> or send them to <a href="mailto:incf-nidash-nidm@googlegroups.com">incf-nidash-nidm@googlegroups.com</a>. All comments are welcome.
+							This document was published by the NIDASH NIDM Working Group. If you wish to make comments regarding this document, please report using the <a href="https://github.com/incf-nidash/nidm/issues/">NIDM issue tracker</a> or send them to <a href="mailto:nidm-users@googlegroups.com">nidm-users@googlegroups.com</a>. All comments are welcome.
 						</section>			
 						</section>	
 						


### PR DESCRIPTION
Following discussions by email that led to the creation of a public mailing list to gather feedback from NIDM users (https://groups.google.com/forum/#!forum/nidm-users), this pull request updates the documentation to mention the mailing list address.