### PR TITLE
Fix install error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ sudo: false
 python:
   - "2.7"
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
-install: pip install -r requirements.txt
+install: 
+ - pip install --upgrade setuptools
+ - pip install -r requirements.txt
 # command to run tests, e.g. python setup.py test
 script:  
 - python -m unittest discover -s ./nidm/nidm-results/test/ -p '[t|T]est*.py'


### PR DESCRIPTION
As in https://github.com/incf-nidash/nidmresults-spm/pull/33, this pull request add an update of the setuptools package before install of the requirements to avoid the `html5lib requires setuptools version 18.5 or above; please upgrade before installing (you have 12.0.5)` error.