### PR TITLE
Fix typos in the online specifications

### DIFF
--- a/doc/content/pages/home.md
+++ b/doc/content/pages/home.md
@@ -2,7 +2,7 @@ Title:
 URL:
 save_as: index.html
 
-The Neuroimaging Data Model (NIDM) is a collection of specification documents that define extensions the the [W3C PROV](http://www.w3.org/TR/prov-primer/) standard for the domain of human brain mapping. NIDM uses provenance information as means to link components from different stages of the scientific research process from dataset descriptors and computational workflow, to derived data and publication.
+The Neuroimaging Data Model (NIDM) is a collection of specification documents that define extensions the [W3C PROV](http://www.w3.org/TR/prov-primer/) standard for the domain of human brain mapping. NIDM uses provenance information as means to link components from different stages of the scientific research process from dataset descriptors and computational workflow, to derived data and publication.
 </br>
 </br>
 </br>

--- a/doc/content/specs/include/nidm-experiment_head.html
+++ b/doc/content/specs/include/nidm-experiment_head.html
@@ -154,7 +154,7 @@
                 <li><a href="http://nidm.nidash.org/specs/nidm-experiment.html">NIDM-EXPERIMENT</a> (Draft), a data model for
                     describing the organization of raw neuroimaging experiment data [[!NIDM-Experiment]];
                 </li>
-                <li><a href="http://nidm.nidash.org/specs/Results_NIDM_Spec.html">NIDM-RESULTS</a> (Draft), a data model for
+                <li><a href="http://nidm.nidash.org/specs/nidm-results.html">NIDM-RESULTS</a> (Draft), a data model for
                     describing the results of neuroimaging analyses.[[!NIDM-Results]].
                 </li>
             </ul>

--- a/doc/content/specs/include/nidm-results_head.html
+++ b/doc/content/specs/include/nidm-results_head.html
@@ -227,7 +227,7 @@
 			  	<table class="thinborder" style="margin-left: auto; margin-right: auto;">
 			  		<caption id="namespace-table"><span><a class="internalDFN" href="#namespace-table">Table 1</a>:</span></a></sup> </span>Prefix and Namespaces used in this specification</caption> <!-- Table 1-->
 			  		<tbody><tr><td><b>prefix</b></td><td><b>namespace IRI</b></td> <td><b>definition</b></td></tr>
-			  			<tr><td>nidm</td><td>http://www.incf.org/ns/nidash/nidm#</td><td>The NIDM namespace</td>
+			  			<tr><td>nidm</td><td>http://purl.org/nidash/nidm#</td><td>The NIDM namespace</td>
 			  			</tr>
 			  			<tr><td>prov</td><td>http://www.w3.org/ns/prov#</td><td>The PROV namespace [[prov-dm]]</td></tr>
 			  			<tr><td>xsd</td><td>http://www.w3.org/2000/10/XMLSchema#</td><td>XML Schema Namespace [[XMLSCHEMA11-2]]</td></tr>

--- a/doc/content/specs/nidm-descriptor.html
+++ b/doc/content/specs/nidm-descriptor.html
@@ -72,7 +72,7 @@
                 },
                 "NIDM-R": {
                     title: "NIDM Results",
-                    href:  "http://nidm.nidash.org/specs/Results_NIDM_Spec.html"
+                    href:  "http://nidm.nidash.org/specs/nidm-results.html"
                 }
             }
         };
@@ -122,7 +122,7 @@
                 <li><a href="http://nidm.nidash.org/specs/nidm-experiment.html">NIDM-EXPERIMENT</a> (Draft), a data model for
                     describing the organization of raw neuroimaging experiment data [[!NIDM-E]];
                 </li>
-                <li><a href="http://nidm.nidash.org/specs/Results_NIDM_Spec.html">NIDM-RESULTS</a> (Draft), a data model for
+                <li><a href="http://nidm.nidash.org/specs/nidm-results.html">NIDM-RESULTS</a> (Draft), a data model for
                     describing the results of neuroimaging analyses.[[!NIDM-R]].
                 </li>
             </ul>

--- a/doc/content/specs/nidm-experiment_dev.html
+++ b/doc/content/specs/nidm-experiment_dev.html
@@ -154,7 +154,7 @@
                 <li><a href="http://nidm.nidash.org/specs/nidm-experiment.html">NIDM-EXPERIMENT</a> (Draft), a data model for
                     describing the organization of raw neuroimaging experiment data [[!NIDM-Experiment]];
                 </li>
-                <li><a href="http://nidm.nidash.org/specs/Results_NIDM_Spec.html">NIDM-RESULTS</a> (Draft), a data model for
+                <li><a href="http://nidm.nidash.org/specs/nidm-results.html">NIDM-RESULTS</a> (Draft), a data model for
                     describing the results of neuroimaging analyses.[[!NIDM-Results]].
                 </li>
             </ul>

--- a/doc/content/specs/nidm-overview.html
+++ b/doc/content/specs/nidm-overview.html
@@ -167,7 +167,7 @@
                 <li><a href="http://nidm.nidash.org/specs/nidm-workflow.html">NIDM-Workflow</a> (Draft), a data model for
                     describing computational workflow on raw neuroimaging experiment data [[!nidm-workflow]];
                 </li>
-                <li><a href="http://nidm.nidash.org/specs/Results_NIDM_Spec.html">NIDM-RESULTS</a> (Draft), a data model for
+                <li><a href="http://nidm.nidash.org/specs/nidm-results.html">NIDM-RESULTS</a> (Draft), a data model for
                     describing the results of neuroimaging analyses.[[!nidm-results]].
                 </li>
                 <li><a href="http://nidm.nidash.org/specs/nidm-niquery-api.html">NIDM-NIQUERY-API</a> (Draft), an API to

--- a/doc/content/specs/nidm-primer.html
+++ b/doc/content/specs/nidm-primer.html
@@ -159,7 +159,7 @@
                 <li><a href="http://nidm.nidash.org/specs/nidm-experiment.html">NIDM-EXPERIMENT</a> (Draft), a data model for
                     describing the organization of raw neuroimaging experiment data [[!nidm-experiment]];
                 </li>
-                <li><a href="http://nidm.nidash.org/specs/Results_NIDM_Spec.html">NIDM-RESULTS</a> (Draft), a data model for
+                <li><a href="http://nidm.nidash.org/specs/nidm-results.html">NIDM-RESULTS</a> (Draft), a data model for
                     describing the results of neuroimaging analyses.[[!nidm-results]].
                 </li>
             </ul>

--- a/doc/content/specs/nidm-results_100.html
+++ b/doc/content/specs/nidm-results_100.html
@@ -225,7 +225,7 @@
 			  	<table class="thinborder" style="margin-left: auto; margin-right: auto;">
 			  		<caption id="namespace-table"><span><a class="internalDFN" href="#namespace-table">Table 1</a>:</span></a></sup> </span>Prefix and Namespaces used in this specification</caption> <!-- Table 1-->
 			  		<tbody><tr><td><b>prefix</b></td><td><b>namespace IRI</b></td> <td><b>definition</b></td></tr>
-			  			<tr><td>nidm</td><td>http://www.incf.org/ns/nidash/nidm#</td><td>The NIDM namespace</td>
+			  			<tr><td>nidm</td><td>http://purl.org/nidash/nidm#</td><td>The NIDM namespace</td>
 			  			</tr>
 			  			<tr><td>prov</td><td>http://www.w3.org/ns/prov#</td><td>The PROV namespace [[prov-dm]]</td></tr>
 			  			<tr><td>xsd</td><td>http://www.w3.org/2000/10/XMLSchema#</td><td>XML Schema Namespace [[XMLSCHEMA11-2]]</td></tr>
@@ -1951,7 +1951,7 @@ niiri:significant_cluster_0001 a prov:Entity , nidm_SignificantCluster: ;
 <section>
 <h3>Updated namespaces</h3>
 <ul>
-<li>nidm namespace (http://www.incf.org/ns/nidash/nidm#) replaced by http://purl.org/nidash/nidm# <a href="https://github.com/incf-nidash/nidm/pull/237">PR 237</a></li>
+<li>nidm namespace (http://purl.org/nidash/nidm#) replaced by http://purl.org/nidash/nidm# <a href="https://github.com/incf-nidash/nidm/pull/237">PR 237</a></li>
 <li>spm namespace (http://www.incf.org/ns/nidash/spm#) replaced by http://purl.org/nidash/spm# <a href="https://github.com/incf-nidash/nidm/pull/237">PR 237</a></li>
 <li>fsl namespace (http://www.incf.org/ns/nidash/fsl#) replaced by http://purl.org/nidash/fsl# <a href="https://github.com/incf-nidash/nidm/pull/237">PR 237</a></li>
 </ul>

--- a/doc/content/specs/nidm-results_110.html
+++ b/doc/content/specs/nidm-results_110.html
@@ -225,7 +225,7 @@
 			  	<table class="thinborder" style="margin-left: auto; margin-right: auto;">
 			  		<caption id="namespace-table"><span><a class="internalDFN" href="#namespace-table">Table 1</a>:</span></a></sup> </span>Prefix and Namespaces used in this specification</caption> <!-- Table 1-->
 			  		<tbody><tr><td><b>prefix</b></td><td><b>namespace IRI</b></td> <td><b>definition</b></td></tr>
-			  			<tr><td>nidm</td><td>http://www.incf.org/ns/nidash/nidm#</td><td>The NIDM namespace</td>
+			  			<tr><td>nidm</td><td>http://purl.org/nidash/nidm#</td><td>The NIDM namespace</td>
 			  			</tr>
 			  			<tr><td>prov</td><td>http://www.w3.org/ns/prov#</td><td>The PROV namespace [[prov-dm]]</td></tr>
 			  			<tr><td>xsd</td><td>http://www.w3.org/2000/10/XMLSchema#</td><td>XML Schema Namespace [[XMLSCHEMA11-2]]</td></tr>

--- a/doc/content/specs/nidm-results_120.html
+++ b/doc/content/specs/nidm-results_120.html
@@ -227,7 +227,7 @@
 			  	<table class="thinborder" style="margin-left: auto; margin-right: auto;">
 			  		<caption id="namespace-table"><span><a class="internalDFN" href="#namespace-table">Table 1</a>:</span></a></sup> </span>Prefix and Namespaces used in this specification</caption> <!-- Table 1-->
 			  		<tbody><tr><td><b>prefix</b></td><td><b>namespace IRI</b></td> <td><b>definition</b></td></tr>
-			  			<tr><td>nidm</td><td>http://www.incf.org/ns/nidash/nidm#</td><td>The NIDM namespace</td>
+			  			<tr><td>nidm</td><td>http://purl.org/nidash/nidm#</td><td>The NIDM namespace</td>
 			  			</tr>
 			  			<tr><td>prov</td><td>http://www.w3.org/ns/prov#</td><td>The PROV namespace [[prov-dm]]</td></tr>
 			  			<tr><td>xsd</td><td>http://www.w3.org/2000/10/XMLSchema#</td><td>XML Schema Namespace [[XMLSCHEMA11-2]]</td></tr>

--- a/doc/content/specs/nidm-results_130-rc1.html
+++ b/doc/content/specs/nidm-results_130-rc1.html
@@ -227,7 +227,7 @@
 			  	<table class="thinborder" style="margin-left: auto; margin-right: auto;">
 			  		<caption id="namespace-table"><span><a class="internalDFN" href="#namespace-table">Table 1</a>:</span></a></sup> </span>Prefix and Namespaces used in this specification</caption> <!-- Table 1-->
 			  		<tbody><tr><td><b>prefix</b></td><td><b>namespace IRI</b></td> <td><b>definition</b></td></tr>
-			  			<tr><td>nidm</td><td>http://www.incf.org/ns/nidash/nidm#</td><td>The NIDM namespace</td>
+			  			<tr><td>nidm</td><td>http://purl.org/nidash/nidm#</td><td>The NIDM namespace</td>
 			  			</tr>
 			  			<tr><td>prov</td><td>http://www.w3.org/ns/prov#</td><td>The PROV namespace [[prov-dm]]</td></tr>
 			  			<tr><td>xsd</td><td>http://www.w3.org/2000/10/XMLSchema#</td><td>XML Schema Namespace [[XMLSCHEMA11-2]]</td></tr>

--- a/doc/content/specs/nidm-results_130-rc2.html
+++ b/doc/content/specs/nidm-results_130-rc2.html
@@ -227,7 +227,7 @@
 			  	<table class="thinborder" style="margin-left: auto; margin-right: auto;">
 			  		<caption id="namespace-table"><span><a class="internalDFN" href="#namespace-table">Table 1</a>:</span></a></sup> </span>Prefix and Namespaces used in this specification</caption> <!-- Table 1-->
 			  		<tbody><tr><td><b>prefix</b></td><td><b>namespace IRI</b></td> <td><b>definition</b></td></tr>
-			  			<tr><td>nidm</td><td>http://www.incf.org/ns/nidash/nidm#</td><td>The NIDM namespace</td>
+			  			<tr><td>nidm</td><td>http://purl.org/nidash/nidm#</td><td>The NIDM namespace</td>
 			  			</tr>
 			  			<tr><td>prov</td><td>http://www.w3.org/ns/prov#</td><td>The PROV namespace [[prov-dm]]</td></tr>
 			  			<tr><td>xsd</td><td>http://www.w3.org/2000/10/XMLSchema#</td><td>XML Schema Namespace [[XMLSCHEMA11-2]]</td></tr>

--- a/doc/content/specs/nidm-results_130-rc3.html
+++ b/doc/content/specs/nidm-results_130-rc3.html
@@ -227,7 +227,7 @@
 			  	<table class="thinborder" style="margin-left: auto; margin-right: auto;">
 			  		<caption id="namespace-table"><span><a class="internalDFN" href="#namespace-table">Table 1</a>:</span></a></sup> </span>Prefix and Namespaces used in this specification</caption> <!-- Table 1-->
 			  		<tbody><tr><td><b>prefix</b></td><td><b>namespace IRI</b></td> <td><b>definition</b></td></tr>
-			  			<tr><td>nidm</td><td>http://www.incf.org/ns/nidash/nidm#</td><td>The NIDM namespace</td>
+			  			<tr><td>nidm</td><td>http://purl.org/nidash/nidm#</td><td>The NIDM namespace</td>
 			  			</tr>
 			  			<tr><td>prov</td><td>http://www.w3.org/ns/prov#</td><td>The PROV namespace [[prov-dm]]</td></tr>
 			  			<tr><td>xsd</td><td>http://www.w3.org/2000/10/XMLSchema#</td><td>XML Schema Namespace [[XMLSCHEMA11-2]]</td></tr>

--- a/doc/content/specs/nidm-results_130.html
+++ b/doc/content/specs/nidm-results_130.html
@@ -227,7 +227,7 @@
 			  	<table class="thinborder" style="margin-left: auto; margin-right: auto;">
 			  		<caption id="namespace-table"><span><a class="internalDFN" href="#namespace-table">Table 1</a>:</span></a></sup> </span>Prefix and Namespaces used in this specification</caption> <!-- Table 1-->
 			  		<tbody><tr><td><b>prefix</b></td><td><b>namespace IRI</b></td> <td><b>definition</b></td></tr>
-			  			<tr><td>nidm</td><td>http://www.incf.org/ns/nidash/nidm#</td><td>The NIDM namespace</td>
+			  			<tr><td>nidm</td><td>http://purl.org/nidash/nidm#</td><td>The NIDM namespace</td>
 			  			</tr>
 			  			<tr><td>prov</td><td>http://www.w3.org/ns/prov#</td><td>The PROV namespace [[prov-dm]]</td></tr>
 			  			<tr><td>xsd</td><td>http://www.w3.org/2000/10/XMLSchema#</td><td>XML Schema Namespace [[XMLSCHEMA11-2]]</td></tr>

--- a/doc/content/specs/nidm-spec-template.html
+++ b/doc/content/specs/nidm-spec-template.html
@@ -160,7 +160,7 @@
 			  	<table class="thinborder" style="margin-left: auto; margin-right: auto;">
 			  		<caption id="namespace-table"><span>Table 1<sup><a class="internalDFN" href="#namespace-table"><span class="diamond"> ◊:</span></a></sup> </span>Prefix and Namespaces used in this specification</caption> <!-- Table 1-->
 			  		<tbody><tr><td><b>prefix</b></td><td><b>namespace IRI</b></td> <td><b>definition</b></td></tr>
-			  			<tr><td>nidm</td><td>http://www.incf.org/ns/nidash/nidm#</td><td>The NIDM namespace</td>
+			  			<tr><td>nidm</td><td>http://purl.org/nidash/nidm#</td><td>The NIDM namespace</td>
 			  			</tr>
 			  			<tr><td>prov</td><td>http://www.w3.org/ns/prov#</td><td>The PROV namespace [[prov-dm]]</td></tr>
 			  			<tr><td>xsd</td><td>http://www.w3.org/2000/10/XMLSchema#</td><td>XML Schema Namespace [[XMLSCHEMA11-2]]</td></tr>

--- a/nidm/container/cff.provn
+++ b/nidm/container/cff.provn
@@ -2,7 +2,7 @@ document
     prefix xsd <http://www.w3.org/2001/XMLSchema#>
     prefix dcterms <http://purl.org/dc/elements/1.1/>
     prefix prov <http://www.w3.org/ns/prov-o/>
-    prefix nidm <http://www.incf.org/ns/nidash/nidm#>
+    prefix nidm <http://purl.org/nidash/nidm#>
     prefix niiri <http://iri.nidash.org/>
     prefix cml <http://www.connectomics.org/cff-2/>
 

--- a/nidm/nidm-dataset-descriptors/nidm-desc-sum-database-level.ttl
+++ b/nidm/nidm-dataset-descriptors/nidm-desc-sum-database-level.ttl
@@ -5,7 +5,7 @@
 @prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix schemaorg: <http://schema.org/> .
 @prefix void: <http://www.w3.org/TR/void/> .
-@prefix nidm: <http://www.incf.org/ns/nidash/nidm#> .
+@prefix nidm: <http://purl.org/nidash/nidm#> .
 @prefix : <http://openfmri.s3.amazonaws.com/nidm.ttl#> .
 
 # Database Summary-level Description of OpenfMRI.

--- a/nidm/nidm-dataset-descriptors/nidm.ttl
+++ b/nidm/nidm-dataset-descriptors/nidm.ttl
@@ -16,7 +16,7 @@
 @prefix void: <http://www.w3.org/TR/void/> .
 @prefix ofmri: <http://openfmri.s3.amazonaws.com/> .
 @prefix cogat: <http://www.cognitiveatlas.org/rdf/id/> .
-@prefix nidm: <http://www.incf.org/ns/nidash/nidm#> .
+@prefix nidm: <http://purl.org/nidash/nidm#> .
 @prefix : <#> .
 
 # Summary-level Description of OpenfMRI.

--- a/nidm/nidm-results/scripts/NIDM-Results-Terms2RDF.ipynb
+++ b/nidm/nidm-results/scripts/NIDM-Results-Terms2RDF.ipynb
@@ -109,7 +109,7 @@
      "collapsed": false,
      "input": [
       "# Namespace declarations\n",
-      "NIDM = prov.Namespace(\"nidm\", \"http://www.incf.org/ns/nidash/nidm#\")\n",
+      "NIDM = prov.Namespace(\"nidm\", \"http://purl.org/nidash/nidm#\")\n",
       "SPM = prov.Namespace(\"spm\", \"http://www.incf.org/ns/nidash/spm#\")\n",
       "FSL = prov.Namespace(\"fsl\", \"http://www.incf.org/ns/nidash/fsl#\")\n",
       "NIIRI = prov.Namespace(\"niiri\", \"http://nidm.nidash.org/iri/\")\n",
@@ -335,7 +335,7 @@
        "text": [
         "@prefix fsl: <http://www.incf.org/ns/nidash/fsl#> .\n",
         "@prefix iao: <http://purl.obolibrary.org/obo/iao.owl#> .\n",
-        "@prefix nidm: <http://www.incf.org/ns/nidash/nidm#> .\n",
+        "@prefix nidm: <http://purl.org/nidash/nidm#> .\n",
         "@prefix owl: <http://www.w3.org/2002/07/owl#> .\n",
         "@prefix prov: <http://www.w3.org/ns/prov#> .\n",
         "@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n",

--- a/nidm/nidm-results/scripts/NIDM_Results_queries.ipynb
+++ b/nidm/nidm-results/scripts/NIDM_Results_queries.ipynb
@@ -90,7 +90,7 @@
        "text": [
         "----- Query ----- \n",
         "prefix prov: <http://www.w3.org/ns/prov#>\n",
-        "prefix nidm: <http://www.incf.org/ns/nidash/nidm#>\n",
+        "prefix nidm: <http://purl.org/nidash/nidm#>\n",
         "prefix spm: <http://www.incf.org/ns/nidash/spm#>\n",
         "prefix fsl: <http://www.incf.org/ns/nidash/fsl#>\n",
         "\n",
@@ -130,7 +130,7 @@
         "Item 0\n",
         "contrastName-->passive listening > rest\n",
         "statFile-->file://./TStatistic.nii.gz\n",
-        "statType-->http://www.incf.org/ns/nidash/nidm#TStatistic\n",
+        "statType-->http://purl.org/nidash/nidm#TStatistic\n",
         "----- FSL Results ----- \n",
         "Item 0"
        ]
@@ -142,11 +142,11 @@
         "\n",
         "contrastName-->listening &gt; rest\n",
         "statFile-->file:///path/to/ZStatistic.nii.gz\n",
-        "statType-->http://www.incf.org/ns/nidash/nidm#ZStatistic\n",
+        "statType-->http://purl.org/nidash/nidm#ZStatistic\n",
         "Item 1\n",
         "contrastName-->listening &gt; rest\n",
         "statFile-->file:///path/to/TStatistic_0001.nii.gz\n",
-        "statType-->http://www.incf.org/ns/nidash/nidm#TStatistic\n"
+        "statType-->http://purl.org/nidash/nidm#TStatistic\n"
        ]
       }
      ],
@@ -177,7 +177,7 @@
        "text": [
         "----- Query ----- \n",
         "prefix prov: <http://www.w3.org/ns/prov#>\n",
-        "prefix nidm: <http://www.incf.org/ns/nidash/nidm#>\n",
+        "prefix nidm: <http://purl.org/nidash/nidm#>\n",
         "prefix spm: <http://www.incf.org/ns/nidash/spm#>\n",
         "prefix fsl: <http://www.incf.org/ns/nidash/fsl#>\n",
         "\n",


### PR DESCRIPTION
This pull requests fix a number of typos in the specification documents:
 - Broken link to NIDM-Results specification in NIDM-primer (reported by @TomMaullin)
 - "the the" typo reported in #376
 - URL of the `nidm` namespace had not been updated to purl in the HTML specs (and was therefore inconsistent with the `owl` file).