### PR TITLE
Issue cleanup

### DIFF
--- a/doc/content/specs/nidm-experiment_dev.html
+++ b/doc/content/specs/nidm-experiment_dev.html
@@ -229,18 +229,11 @@
                             </tr>
                 
                         <tr>
-                            <td><a title="Model">nidm:Model</a>
-                            </td>
-                    
-                                <td rowspan="2" style="text-align: center;"> prov:'Entity'</td>
-                        
-                                <td>nidm:Model</td>
-                            </tr>
-                
-                        <tr>
                             <td><a title="Group">nidm:Group</a>
                             </td>
                     
+                                <td rowspan="1" style="text-align: center;"> prov:'Entity'</td>
+                        
                                 <td>nidm:Group</td>
                             </tr>
                 
@@ -259,13 +252,6 @@
                 <h1 label="Task">nidm:'Task'</h1>
                 <div class="glossary-ref">
                     <a title="Task"><dfn title="Task">nidm:'Task'</dfn></a>: In the field of pyschology, a task is an activity that is performed by a subject to elucidate some aspect of human behavior or underlying process.<p> <a title="Task">nidm:'Task'</a> is a prov:Activity.</p>
-                </div>
-                </section>
-            <!-- nidm:Model (Model) -->
-            <section id="section-nidm:Model">
-                <h1 label="Model">nidm:Model</h1>
-                <div class="glossary-ref">
-                    <a title="Model"><dfn title="Model">nidm:Model</dfn></a>: <p> <a title="Model">nidm:Model</a> is a prov:'Entity'.</p>
                 </div>
                 </section>
             <!-- nidm:Group (Group) -->
@@ -287,6 +273,13 @@
                 <h1 label="InvestigationProcess">nidm:InvestigationProcess</h1>
                 <div class="glossary-ref">
                     <a title="InvestigationProcess"><dfn title="InvestigationProcess">nidm:InvestigationProcess</dfn></a>: <p> <a title="InvestigationProcess">nidm:InvestigationProcess</a> is.</p>
+                </div>
+                </section>
+            <!-- nidm:Model (Model) -->
+            <section id="section-nidm:Model">
+                <h1 label="Model">nidm:Model</h1>
+                <div class="glossary-ref">
+                    <a title="Model"><dfn title="Model">nidm:Model</dfn></a>: <p> <a title="Model">nidm:Model</a> is.</p>
                 </div>
                 </section>
             <!-- nidm:Contrast (Contrast) -->
@@ -664,13 +657,6 @@
                             </tr>
                 
                         <tr>
-                            <td><a title="ImagingProtocol">nidm:'Imaging Protocol'</a>
-                            </td>
-                    
-                                <td>nidm:ImagingProtocol</td>
-                            </tr>
-                
-                        <tr>
                             <td><a title="LetterFluencyTest">nidm:LetterFluencyTest</a>
                             </td>
                     
@@ -717,6 +703,13 @@
                             </td>
                     
                                 <td>nidm:PremorbidAdjustment</td>
+                            </tr>
+                
+                        <tr>
+                            <td><a title="Protocol">nidm:'Protocol'</a>
+                            </td>
+                    
+                                <td>nidm:Protocol</td>
                             </tr>
                 
                         <tr>
@@ -1030,13 +1023,6 @@
                     <a title="FingerTappingTest"><dfn title="FingerTappingTest">nidm:FingerTappingTest</dfn></a>: In this test, the subject is asked to tap a button as fast as possible for ten seconds each with the index finger alternating trials with each hand. Finger tapping is used to assess subtle motor and other cognitive impairments. (source: CMINDS).<p> <a title="FingerTappingTest">nidm:FingerTappingTest</a> is a prov:'Entity'.</p>
                 </div>
                 </section>
-            <!-- nidm:'Imaging Protocol' (ImagingProtocol) -->
-            <section id="section-nidm:'Imaging Protocol'">
-                <h1 label="ImagingProtocol">nidm:'Imaging Protocol'</h1>
-                <div class="glossary-ref">
-                    <a title="ImagingProtocol"><dfn title="ImagingProtocol">nidm:'Imaging Protocol'</dfn></a>: An imaging protocol is a document that contains the types of images to be acquired during a session and the acquisition device parameters that are used in that acquisition.<p> <a title="ImagingProtocol">nidm:'Imaging Protocol'</a> is a <a title="PerformedPlan">nidm:'Performed Plan'</a>.</p>
-                </div>
-                </section>
             <!-- nidm:LetterFluencyTest (LetterFluencyTest) -->
             <section id="section-nidm:LetterFluencyTest">
                 <h1 label="LetterFluencyTest">nidm:LetterFluencyTest</h1>
@@ -1069,7 +1055,7 @@
             <section id="section-nidm:'Performed Plan'">
                 <h1 label="PerformedPlan">nidm:'Performed Plan'</h1>
                 <div class="glossary-ref">
-                    <a title="PerformedPlan"><dfn title="PerformedPlan">nidm:'Performed Plan'</dfn></a>: The actual implementation of a plan during a data acquisition session.<p> <a title="PerformedPlan">nidm:'Performed Plan'</a> is a prov:'Entity' and  has the following child: <a title="ImagingProtocol">nidm:'Imaging Protocol'</a>.</p>
+                    <a title="PerformedPlan"><dfn title="PerformedPlan">nidm:'Performed Plan'</dfn></a>: The actual implementation of a plan during a data acquisition session.<p> <a title="PerformedPlan">nidm:'Performed Plan'</a> is a prov:'Entity' and  has the following child: <a title="Protocol">nidm:'Protocol'</a>.</p>
                 </div>
                 </section>
             <!-- nidm:PositiveAndNegativeSyndromeScale (PositiveAndNegativeSyndromeScale) -->
@@ -1084,6 +1070,13 @@
                 <h1 label="PremorbidAdjustment">nidm:PremorbidAdjustment</h1>
                 <div class="glossary-ref">
                     <a title="PremorbidAdjustment"><dfn title="PremorbidAdjustment">nidm:PremorbidAdjustment</dfn></a>: The Premorbid Adjustment Scale (PAS) is a rating scale which was developed to be applicable in a research setting. It is designed to evaluate the degree of achievement of developmental goals at each of several periods of a subject's life before the onset of schizophrenia.<p> <a title="PremorbidAdjustment">nidm:PremorbidAdjustment</a> is a prov:'Entity'.</p>
+                </div>
+                </section>
+            <!-- nidm:'Protocol' (Protocol) -->
+            <section id="section-nidm:'Protocol'">
+                <h1 label="Protocol">nidm:'Protocol'</h1>
+                <div class="glossary-ref">
+                    <a title="Protocol"><dfn title="Protocol">nidm:'Protocol'</dfn></a>: An protocol is a document that contains information necessary to acquire the desired data during a session and the acquisition device parameters that are to be used in that acquisition.<p> <a title="Protocol">nidm:'Protocol'</a> is a <a title="PerformedPlan">nidm:'Performed Plan'</a>.</p>
                 </div>
                 </section>
             <!-- nidm:'Pulse Sequence' (PulseSequence) -->

--- a/doc/content/specs/nidm-results_dev.html
+++ b/doc/content/specs/nidm-results_dev.html
@@ -358,17 +358,17 @@
                             </tr>
                 
                         <tr>
-                            <td><a title="SCR_007037" href ="http://scicrunch.org/resolver/SCR_007037">scr:'SPM'</a>
+                            <td><a title="SCR_007037" href ="http://scicrunch.org/resolver/SCR_007037">src:'SPM'</a>
                             </td>
                     
-                                <td>scr:SCR_007037</td>
+                                <td>src:SCR_007037</td>
                             </tr>
                 
                         <tr>
-                            <td><a title="SCR_002823" href ="http://scicrunch.org/resolver/SCR_002823">scr:'FSL'</a>
+                            <td><a title="SCR_002823" href ="http://scicrunch.org/resolver/SCR_002823">src:'FSL'</a>
                             </td>
                     
-                                <td>scr:SCR_002823</td>
+                                <td>src:SCR_002823</td>
                             </tr>
                 
                 </tbody>
@@ -567,7 +567,7 @@ niiri:coordinate_space_id_1 a prov:Entity , nidm_CoordinateSpace: ;
             <section id="section-nidm:'Neuroimaging Analysis Software'">
                 <h1 label="NIDM_0000164">nidm:'Neuroimaging Analysis Software'</h1>
                 <div class="glossary-ref">
-                    <a title="NIDM_0000164"><dfn title="NIDM_0000164">nidm:'Neuroimaging Analysis Software'</dfn></a> <a href="https://github.com/incf-nidash/nidm/issues?&q=is%3Aopen+'nidm:'Neuroimaging Analysis Software''""><sup>&#9734;</sup></a><a href="https://github.com/incf-nidash/nidm/issues/new";"><sup>+</sup></a>: Tool used to process neuroimaging data.<p> <a title="NIDM_0000164">nidm:'Neuroimaging Analysis Software'</a> is a prov:Agent and  has the following children: <a title="SCR_002823" href ="http://scicrunch.org/resolver/SCR_002823">scr:'FSL'</a>, <a title="SCR_007037" href ="http://scicrunch.org/resolver/SCR_007037">scr:'SPM'</a>.</p>
+                    <a title="NIDM_0000164"><dfn title="NIDM_0000164">nidm:'Neuroimaging Analysis Software'</dfn></a> <a href="https://github.com/incf-nidash/nidm/issues?&q=is%3Aopen+'nidm:'Neuroimaging Analysis Software''""><sup>&#9734;</sup></a><a href="https://github.com/incf-nidash/nidm/issues/new";"><sup>+</sup></a>: Tool used to process neuroimaging data.<p> <a title="NIDM_0000164">nidm:'Neuroimaging Analysis Software'</a> is a prov:Agent and  has the following children: <a title="SCR_002823" href ="http://scicrunch.org/resolver/SCR_002823">src:'FSL'</a>, <a title="SCR_007037" href ="http://scicrunch.org/resolver/SCR_007037">src:'SPM'</a>.</p>
                 </div>
                 <p></p>
                 <div class="attributes" id="attributes-nidm:'Neuroimaging Analysis Software'"> A <a title="NIDM_0000164">nidm:'Neuroimaging Analysis Software'</a> has attributes:
@@ -577,16 +577,16 @@ niiri:coordinate_space_id_1 a prov:Entity , nidm_CoordinateSpace: ;
                 </ul>
                 </div>
                 </section>
-            <!-- scr:'SPM' (SCR_007037) -->
-            <section id="section-scr:'SPM'">
-                <h1 label="SCR_007037">scr:'SPM'</h1>
+            <!-- src:'SPM' (SCR_007037) -->
+            <section id="section-src:'SPM'">
+                <h1 label="SCR_007037">src:'SPM'</h1>
                 <div class="glossary-ref">
-                    <a title="SCR_007037" href ="http://scicrunch.org/resolver/SCR_007037"><dfn title="SCR_007037" href ="http://scicrunch.org/resolver/SCR_007037">scr:'SPM'</dfn></a> <a href="https://github.com/incf-nidash/nidm/issues?&q=is%3Aopen+'scr:'SPM''""><sup>&#9734;</sup></a><a href="https://github.com/incf-nidash/nidm/issues/new";"><sup>+</sup></a>: Software package for the analysis of brain imaging data sequences. The sequences can be a series of images from different cohorts, or time-series from the same subject. The current release is designed for the analysis of fMRI, PET, SPECT, EEG and MEG.<p> <a title="SCR_007037" href ="http://scicrunch.org/resolver/SCR_007037">scr:'SPM'</a> is a <a title="NIDM_0000164">nidm:'Neuroimaging Analysis Software'</a>.</p>
+                    <a title="SCR_007037" href ="http://scicrunch.org/resolver/SCR_007037"><dfn title="SCR_007037" href ="http://scicrunch.org/resolver/SCR_007037">src:'SPM'</dfn></a> <a href="https://github.com/incf-nidash/nidm/issues?&q=is%3Aopen+'src:'SPM''""><sup>&#9734;</sup></a><a href="https://github.com/incf-nidash/nidm/issues/new";"><sup>+</sup></a>: Software package for the analysis of brain imaging data sequences. The sequences can be a series of images from different cohorts, or time-series from the same subject. The current release is designed for the analysis of fMRI, PET, SPECT, EEG and MEG.<p> <a title="SCR_007037" href ="http://scicrunch.org/resolver/SCR_007037">src:'SPM'</a> is a <a title="NIDM_0000164">nidm:'Neuroimaging Analysis Software'</a>.</p>
                 </div>
                 <p></p>
-                <div class="attributes" id="attributes-scr:'SPM'"> A <a title="SCR_007037" href ="http://scicrunch.org/resolver/SCR_007037">scr:'SPM'</a> has attributes:
+                <div class="attributes" id="attributes-src:'SPM'"> A <a title="SCR_007037" href ="http://scicrunch.org/resolver/SCR_007037">src:'SPM'</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="scr:'SPM'.label">rdfs:label</span>:                     (<em class="rfc2119" title="OPTIONAL">OPTIONAL</em>) Human readable description of the <a title="SCR_007037" href ="http://scicrunch.org/resolver/SCR_007037">scr:'SPM'</a>.</li>
+                    <li><span class="attribute" id="src:'SPM'.label">rdfs:label</span>:                     (<em class="rfc2119" title="OPTIONAL">OPTIONAL</em>) Human readable description of the <a title="SCR_007037" href ="http://scicrunch.org/resolver/SCR_007037">src:'SPM'</a>.</li>
                         <li><a title="NIDM_0000122">nidm:'software Version'</a></span>: (<em class="rfc2119" title="OPTIONAL">OPTIONAL</em>) Name and number that specifies the software version. For SPM, this includes the main software version followed by the revision number (e.g. 8.6225 for SPM8 revision 6225). (range <a title="string" href ="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>).</li>
                 </ul>
                 </div>
@@ -600,16 +600,16 @@ niiri:spm_software_id a prov:Agent , scr_SPM: , prov:SoftwareAgent ;
 	rdfs:label "SPM"^^xsd:string; ;
 	nidm_softwareVersion: "8.6225"^^xsd:string .</pre>
                 </section>
-            <!-- scr:'FSL' (SCR_002823) -->
-            <section id="section-scr:'FSL'">
-                <h1 label="SCR_002823">scr:'FSL'</h1>
+            <!-- src:'FSL' (SCR_002823) -->
+            <section id="section-src:'FSL'">
+                <h1 label="SCR_002823">src:'FSL'</h1>
                 <div class="glossary-ref">
-                    <a title="SCR_002823" href ="http://scicrunch.org/resolver/SCR_002823"><dfn title="SCR_002823" href ="http://scicrunch.org/resolver/SCR_002823">scr:'FSL'</dfn></a> <a href="https://github.com/incf-nidash/nidm/issues?&q=is%3Aopen+'scr:'FSL''""><sup>&#9734;</sup></a><a href="https://github.com/incf-nidash/nidm/issues/new";"><sup>+</sup></a>: A comprehensive library of image analysis and statistical tools for fMRI, MRI and DTI brain imaging data. The tools include registration, atlases, Diffusion MRI tools for parameter reconstruction and probabilistic taractography, and a viewer. FSL runs on Apple and PCs (Linux and Windows), and is very easy to install. Most of the tools can be run both from the command line and as GUIs ('point-and-click' graphical user interfaces). Several complementary brain atlases, integrated into FSLView and Featquery, allowing viewing of structural and cytoarchitectonic standard space labels and probability maps for cortical and subcortical structures and white matter tracts. Atlases included with FSL: * Harvard-Oxford cortical and subcortical structural atlases * Julich histological atlas * JHU DTI-based white-matter atlases * Oxford thalamic connectivity atlas * Talairach atlas * MNI structural atlas * Cerebellum atlas FSL is written mainly by members of the Analysis Group, FMRIB, Oxford, UK.<p> <a title="SCR_002823" href ="http://scicrunch.org/resolver/SCR_002823">scr:'FSL'</a> is a <a title="NIDM_0000164">nidm:'Neuroimaging Analysis Software'</a>.</p>
+                    <a title="SCR_002823" href ="http://scicrunch.org/resolver/SCR_002823"><dfn title="SCR_002823" href ="http://scicrunch.org/resolver/SCR_002823">src:'FSL'</dfn></a> <a href="https://github.com/incf-nidash/nidm/issues?&q=is%3Aopen+'src:'FSL''""><sup>&#9734;</sup></a><a href="https://github.com/incf-nidash/nidm/issues/new";"><sup>+</sup></a>: A comprehensive library of image analysis and statistical tools for fMRI, MRI and DTI brain imaging data. The tools include registration, atlases, Diffusion MRI tools for parameter reconstruction and probabilistic taractography, and a viewer. FSL runs on Apple and PCs (Linux and Windows), and is very easy to install. Most of the tools can be run both from the command line and as GUIs ('point-and-click' graphical user interfaces). Several complementary brain atlases, integrated into FSLView and Featquery, allowing viewing of structural and cytoarchitectonic standard space labels and probability maps for cortical and subcortical structures and white matter tracts. Atlases included with FSL: * Harvard-Oxford cortical and subcortical structural atlases * Julich histological atlas * JHU DTI-based white-matter atlases * Oxford thalamic connectivity atlas * Talairach atlas * MNI structural atlas * Cerebellum atlas FSL is written mainly by members of the Analysis Group, FMRIB, Oxford, UK.<p> <a title="SCR_002823" href ="http://scicrunch.org/resolver/SCR_002823">src:'FSL'</a> is a <a title="NIDM_0000164">nidm:'Neuroimaging Analysis Software'</a>.</p>
                 </div>
                 <p></p>
-                <div class="attributes" id="attributes-scr:'FSL'"> A <a title="SCR_002823" href ="http://scicrunch.org/resolver/SCR_002823">scr:'FSL'</a> has attributes:
+                <div class="attributes" id="attributes-src:'FSL'"> A <a title="SCR_002823" href ="http://scicrunch.org/resolver/SCR_002823">src:'FSL'</a> has attributes:
                 <ul>
-                    <li><span class="attribute" id="scr:'FSL'.label">rdfs:label</span>:                     (<em class="rfc2119" title="OPTIONAL">OPTIONAL</em>) Human readable description of the <a title="SCR_002823" href ="http://scicrunch.org/resolver/SCR_002823">scr:'FSL'</a>.</li>
+                    <li><span class="attribute" id="src:'FSL'.label">rdfs:label</span>:                     (<em class="rfc2119" title="OPTIONAL">OPTIONAL</em>) Human readable description of the <a title="SCR_002823" href ="http://scicrunch.org/resolver/SCR_002823">src:'FSL'</a>.</li>
                         <li><a title="FSL_0000005"><dfn title="FSL_0000005">fsl:'feat Version'</dfn></a> <a href="https://github.com/incf-nidash/nidm/issues?&q=is%3Aopen+'fsl:'feat Version''""><sup>&#9734;</sup></a><a href="https://github.com/incf-nidash/nidm/issues/new";"><sup>+</sup></a></span>: (<em class="rfc2119" title="OPTIONAL">OPTIONAL</em>) Version of the FEAT software. (range <a title="string" href ="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>).</li>
                         <li><a title="NIDM_0000122">nidm:'software Version'</a></span>: (<em class="rfc2119" title="OPTIONAL">OPTIONAL</em>) Name and number that specifies the software version. For SPM, this includes the main software version followed by the revision number (e.g. 8.6225 for SPM8 revision 6225). (range <a title="string" href ="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>).</li>
                 </ul>

--- a/nidm/nidm-experiment/imports/sio_import.ttl
+++ b/nidm/nidm-experiment/imports/sio_import.ttl
@@ -612,24 +612,6 @@ ns4:SIO_000258 rdf:type ns2:Class ;
 
 
 
-###  http://semanticscience.org/resource/SIO_000289
-
-ns4:SIO_000289 rdf:type ns2:Class ;
-               
-               ns3:label "set"@en ;
-               
-               ns3:subClassOf ns4:SIO_000075 ;
-               
-               ns0:description "A set is a collection of entities, for which there may be zero members."@en ;
-               
-               ns0:identifier "SIO_000289" ;
-               
-               ns3:isDefinedBy <http://semanticscience.org/ontology/sio.owl> .
-
-
-
-
-
 ###  http://semanticscience.org/resource/SIO_000366
 
 ns4:SIO_000366 rdf:type ns2:Class ;

--- a/nidm/nidm-experiment/terms/nidm-experiment.owl
+++ b/nidm/nidm-experiment/terms/nidm-experiment.owl
@@ -637,11 +637,11 @@ nidm:DICOMTagCollection rdf:type owl:Class ;
 
 
 
-###  http://purl.org/nidash/nidm#DataCollectionDeviceOperator
+###  http://purl.org/nidash/nidm#DataAcquisitionDeviceOperator
 
-nidm:DataCollectionDeviceOperator rdf:type owl:Class ;
+nidm:DataAcquisitionDeviceOperator rdf:type owl:Class ;
                                   
-                                  rdfs:label "Data Collection Device Operator" ;
+                                  rdfs:label "Data Acquisition Device Operator" ;
                                   
                                   rdfs:subClassOf prov:Role .
 

--- a/nidm/nidm-experiment/terms/nidm-experiment.owl
+++ b/nidm/nidm-experiment/terms/nidm-experiment.owl
@@ -347,7 +347,7 @@ onli:instrument-variable rdf:type owl:Class ;
 
 onli:scale rdf:type owl:Class ;
            
-           rdfs:subClassOf prov:Entity .
+           rdfs:subClassOf sio:SIO_000078 .
 
 
 
@@ -355,7 +355,7 @@ onli:scale rdf:type owl:Class ;
 
 onli:scale-item rdf:type owl:Class ;
                 
-                rdfs:subClassOf prov:Entity .
+                rdfs:subClassOf sio:SIO_000015 .
 
 
 
@@ -363,7 +363,7 @@ onli:scale-item rdf:type owl:Class ;
 
 onli:score rdf:type owl:Class ;
            
-           rdfs:subClassOf prov:Entity .
+           rdfs:subClassOf sio:SIO_000015 .
 
 
 
@@ -389,16 +389,6 @@ nidm:Acquisition rdf:type owl:Class ;
 
 
 
-###  http://purl.org/nidash/nidm#DataCollectionDeviceOperator
-
-nidm:DataCollectionDeviceOperator rdf:type owl:Class ;
-                               
-                               rdfs:label "Data Collection Device Operator" ;
-                               
-                               rdfs:subClassOf prov:Role .
-
-
-
 ###  http://purl.org/nidash/nidm#AcquisitionMethod
 
 nidm:AcquisitionMethod rdf:type owl:Class ;
@@ -409,182 +399,13 @@ nidm:AcquisitionMethod rdf:type owl:Class ;
 
 
 
-###  http://purl.org/nidash/nidm#VoltageClamp
-
-nidm:VoltageClamp rdf:type owl:Class ;
-                       
-                       rdfs:label "Voltage Clamp" ;
-                       
-                       rdfs:subClassOf nidm:AcquisitionMethod .
-
-
-
-###  http://purl.org/nidash/nidm#CurrentClamp
-
-nidm:CurrentClamp rdf:type owl:Class ;
-                       
-                       rdfs:label "Current Clamp" ;
-                       
-                       rdfs:subClassOf nidm:AcquisitionMethod .
-
-
-
-###  http://purl.org/nidash/nidm#PatchClamp
-
-nidm:PatchClamp rdf:type owl:Class ;
-                       
-                       rdfs:label "Patch Clamp" ;
-                       
-                       rdfs:subClassOf nidm:AcquisitionMethod .
-
-
-
-###  http://purl.org/nidash/nidm#SharpElectrode
-
-nidm:SharpElectrode rdf:type owl:Class ;
-                       
-                       rdfs:label "Sharp Electrode" ;
-                       
-                       rdfs:subClassOf nidm:AcquisitionMethod .
-
-
-
-###  http://purl.org/nidash/nidm#SingleUnitRecording
-
-nidm:SingleUnitReccording rdf:type owl:Class ;
-                       
-                       rdfs:label "Single-unit Recording" ;
-                       
-                       rdfs:subClassOf nidm:AcquisitionMethod .
-
-
-
-###  http://purl.org/nidash/nidm#MultiUnitRecording
-
-nidm:MultiUnitReccording rdf:type owl:Class ;
-                       
-                       rdfs:label "Multi-unit Recording" ;
-                       
-                       rdfs:subClassOf nidm:AcquisitionMethod .
-
-
-
-###  http://purl.org/nidash/nidm#FieldPotential
-
-nidm:FieldPotential rdf:type owl:Class ;
-                       
-                       rdfs:label "Field Potential" ;
-                       
-                       rdfs:subClassOf nidm:AcquisitionMethod .
-
-
-
-###  http://purl.org/nidash/nidm#Amperometry
-
-nidm:Amperometry rdf:type owl:Class ;
-                       
-                       rdfs:label "Amperometry" ;
-                       
-                       rdfs:subClassOf nidm:AcquisitionMethod .
-
-
-
 ###  http://purl.org/nidash/nidm#AcquisitionModality
 
 nidm:AcquisitionModality rdf:type owl:Class ;
-                       
-                       rdfs:label "Acquisition Modality" ;
-                       
-                       rdfs:subClassOf nidm:AcquisitionObjectQuality .
-
-
-
-###  http://purl.org/nidash/nidm#MagneticResonanceImaging
-
-nidm:MagneticResonanceImaging rdf:type owl:Class ;
-                       
-                       rdfs:label "Magnetic Resonance Imaging" ;
-                       
-                       rdfs:subClassOf nidm:AcquisitionModality .
-
-
-
-###  http://purl.org/nidash/nidm#NuclearMagneticResonanceSpectroscopy
-
-nidm:NuclearMagneticResonanceSpectroscopy rdf:type owl:Class ;
-                       
-                       rdfs:label "Nuclear Magnetic Resonance Spectroscopy" ;
-                       
-                       rdfs:subClassOf nidm:AcquisitionModality .
-
-
-
-###  http://purl.org/nidash/nidm#PositronEmissionTomography
-
-nidm:PositronEmissionTomography rdf:type owl:Class ;
-                       
-                       rdfs:label "Positron Emission Tomography" ;
-                       
-                       rdfs:subClassOf nidm:AcquisitionModality .
-
-
-
-###  http://purl.org/nidash/nidm#ComputedTomography
-
-nidm:ComputedTomography rdf:type owl:Class ;
-                       
-                       rdfs:label "Computed Tomography" ;
-                       
-                       rdfs:subClassOf nidm:AcquisitionModality .
-
-
-
-###  http://purl.org/nidash/nidm#Magnetoencephalography
-
-nidm:Magnetoencephalography rdf:type owl:Class ;
-                       
-                       rdfs:label "Magnetoencephalography" ;
-                       
-                       rdfs:subClassOf nidm:AcquisitionModality .
-
-
-
-###  http://purl.org/nidash/nidm#Electroencephalography
-
-nidm:Electroencephalography rdf:type owl:Class ;
-                       
-                       rdfs:label "Electroencephalography" ;
-                       
-                       rdfs:subClassOf nidm:AcquisitionModality .
-
-
-###  http://purl.org/nidash/nidm#Electrocorticography
-
-nidm:Electrocorticography rdf:type owl:Class ;
-                       
-                       rdfs:label "Electrocorticography" ;
-                       
-                       rdfs:subClassOf nidm:AcquisitionModality .
-
-
-
-###  http://purl.org/nidash/nidm#IntracellularElectrophysiologyRecording
-
-nidm:IntracellularElectrophysiologyRecording rdf:type owl:Class ;
-                       
-                       rdfs:label "Intracellular Electrophysiology Recording" ;
-                       
-                       rdfs:subClassOf nidm:AcquisitionModality .
-
-
-
-###  http://purl.org/nidash/nidm#ExtracellularElectrophysiologyRecording
-
-nidm:ExtracellularElectrophysiologyRecording rdf:type owl:Class ;
-                       
-                       rdfs:label "Extracellular Electrophysiology Recording" ;
-                       
-                       rdfs:subClassOf nidm:AcquisitionModality .
+                         
+                         rdfs:label "Acquisition Modality" ;
+                         
+                         rdfs:subClassOf nidm:AcquisitionObjectQuality .
 
 
 
@@ -612,12 +433,21 @@ nidm:AcquisitionObjectQuality rdf:type owl:Class ;
 
 
 
+###  http://purl.org/nidash/nidm#Amperometry
+
+nidm:Amperometry rdf:type owl:Class ;
+                 
+                 rdfs:label "Amperometry" ;
+                 
+                 rdfs:subClassOf nidm:AcquisitionMethod .
+
+
+
 ###  http://purl.org/nidash/nidm#Anatomical
 
 nidm:Anatomical rdf:type owl:Class ;
                 
                 rdfs:subClassOf nidm:ImageUsageType .
-
 
 
 
@@ -676,8 +506,8 @@ nidm:BarnesScale rdf:type owl:Class ;
 ###  http://purl.org/nidash/nidm#BehavioralDataAcquisition
 
 nidm:BehavioralDataAcquisition rdf:type owl:Class ;
-
-rdfs:label "Behavioral Data Acquisition" ;
+                               
+                               rdfs:label "Behavioral Data Acquisition" ;
                                
                                rdfs:subClassOf nidm:Acquisition .
 
@@ -751,10 +581,20 @@ nidm:CombinedAssessment rdf:type owl:Class ;
 
 
 
+###  http://purl.org/nidash/nidm#ComputedTomography
+
+nidm:ComputedTomography rdf:type owl:Class ;
+                        
+                        rdfs:label "Computed Tomography" ;
+                        
+                        rdfs:subClassOf nidm:AcquisitionModality .
+
+
+
 ###  http://purl.org/nidash/nidm#Computer
 
 nidm:Computer rdf:type owl:Class ;
-
+              
               rdfs:label "Computer" ;
               
               rdfs:subClassOf sio:SIO_000956 .
@@ -766,6 +606,16 @@ nidm:Computer rdf:type owl:Class ;
 nidm:ContinuousPerformanceTest rdf:type owl:Class ;
                                
                                rdfs:subClassOf onli:assessment-instrument .
+
+
+
+###  http://purl.org/nidash/nidm#CurrentClamp
+
+nidm:CurrentClamp rdf:type owl:Class ;
+                  
+                  rdfs:label "Current Clamp" ;
+                  
+                  rdfs:subClassOf nidm:AcquisitionMethod .
 
 
 
@@ -785,6 +635,15 @@ nidm:DICOMTagCollection rdf:type owl:Class ;
                         
                         prov:wasAssociatedWith nidm:AcquisitionObject .
 
+
+
+###  http://purl.org/nidash/nidm#DataCollectionDeviceOperator
+
+nidm:DataCollectionDeviceOperator rdf:type owl:Class ;
+                                  
+                                  rdfs:label "Data Collection Device Operator" ;
+                                  
+                                  rdfs:subClassOf prov:Role .
 
 
 
@@ -904,12 +763,41 @@ nidm:EdinburghHandnessTest rdf:type owl:Class ;
 
 
 
+###  http://purl.org/nidash/nidm#Electrocorticography
+
+nidm:Electrocorticography rdf:type owl:Class ;
+                          
+                          rdfs:label "Electrocorticography" ;
+                          
+                          rdfs:subClassOf nidm:AcquisitionModality .
+
+
+
+###  http://purl.org/nidash/nidm#Electroencephalography
+
+nidm:Electroencephalography rdf:type owl:Class ;
+                            
+                            rdfs:label "Electroencephalography" ;
+                            
+                            rdfs:subClassOf nidm:AcquisitionModality .
+
+
 
 ###  http://purl.org/nidash/nidm#EventBased
 
 nidm:EventBased rdf:type owl:Class ;
                 
                 rdfs:subClassOf nidm:NIDM_0000155 .
+
+
+
+###  http://purl.org/nidash/nidm#ExtracellularElectrophysiologyRecording
+
+nidm:ExtracellularElectrophysiologyRecording rdf:type owl:Class ;
+                                             
+                                             rdfs:label "Extracellular Electrophysiology Recording" ;
+                                             
+                                             rdfs:subClassOf nidm:AcquisitionModality .
 
 
 
@@ -929,6 +817,16 @@ nidm:FagerstromSmokingTest rdf:type owl:Class ;
 
 
 
+###  http://purl.org/nidash/nidm#FieldPotential
+
+nidm:FieldPotential rdf:type owl:Class ;
+                    
+                    rdfs:label "Field Potential" ;
+                    
+                    rdfs:subClassOf nidm:AcquisitionMethod .
+
+
+
 ###  http://purl.org/nidash/nidm#FingerTappingTest
 
 nidm:FingerTappingTest rdf:type owl:Class ;
@@ -940,7 +838,7 @@ nidm:FingerTappingTest rdf:type owl:Class ;
 ###  http://purl.org/nidash/nidm#FlowWeighted
 
 nidm:FlowWeighted rdf:type owl:Class ;
-
+                  
                   rdfs:label "Flow Weighted"^^xsd:string ;
                   
                   rdfs:subClassOf nidm:ImageContrastType .
@@ -963,7 +861,6 @@ nidm:Group rdf:type owl:Class ;
 
 
 
-
 ###  http://purl.org/nidash/nidm#ImageContrastType
 
 nidm:ImageContrastType rdf:type owl:Class ;
@@ -977,10 +874,10 @@ nidm:ImageContrastType rdf:type owl:Class ;
 ###  http://purl.org/nidash/nidm#ImageDataReconstruction
 
 nidm:ImageDataReconstruction rdf:type owl:Class ;
-
-                    rdfs:label "Image Data Reconstruction" ;
                              
-                    rdfs:subClassOf prov:Activity .
+                             rdfs:label "Image Data Reconstruction" ;
+                             
+                             rdfs:subClassOf prov:Activity .
 
 
 
@@ -994,23 +891,11 @@ nidm:ImageUsageType rdf:type owl:Class ;
 
 
 
-###  http://purl.org/nidash/nidm#ImagingProtocol
-
-nidm:ImagingProtocol rdf:type owl:Class ;
-                     
-                     rdfs:label "Imaging Protocol"^^xsd:string ;
-                     
-                     rdfs:subClassOf nidm:PerformedPlan ;
-                     
-                     obo:IAO_0000115 "An imaging protocol is a document that contains the types of images to be acquired during a session and the acquisition device parameters that are used in that acquisition."^^xsd:string .
-
-
-
 ###  http://purl.org/nidash/nidm#InformedConsentAcquisition
 
 nidm:InformedConsentAcquisition rdf:type owl:Class ;
-
-                             rdfs:label "Informed Consent Acquisition" ;
+                                
+                                rdfs:label "Informed Consent Acquisition" ;
                                 
                                 rdfs:subClassOf nidm:Acquisition .
 
@@ -1042,6 +927,16 @@ nidm:Inside-outSpiral rdf:type owl:Class ;
 
 
 
+###  http://purl.org/nidash/nidm#IntracellularElectrophysiologyRecording
+
+nidm:IntracellularElectrophysiologyRecording rdf:type owl:Class ;
+                                             
+                                             rdfs:label "Intracellular Electrophysiology Recording" ;
+                                             
+                                             rdfs:subClassOf nidm:AcquisitionModality .
+
+
+
 ###  http://purl.org/nidash/nidm#LetterFluencyTest
 
 nidm:LetterFluencyTest rdf:type owl:Class ;
@@ -1057,6 +952,24 @@ nidm:LetterNumberSpanTest rdf:type owl:Class ;
                           rdfs:subClassOf onli:assessment-instrument .
 
 
+
+###  http://purl.org/nidash/nidm#MagneticResonanceImaging
+
+nidm:MagneticResonanceImaging rdf:type owl:Class ;
+                              
+                              rdfs:label "Magnetic Resonance Imaging" ;
+                              
+                              rdfs:subClassOf nidm:AcquisitionModality .
+
+
+
+###  http://purl.org/nidash/nidm#Magnetoencephalography
+
+nidm:Magnetoencephalography rdf:type owl:Class ;
+                            
+                            rdfs:label "Magnetoencephalography" ;
+                            
+                            rdfs:subClassOf nidm:AcquisitionModality .
 
 
 
@@ -1080,19 +993,19 @@ nidm:Mixed rdf:type owl:Class ;
 
 nidm:Model rdf:type owl:Class ;
            
-           rdfs:subClassOf prov:Entity .
+           rdfs:subClassOf sio:SIO_000136 .
 
 
 
 ###  http://purl.org/nidash/nidm#ModelDesigner
 
 nidm:ModelDesigner rdf:type owl:Class ;
-                    
-                    rdfs:label "Model Designer" ;
-                    
-                    rdfs:subClassOf prov:Role ;
-                    
-                    obo:IAO_0000115 "A model designer is a role for a person who creates the model to be used in an experiment" .
+                   
+                   rdfs:label "Model Designer" ;
+                   
+                   rdfs:subClassOf prov:Role ;
+                   
+                   obo:IAO_0000115 "A model designer is a role for a person who creates the model to be used in an experiment" .
 
 
 
@@ -1103,6 +1016,16 @@ nidm:ModelSpecification rdf:type owl:Class ;
                         rdfs:label "Model Specification" ;
                         
                         rdfs:subClassOf prov:Activity .
+
+
+
+###  http://purl.org/nidash/nidm#MultiUnitReccording
+
+nidm:MultiUnitReccording rdf:type owl:Class ;
+                         
+                         rdfs:label "Multi-unit Recording" ;
+                         
+                         rdfs:subClassOf nidm:AcquisitionMethod .
 
 
 
@@ -1130,6 +1053,16 @@ nidm:NorthAmericanAdultReadingTest rdf:type owl:Class ;
 
 
 
+###  http://purl.org/nidash/nidm#NuclearMagneticResonanceSpectroscopy
+
+nidm:NuclearMagneticResonanceSpectroscopy rdf:type owl:Class ;
+                                          
+                                          rdfs:label "Nuclear Magnetic Resonance Spectroscopy" ;
+                                          
+                                          rdfs:subClassOf nidm:AcquisitionModality .
+
+
+
 ###  http://purl.org/nidash/nidm#OrganismType
 
 nidm:OrganismType rdf:type owl:Class ;
@@ -1154,7 +1087,6 @@ nidm:Outside-inSpiral rdf:type owl:Class ;
 
 
 
-
 ###  http://purl.org/nidash/nidm#ParallelImagingMethod
 
 nidm:ParallelImagingMethod rdf:type owl:Class ;
@@ -1168,6 +1100,16 @@ nidm:ParallelImagingMethod rdf:type owl:Class ;
                            obo:IAO_0000116 "To be discussed"^^xsd:string ;
                            
                            obo:IAO_0000114 obo:IAO_0000125 .
+
+
+
+###  http://purl.org/nidash/nidm#PatchClamp
+
+nidm:PatchClamp rdf:type owl:Class ;
+                
+                rdfs:label "Patch Clamp" ;
+                
+                rdfs:subClassOf nidm:AcquisitionMethod .
 
 
 
@@ -1192,6 +1134,16 @@ nidm:PerformedPlan rdf:type owl:Class ;
 nidm:PositiveAndNegativeSyndromeScale rdf:type owl:Class ;
                                       
                                       rdfs:subClassOf onli:assessment-instrument .
+
+
+
+###  http://purl.org/nidash/nidm#PositronEmissionTomography
+
+nidm:PositronEmissionTomography rdf:type owl:Class ;
+                                
+                                rdfs:label "Positron Emission Tomography" ;
+                                
+                                rdfs:subClassOf nidm:AcquisitionModality .
 
 
 
@@ -1238,6 +1190,18 @@ nidm:Project rdf:type owl:Class ;
              obo:IAO_0000115 "A coordinated set of activities designed to generate data objects, with the ultimate goal of discovery or hypothesis testing."^^xsd:string ;
              
              obo:IAO_0000114 obo:IAO_0000428 .
+
+
+
+###  http://purl.org/nidash/nidm#Protocol
+
+nidm:Protocol rdf:type owl:Class ;
+              
+              rdfs:label "Protocol"^^xsd:string ;
+              
+              rdfs:subClassOf nidm:PerformedPlan ;
+              
+              obo:IAO_0000115 "An protocol is a document that contains information necessary to acquire the desired data during a session and the acquisition device parameters that are to be used in that acquisition."^^xsd:string .
 
 
 
@@ -1321,7 +1285,6 @@ nidm:SemanticVerbalLearningTest rdf:type owl:Class ;
 
 
 
-
 ###  http://purl.org/nidash/nidm#Session
 
 nidm:Session rdf:type owl:Class ;
@@ -1340,7 +1303,7 @@ nidm:SessionObject rdf:type owl:Class ;
                    
                    rdfs:label "Session Object"^^xsd:string ;
                    
-                   rdfs:subClassOf prov:Entity ,
+                   rdfs:subClassOf prov:Collection ,
                                    [ rdf:type owl:Restriction ;
                                      owl:onProperty dct:hasPart ;
                                      owl:someValuesFrom nidm:AcquisitionObject
@@ -1351,6 +1314,16 @@ nidm:SessionObject rdf:type owl:Class ;
                    obo:IAO_0000114 obo:IAO_0000428 ;
                    
                    obo:IAO_0000117 <http://purl.org/nicholsn/card.ttl> .
+
+
+
+###  http://purl.org/nidash/nidm#SharpElectrode
+
+nidm:SharpElectrode rdf:type owl:Class ;
+                    
+                    rdfs:label "Sharp Electrode" ;
+                    
+                    rdfs:subClassOf nidm:AcquisitionMethod .
 
 
 
@@ -1383,6 +1356,16 @@ nidm:SimultaneousMultisliceMethod rdf:type owl:Class ;
                                   obo:IAO_0000116 "To be discussed"^^xsd:string ;
                                   
                                   obo:IAO_0000114 obo:IAO_0000125 .
+
+
+
+###  http://purl.org/nidash/nidm#SingleUnitReccording
+
+nidm:SingleUnitReccording rdf:type owl:Class ;
+                          
+                          rdfs:label "Single-unit Recording" ;
+                          
+                          rdfs:subClassOf nidm:AcquisitionMethod .
 
 
 
@@ -1437,17 +1420,16 @@ nidm:StimulusPresentationFile rdf:type owl:Class ;
 ###  http://purl.org/nidash/nidm#StimulusResponseFile
 
 nidm:StimulusResponseFile rdf:type owl:Class ;
-                              
-                              rdfs:label "Stimulus Response File"^^xsd:string ;
-                              
-                              rdfs:subClassOf nidm:AuxiliaryFile ;
-                              
-                              obo:IAO_0000115 "A file that contains the recorded response of the subject to an experimental stimulus (e.g., words, pictures) in the course of any experiment."^^xsd:string ;
-                              
-                              obo:IAO_0000116 "To be discussed"^^xsd:string ;
-                              
-                              obo:IAO_0000114 obo:IAO_0000125 .
-
+                          
+                          rdfs:label "Stimulus Response File"^^xsd:string ;
+                          
+                          rdfs:subClassOf nidm:AuxiliaryFile ;
+                          
+                          obo:IAO_0000115 "A file that contains the recorded response of the subject to an experimental stimulus (e.g., words, pictures) in the course of any experiment."^^xsd:string ;
+                          
+                          obo:IAO_0000116 "To be discussed"^^xsd:string ;
+                          
+                          obo:IAO_0000114 obo:IAO_0000125 .
 
 
 
@@ -1514,7 +1496,7 @@ nidm:SymbolDigitAssociationTest rdf:type owl:Class ;
 ###  http://purl.org/nidash/nidm#T1Weighted
 
 nidm:T1Weighted rdf:type owl:Class ;
-
+                
                 rdfs:label "T1 Weighted"^^xsd:string ;
                 
                 rdfs:subClassOf nidm:ImageContrastType .
@@ -1524,7 +1506,7 @@ nidm:T1Weighted rdf:type owl:Class ;
 ###  http://purl.org/nidash/nidm#T2StarWeighted
 
 nidm:T2StarWeighted rdf:type owl:Class ;
-
+                    
                     rdfs:label "T2 Star Weighted"^^xsd:string ;
                     
                     rdfs:subClassOf nidm:ImageContrastType .
@@ -1534,7 +1516,7 @@ nidm:T2StarWeighted rdf:type owl:Class ;
 ###  http://purl.org/nidash/nidm#T2Weighted
 
 nidm:T2Weighted rdf:type owl:Class ;
-
+                
                 rdfs:label "T2 Weighted"^^xsd:string ;
                 
                 rdfs:subClassOf nidm:ImageContrastType .
@@ -1584,6 +1566,16 @@ nidm:TrailsB rdf:type owl:Class ;
 nidm:VisualFiguralLearningTest rdf:type owl:Class ;
                                
                                rdfs:subClassOf onli:assessment-instrument .
+
+
+
+###  http://purl.org/nidash/nidm#VoltageClamp
+
+nidm:VoltageClamp rdf:type owl:Class ;
+                  
+                  rdfs:label "Voltage Clamp" ;
+                  
+                  rdfs:subClassOf nidm:AcquisitionMethod .
 
 
 
@@ -1640,7 +1632,6 @@ nidm:k-spaceTraversalScheme rdf:type owl:Class ;
                             obo:IAO_0000116 "To be discussed"^^xsd:string ;
                             
                             obo:IAO_0000114 obo:IAO_0000125 .
-
 
 
 
@@ -1740,8 +1731,6 @@ prov:Collection rdf:type owl:Class ;
                 
                 rdfs:label "Collection"^^xsd:string ;
                 
-                rdfs:subClassOf sio:SIO_000289 ;
-                
                 obo:IAO_0000115 "A collection is an entity that provides structure to some constituents, which are themselves entities. These constituents are said to be member of the collections."^^xsd:string .
 
 
@@ -1754,8 +1743,7 @@ prov:Entity rdf:type owl:Class ;
 
 
 
-
-### http://www.w3.org/ns/prov-o#Plan
+###  http://www.w3.org/ns/prov#Plan
 
 prov:Plan rdfs:subClassOf sio:SIO_000091 .
 
@@ -2059,16 +2047,6 @@ qibo:Phantom_experimental_subject rdf:type owl:NamedIndividual .
 #################################################################
 
 
-nidm:DelayedVisualFiguralLearningTest dct:source "TBD"^^xsd:string ;
-                                      
-                                      obo:IAO_0000115 "TBD"^^xsd:string ;
-                                      
-                                      obo:IAO_0000116 "To be discussed"^^xsd:string ;
-                                      
-                                      obo:IAO_0000114 obo:IAO_0000125 .
-
-
-
 nidm:LetterFluencyTest obo:IAO_0000115 "The Letter Fluency test is used to evaluate the spontaneous production of words beginning with a given letter within a limited amount of time (60 seconds)."^^xsd:string ;
                        
                        obo:IAO_0000116 "To be discussed"^^xsd:string ;
@@ -2076,6 +2054,16 @@ nidm:LetterFluencyTest obo:IAO_0000115 "The Letter Fluency test is used to evalu
                        dct:source "fBIRN CMINDS document"^^xsd:string ;
                        
                        obo:IAO_0000114 obo:IAO_0000125 .
+
+
+
+nidm:DelayedVisualFiguralLearningTest dct:source "TBD"^^xsd:string ;
+                                      
+                                      obo:IAO_0000115 "TBD"^^xsd:string ;
+                                      
+                                      obo:IAO_0000116 "To be discussed"^^xsd:string ;
+                                      
+                                      obo:IAO_0000114 obo:IAO_0000125 .
 
 
 
@@ -2129,16 +2117,6 @@ nidm:CategoryFluencyTest obo:IAO_0000115 "Category Fluency (aka: Category Instan
 
 
 
-nidm:SocioeconomicScale obo:IAO_0000115 "TBD"^^xsd:string ;
-                        
-                        dct:source "TBD"^^xsd:string ;
-                        
-                        obo:IAO_0000116 "To be discussed"^^xsd:string ;
-                        
-                        obo:IAO_0000114 obo:IAO_0000125 .
-
-
-
 nidm:VisualFiguralLearningTest obo:IAO_0000115 "The Visual Figure Learning Test is used to assess visual (figural) memory functions: immediate recall, rate of acquisition (learning), delayed recall, and recognition. The subject is visually presented with six geometric figures arrayed in a 3 x 2 matrix for 10 seconds, after which the subject must reproduce (draw) as many of the figures as possible, in the same location as they appeared in the matrix. There is no time limit for recall. The subject is then asked to complete two additional learning trials using the same matrix of stimuli. After approximately 20 minutes containing other, mostly verbal assessments, the subject is asked to reproduce the figures again. Following this delayed recall trial, the subject is then presented with a series of 12 figures (the 6 original and 6 distractors) one at a time, and asked to respond “Yes” if the figure was in the original set, or “No” if it was not."^^xsd:string ;
                                
                                obo:IAO_0000116 "To be discussed"^^xsd:string ;
@@ -2146,6 +2124,16 @@ nidm:VisualFiguralLearningTest obo:IAO_0000115 "The Visual Figure Learning Test 
                                dct:source "fBIRN CMINDS document"^^xsd:string ;
                                
                                obo:IAO_0000114 obo:IAO_0000125 .
+
+
+
+nidm:SocioeconomicScale obo:IAO_0000115 "TBD"^^xsd:string ;
+                        
+                        dct:source "TBD"^^xsd:string ;
+                        
+                        obo:IAO_0000116 "To be discussed"^^xsd:string ;
+                        
+                        obo:IAO_0000114 obo:IAO_0000125 .
 
 
 
@@ -2159,16 +2147,6 @@ nidm:SymbolDigitAssociationTest obo:IAO_0000115 "In this test, the subject is pr
 
 
 
-nidm:CombinedAssessment obo:IAO_0000115 "An assessment that combines two or more independent assessments."^^xsd:string ;
-                        
-                        dct:source "KGH"^^xsd:string ;
-                        
-                        obo:IAO_0000116 "To be discussed"^^xsd:string ;
-                        
-                        obo:IAO_0000114 obo:IAO_0000125 .
-
-
-
 nidm:LetterNumberSpanTest obo:IAO_0000115 "In this test of auditory working memory, sequences of mixed letters and numbers are verbally presented and the subject is required to reorganize them into a progressive or ascending order and then report the reordered sequence to the examiner."^^xsd:string ;
                           
                           obo:IAO_0000116 "To be discussed"^^xsd:string ;
@@ -2176,6 +2154,16 @@ nidm:LetterNumberSpanTest obo:IAO_0000115 "In this test of auditory working memo
                           dct:source "fBIRN CMINDS document"^^xsd:string ;
                           
                           obo:IAO_0000114 obo:IAO_0000125 .
+
+
+
+nidm:CombinedAssessment obo:IAO_0000115 "An assessment that combines two or more independent assessments."^^xsd:string ;
+                        
+                        dct:source "KGH"^^xsd:string ;
+                        
+                        obo:IAO_0000116 "To be discussed"^^xsd:string ;
+                        
+                        obo:IAO_0000114 obo:IAO_0000125 .
 
 
 
@@ -2292,6 +2280,16 @@ nidm:BarnesScale obo:IAO_0000115 "TBD"^^xsd:string ;
 
 
 
+nidm:SpatialMemorySpan obo:IAO_0000115 "This test is used to assess an individual’s capacity for holding a visual-spatial sequence in working memory. The test requires the subject to tap a sequence of boxes (attached to a board in a random arrangement) in the same order that they were tapped by the examiner. The sequences increase in length through 8 levels (two trials at each level) until the subject misses both trials at a given level. The test is then repeated with the subject touching the boxes in the reverse order that they were touched by the examiner. Again, the sequences increase in length for two trials each for 8 levels, or until the subject misses both trials at a given level."^^xsd:string ;
+                       
+                       obo:IAO_0000116 "To be discussed"^^xsd:string ;
+                       
+                       dct:source "fBIRN CMINDS document"^^xsd:string ;
+                       
+                       obo:IAO_0000114 obo:IAO_0000125 .
+
+
+
 nidm:ClinicalGlobalImpression obo:IAO_0000115 "An estimation of the global state of the subject."^^xsd:string ;
                               
                               dct:source "KGH"^^xsd:string ;
@@ -2302,13 +2300,13 @@ nidm:ClinicalGlobalImpression obo:IAO_0000115 "An estimation of the global state
 
 
 
-nidm:SpatialMemorySpan obo:IAO_0000115 "This test is used to assess an individual’s capacity for holding a visual-spatial sequence in working memory. The test requires the subject to tap a sequence of boxes (attached to a board in a random arrangement) in the same order that they were tapped by the examiner. The sequences increase in length through 8 levels (two trials at each level) until the subject misses both trials at a given level. The test is then repeated with the subject touching the boxes in the reverse order that they were touched by the examiner. Again, the sequences increase in length for two trials each for 8 levels, or until the subject misses both trials at a given level."^^xsd:string ;
-                       
-                       obo:IAO_0000116 "To be discussed"^^xsd:string ;
-                       
-                       dct:source "fBIRN CMINDS document"^^xsd:string ;
-                       
-                       obo:IAO_0000114 obo:IAO_0000125 .
+nidm:PositiveAndNegativeSyndromeScale obo:IAO_0000115 "This scale is used for typological  and dimensional assessment.  Based on two established psychiatric  rating systems,  the 30-item PANSS was conceived  as an operationalized,  drug-sensitive instrument that provides  balanced representation  of positive  and negative symptoms and gauges  their relationship  to one another and to global  psychopathology."^^xsd:string ;
+                                      
+                                      obo:IAO_0000116 "To be discussed"^^xsd:string ;
+                                      
+                                      dct:source "http://schizophreniabulletin.oxfordjournals.org/content/13/2/261.full.pdf+html"^^xsd:string ;
+                                      
+                                      obo:IAO_0000114 obo:IAO_0000125 .
 
 
 
@@ -2329,16 +2327,6 @@ nidm:FagerstromSmokingTest obo:IAO_0000115 "The Fagerström Test for Nicotine De
                            dct:source "fBIRN CMINDS document"^^xsd:string ;
                            
                            obo:IAO_0000114 obo:IAO_0000125 .
-
-
-
-nidm:PositiveAndNegativeSyndromeScale obo:IAO_0000115 "This scale is used for typological  and dimensional assessment.  Based on two established psychiatric  rating systems,  the 30-item PANSS was conceived  as an operationalized,  drug-sensitive instrument that provides  balanced representation  of positive  and negative symptoms and gauges  their relationship  to one another and to global  psychopathology."^^xsd:string ;
-                                      
-                                      obo:IAO_0000116 "To be discussed"^^xsd:string ;
-                                      
-                                      dct:source "http://schizophreniabulletin.oxfordjournals.org/content/13/2/261.full.pdf+html"^^xsd:string ;
-                                      
-                                      obo:IAO_0000114 obo:IAO_0000125 .
 
 
 


### PR DESCRIPTION
This PR:
Done - 15) Should we create the more generic "Protocol" as a Performed Plan and then tag using nidm:AcquisitionModality? Answer = yes.

3) score should go under mathematical_entity

4) what is a scale_item?
There are all types of scales in SIO - decimal scale, integer scale, etc. Do we need any of these?
The issue here is that both can be either a sio:'language entity' or a sio:'mathematical entity', so I have
to make the parent more general than each (except now onl:scale_item and onl:score are on the same level as both of those entities which seems not quite right since score and scale_item has an "is a" relationship with those entities. This will have to be revisited later as a separate issue.

Done 2) The definition of onl:scale is consistent with it being a sio:"language entity"

Done 6) nidm:SessionObject - I think this should be a collection. That way each scan file can be a member of the collection, but you can still retrieve the whole object if you want all of the scans from a given session. This is how it's defined by Nolan and "hasPart some AcquisitionObject".  
Put nidm:SessionObject under prov:collection and get rid of the placement of prov:collection under sio:set. Remove sio:set as we don't really need it since we have prov:Collection.

Done 2) nidm:Model could go under sio:'language entity' -> sio:'description'