### PR TITLE
Small fixes in NIDM-Results 1.3.0 examples: cluster label map in SPM, beta exported

### DIFF
--- a/nidm/nidm-results/scripts/create_spm_example_001.py
+++ b/nidm/nidm-results/scripts/create_spm_example_001.py
@@ -571,8 +571,8 @@ df50ea84deca8de0725641a0105b712a80a0c8931df9bdf3bef788b1041379d00875",
             format="image/nifti",
             label="Cluster Labels Map",
             coordinate_space_id="niiri:coordinate_space_id_1",
-            sha="13093aae03897e2518307d000eb298f4b1439814d8d3d77c622b717423f93\
-506dd5de5669513ab65c6dd74a7d27ee9df08620f546ed00575517b40e5878c2c96"
+            sha="a132bb284da461fd9e20eb2986373a9171c90a342c1e694297bc02f5674a3\
+11a560b7ff34bdf045dc191d4afff8c690a373db6408c1fe93f7c25e23707ce65c3"
             ),
         "SPM_Software": dict(
             software_id="niiri:software_id",

--- a/nidm/nidm-results/scripts/create_spm_example_001.py
+++ b/nidm/nidm-results/scripts/create_spm_example_001.py
@@ -78,24 +78,44 @@ def main():
             error_model_id="niiri:error_model_id",
             software_id="niiri:software_id"
             ),
-        "ParameterEstimateMap-1": dict(
+        "ParameterEstimateMap_Location-1": dict(
             beta_map_id="niiri:beta_map_id_1",
             label="Beta Map 1",
             coordinate_space_id="niiri:coordinate_space_id_1",
-            filename="beta_0001.nii",
+            filename="ParameterEstimate_0001.nii.gz",
+            location="ParameterEstimate_0001.nii.gz",
             format="image/nifti",
             sha="fab2573099693215bac756bc796fbc983524473dec5c1b2d66fb83694c174\
 12731df7f574094cb6c4a77994af7be11ed9aa545090fbe8ec6565a5c3c3dae8f0f",
             param_est_id="niiri:model_pe_id"),
-        "ParameterEstimateMap-2": dict(
+        "ParameterEstimateMap_Location-2": dict(
             beta_map_id="niiri:beta_map_id_2",
             label="Beta Map 2",
             coordinate_space_id="niiri:coordinate_space_id_1",
-            filename="beta_0002.nii",
+            filename="ParameterEstimate_0002.nii.gz",
+            location="ParameterEstimate_0002.nii.gz",
             format="image/nifti",
             sha="3f72b788762d9ab2c7ddb5e4d446872694ee42fc8897fe5317b54efb7924f\
 784da6499065db897a49595d8763d1893ad65ad102b0c88f2e72e2d028173343008",
             param_est_id="niiri:model_pe_id"),
+        "DerivedMap-ParameterEstimateMap-1": dict(
+            derived_from_map_id="niiri:beta_map_id_1_der",
+            derived_map_type="nidm:NIDM_0000061",
+            filename="beta_0001.nii",
+            format="image/nifti",
+            sha="fab2573099693215bac756bc796fbc983524473dec5c1b2d66fb83694c174\
+12731df7f574094cb6c4a77994af7be11ed9aa545090fbe8ec6565a5c3c3dae8f0f",
+            map_id="niiri:beta_map_id_1"
+            ),
+        "DerivedMap-ParameterEstimateMap-2": dict(
+            derived_from_map_id="niiri:beta_map_id_2_der",
+            derived_map_type="nidm:NIDM_0000061",
+            filename="beta_0002.nii",
+            format="image/nifti",
+            sha="3f72b788762d9ab2c7ddb5e4d446872694ee42fc8897fe5317b54efb7924f\
+784da6499065db897a49595d8763d1893ad65ad102b0c88f2e72e2d028173343008",
+            map_id="niiri:beta_map_id_2"
+            ),
         "CoordinateSpace-1": dict(
             coordinate_space_id="niiri:coordinate_space_id_1",
             label="Coordinate space 1",

--- a/nidm/nidm-results/scripts/create_spm_example_001.py
+++ b/nidm/nidm-results/scripts/create_spm_example_001.py
@@ -80,7 +80,7 @@ def main():
             ),
         "ParameterEstimateMap_Location-1": dict(
             beta_map_id="niiri:beta_map_id_1",
-            label="Beta Map 1",
+            label="Parameter Estimate Map 1",
             coordinate_space_id="niiri:coordinate_space_id_1",
             filename="ParameterEstimate_0001.nii.gz",
             location="ParameterEstimate_0001.nii.gz",
@@ -90,7 +90,7 @@ def main():
             param_est_id="niiri:model_pe_id"),
         "ParameterEstimateMap_Location-2": dict(
             beta_map_id="niiri:beta_map_id_2",
-            label="Beta Map 2",
+            label="Parameter Estimate Map 2",
             coordinate_space_id="niiri:coordinate_space_id_1",
             filename="ParameterEstimate_0002.nii.gz",
             location="ParameterEstimate_0002.nii.gz",

--- a/nidm/nidm-results/spm/example001/example001_spm_results.ttl
+++ b/nidm/nidm-results/spm/example001/example001_spm_results.ttl
@@ -399,7 +399,7 @@ _:blank1 prov:atTime "2014-05-19T10:30:00.000+01:00"^^xsd:dateTime .
 niiri:beta_map_id_1 prov:wasGeneratedBy niiri:model_pe_id .
 
 niiri:beta_map_id_1 a prov:Entity , nidm_ParameterEstimateMap: ;
-    rdfs:label "Beta Map 1" ;
+    rdfs:label "Parameter Estimate Map 1" ;
     nfo:fileName "ParameterEstimate_0001.nii.gz"^^xsd:string ;
     nidm_inCoordinateSpace: niiri:coordinate_space_id_1 ;
     crypto:sha512 "fab2573099693215bac756bc796fbc983524473dec5c1b2d66fb83694c17412731df7f574094cb6c4a77994af7be11ed9aa545090fbe8ec6565a5c3c3dae8f0f"^^xsd:string ;
@@ -410,7 +410,7 @@ niiri:beta_map_id_1 a prov:Entity , nidm_ParameterEstimateMap: ;
 niiri:beta_map_id_2 prov:wasGeneratedBy niiri:model_pe_id .
 
 niiri:beta_map_id_2 a prov:Entity , nidm_ParameterEstimateMap: ;
-    rdfs:label "Beta Map 2" ;
+    rdfs:label "Parameter Estimate Map 2" ;
     nfo:fileName "ParameterEstimate_0002.nii.gz"^^xsd:string ;
     nidm_inCoordinateSpace: niiri:coordinate_space_id_1 ;
     crypto:sha512 "3f72b788762d9ab2c7ddb5e4d446872694ee42fc8897fe5317b54efb7924f784da6499065db897a49595d8763d1893ad65ad102b0c88f2e72e2d028173343008"^^xsd:string ;

--- a/nidm/nidm-results/spm/example001/example001_spm_results.ttl
+++ b/nidm/nidm-results/spm/example001/example001_spm_results.ttl
@@ -40,6 +40,7 @@
 @prefix nidm_targetIntensity: <http://purl.org/nidash/nidm#NIDM_0000124> .
 @prefix nidm_hasMRIProtocol: <http://purl.org/nidash/nidm#NIDM_0000172> .
 @prefix nidm_MaskMap: <http://purl.org/nidash/nidm#NIDM_0000054> .
+@prefix nidm_ParameterEstimateMap: <http://purl.org/nidash/nidm#NIDM_0000061> .
 @prefix nidm_ResidualMeanSquaresMap: <http://purl.org/nidash/nidm#NIDM_0000066> .
 @prefix nidm_ReselsPerVoxelMap: <http://purl.org/nidash/nidm#NIDM_0000144> .
 @prefix nidm_StatisticMap: <http://purl.org/nidash/nidm#NIDM_0000076> .
@@ -79,7 +80,6 @@
 @prefix nidm_withEstimationMethod: <http://purl.org/nidash/nidm#NIDM_0000134> .
 @prefix nidm_NIDMResults: <http://purl.org/nidash/nidm#NIDM_0000027> .
 @prefix nidm_version: <http://purl.org/nidash/nidm#NIDM_0000127> .
-@prefix nidm_ParameterEstimateMap: <http://purl.org/nidash/nidm#NIDM_0000061> .
 @prefix nidm_PeakDefinitionCriteria: <http://purl.org/nidash/nidm#NIDM_0000063> .
 @prefix nidm_minDistanceBetweenPeaks: <http://purl.org/nidash/nidm#NIDM_0000109> .
 @prefix nidm_maxNumberOfPeaksPerCluster: <http://purl.org/nidash/nidm#NIDM_0000108> .
@@ -132,7 +132,7 @@ niiri:cluster_label_map_id a prov:Entity , nidm_ClusterLabelsMap: ;
 	nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     rdfs:label "Cluster Labels Map" ;
     nidm_inCoordinateSpace: niiri:coordinate_space_id_1 ;
-    crypto:sha512 "13093aae03897e2518307d000eb298f4b1439814d8d3d77c622b717423f93506dd5de5669513ab65c6dd74a7d27ee9df08620f546ed00575517b40e5878c2c96"^^xsd:string ;
+    crypto:sha512 "a132bb284da461fd9e20eb2986373a9171c90a342c1e694297bc02f5674a311a560b7ff34bdf045dc191d4afff8c690a373db6408c1fe93f7c25e23707ce65c3"^^xsd:string ;
 	dct:format "image/nifti"^^xsd:string .
 
 niiri:contrast_estimation_id prov:used niiri:beta_map_id_2 .
@@ -234,6 +234,20 @@ niiri:mask_id_1_der a prov:Entity , nidm_MaskMap: ;
     crypto:sha512 "fbc254cab29db5532feccce554ec9d3c845197eca9013ec9f0efd5d8d56e3aa008ccee4038fb3651d30447fa0f316938b07c3ad961b623458dcd9b46968a8e11"^^xsd:string .
 
 niiri:mask_id_1 prov:wasDerivedFrom niiri:mask_id_1_der .
+
+niiri:beta_map_id_1_der a prov:Entity , nidm_ParameterEstimateMap: ;
+    nfo:fileName "beta_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "fab2573099693215bac756bc796fbc983524473dec5c1b2d66fb83694c17412731df7f574094cb6c4a77994af7be11ed9aa545090fbe8ec6565a5c3c3dae8f0f"^^xsd:string .
+
+niiri:beta_map_id_1 prov:wasDerivedFrom niiri:beta_map_id_1_der .
+
+niiri:beta_map_id_2_der a prov:Entity , nidm_ParameterEstimateMap: ;
+    nfo:fileName "beta_0002.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "3f72b788762d9ab2c7ddb5e4d446872694ee42fc8897fe5317b54efb7924f784da6499065db897a49595d8763d1893ad65ad102b0c88f2e72e2d028173343008"^^xsd:string .
+
+niiri:beta_map_id_2 prov:wasDerivedFrom niiri:beta_map_id_2_der .
 
 niiri:residual_mean_squares_map_id_der a prov:Entity , nidm_ResidualMeanSquaresMap: ;
     nfo:fileName "ResMS.nii"^^xsd:string ;
@@ -386,19 +400,23 @@ niiri:beta_map_id_1 prov:wasGeneratedBy niiri:model_pe_id .
 
 niiri:beta_map_id_1 a prov:Entity , nidm_ParameterEstimateMap: ;
     rdfs:label "Beta Map 1" ;
-    nfo:fileName "beta_0001.nii"^^xsd:string ;
+    nfo:fileName "ParameterEstimate_0001.nii.gz"^^xsd:string ;
     nidm_inCoordinateSpace: niiri:coordinate_space_id_1 ;
     crypto:sha512 "fab2573099693215bac756bc796fbc983524473dec5c1b2d66fb83694c17412731df7f574094cb6c4a77994af7be11ed9aa545090fbe8ec6565a5c3c3dae8f0f"^^xsd:string ;
-    dct:format "image/nifti"^^xsd:string .
+    dct:format "image/nifti"^^xsd:string ;
+    prov:atLocation "ParameterEstimate_0001.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ParameterEstimate_0001.nii.gz"^^xsd:string .
 
 niiri:beta_map_id_2 prov:wasGeneratedBy niiri:model_pe_id .
 
 niiri:beta_map_id_2 a prov:Entity , nidm_ParameterEstimateMap: ;
     rdfs:label "Beta Map 2" ;
-    nfo:fileName "beta_0002.nii"^^xsd:string ;
+    nfo:fileName "ParameterEstimate_0002.nii.gz"^^xsd:string ;
     nidm_inCoordinateSpace: niiri:coordinate_space_id_1 ;
     crypto:sha512 "3f72b788762d9ab2c7ddb5e4d446872694ee42fc8897fe5317b54efb7924f784da6499065db897a49595d8763d1893ad65ad102b0c88f2e72e2d028173343008"^^xsd:string ;
-    dct:format "image/nifti"^^xsd:string .
+    dct:format "image/nifti"^^xsd:string ;
+    prov:atLocation "ParameterEstimate_0002.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ParameterEstimate_0002.nii.gz"^^xsd:string .
 
 niiri:peak_definition_criteria_id a prov:Entity , nidm_PeakDefinitionCriteria: ;
 	rdfs:label "Peak Definition Criteria" ;


### PR DESCRIPTION
This PR includes a few fixes in the NIDM-Results SPM examples, in particular:
- Create separate entities for derived parameter estimate maps (now considering that the beta maps are exported and included in the NIDM-Results pack).
- Update the placeholder sha-sum to the actual values.

Those fixes were created as part of the test of the updated SPM exporter at: https://github.com/incf-nidash/nidmresults-spm/pull/36.
